### PR TITLE
Report CI failures to Discord #ci (GRYT-21)

### DIFF
--- a/.github/workflows/discord-ci-notify.yml
+++ b/.github/workflows/discord-ci-notify.yml
@@ -1,0 +1,23 @@
+name: Discord CI notification
+
+# Reports failed workflow runs to #ci in Discord, and the recovery when one
+# goes green again. Implementation lives in Gryt-chat/.github so all repos
+# share one copy. Needs the org secret DISCORD_CI_WEBHOOK_URL.
+#
+# Workflows are listed by name rather than left to a wildcard: GitHub's docs
+# don't say whether omitting `workflows` means all of them, and an unlisted
+# workflow notifies nobody. Add new workflows here as you add them.
+
+on:
+  workflow_run:
+    workflows:
+      - Release Client
+      - Release Server
+      - Update Submodules
+      - Sync Vikunja task
+    types: [completed]
+
+jobs:
+  notify:
+    uses: Gryt-chat/.github/.github/workflows/discord-ci-notify.yml@main
+    secrets: inherit


### PR DESCRIPTION
Caller for the shared notifier added in [Gryt-chat/.github#3](https://github.com/Gryt-chat/.github/pull/3). **Merge that PR first** — until it lands, this references a workflow that doesn't exist and its first run will fail.

## What lands in #ci

A message when one of the watched workflows fails, and one more when it next goes green. Green-after-green, cancelled and skipped are all silent, so the channel stays quiet enough to leave unmuted.

Watched in this repo:

- `Release Client`
- `Release Server`
- `Update Submodules`
- `Sync Vikunja task`

## Worth a look

Workflows are listed **by name**, not wildcarded. GitHub's docs don't state whether omitting `on.workflow_run.workflows` means "all", so I didn't bet on it. The tradeoff is drift — add a workflow here and forget this list, and it notifies nobody. There's a comment in the file saying so.

## Not verifiable before merge

`workflow_run` only fires when the workflow file is on the default branch, so this cannot be exercised from a PR branch. The decision logic was tested locally against stubbed `gh`/`curl` across failure, timeout, recovery, green-after-green and cancelled; see the .github PR for that table. The end-to-end path stays unproven until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)