### PR TITLE
Pick the release channel at dispatch instead of from the branch (GRYT-24)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -3,6 +3,15 @@ name: Release Client
 on:
   workflow_dispatch:
     inputs:
+      channel:
+        description: "Release channel"
+        required: true
+        default: "beta"
+        type: choice
+        options:
+          - beta
+          - latest
+
       bump:
         description: "Client/product version change"
         required: true
@@ -95,18 +104,28 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Determine channel from branch
+      - name: Determine channel
         id: channel
         shell: bash
         run: |
           set -euo pipefail
 
-          if [[ "${{ github.ref_name }}" == "main" ]]; then
-            CHANNEL="latest"
-          elif [[ "${{ github.ref_name }}" == "beta" ]]; then
-            CHANNEL="beta"
-          else
-            echo "Client releases must be run from the beta or main branch."
+          # The channel is picked at dispatch rather than read off the branch.
+          # Deriving it from github.ref_name implied that a beta release built
+          # from a beta branch, which was never true: the client submodule is
+          # force-moved to client:main a few steps above, so beta and stable
+          # always built identical client code. Only the labelling differed,
+          # and the beta branch's stale server and SFU gitlinks made the
+          # embedded binaries silently disagree with the client.
+          CHANNEL="${{ github.event.inputs.channel }}"
+
+          if [[ "$CHANNEL" != "latest" && "$CHANNEL" != "beta" ]]; then
+            echo "Unsupported channel: $CHANNEL"
+            exit 1
+          fi
+
+          if [[ "${{ github.ref_name }}" != "main" ]]; then
+            echo "Client releases run from main."
             echo "Current branch: ${{ github.ref_name }}"
             exit 1
           fi

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -3,6 +3,15 @@ name: Release Server
 on:
   workflow_dispatch:
     inputs:
+      channel:
+        description: "Release channel"
+        required: true
+        default: "beta"
+        type: choice
+        options:
+          - beta
+          - latest
+
       bump:
         description: "Server version change"
         required: true
@@ -105,18 +114,24 @@ jobs:
           cache: true
           cache-dependency-path: packages/sfu/go.sum
 
-      - name: Determine channel from branch
+      - name: Determine channel
         id: channel
         shell: bash
         run: |
           set -euo pipefail
 
-          if [[ "${{ github.ref_name }}" == "main" ]]; then
-            CHANNEL="latest"
-          elif [[ "${{ github.ref_name }}" == "beta" ]]; then
-            CHANNEL="beta"
-          else
-            echo "Server releases must be run from the beta or main branch."
+          # Picked at dispatch rather than read off the branch, matching
+          # release-client.yml. See that workflow for why the branch was never
+          # a meaningful signal here.
+          CHANNEL="${{ github.event.inputs.channel }}"
+
+          if [[ "$CHANNEL" != "latest" && "$CHANNEL" != "beta" ]]; then
+            echo "Unsupported channel: $CHANNEL"
+            exit 1
+          fi
+
+          if [[ "${{ github.ref_name }}" != "main" ]]; then
+            echo "Server releases run from main."
             echo "Current branch: ${{ github.ref_name }}"
             exit 1
           fi

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -1,17 +1,13 @@
 name: Update Submodules
 
+# Updates submodule gitlinks on main. This used to take a target_branch input
+# defaulting to beta, which is where the "chore: update all submodules on beta"
+# commits came from. With the beta branch gone there is only one target left, so
+# the input would be a choice of one.
+
 on:
   workflow_dispatch:
     inputs:
-      target_branch:
-        description: "Branch to update"
-        required: true
-        default: "beta"
-        type: choice
-        options:
-          - beta
-          - main
-
       submodules:
         description: "Submodules to update"
         required: true
@@ -36,7 +32,7 @@ jobs:
       - name: Checkout monorepo
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.target_branch || 'beta' }}
+          ref: main
           fetch-depth: 0
           submodules: recursive
 
@@ -61,19 +57,12 @@ jobs:
           set -euo pipefail
 
           SELECTED="${{ github.event.inputs.submodules || 'all' }}"
-          TARGET_BRANCH="${{ github.event.inputs.target_branch || 'beta' }}"
-
-          if [[ "$TARGET_BRANCH" == "main" ]]; then
-            DEFAULT_SUBMODULE_BRANCH="main"
-          else
-            DEFAULT_SUBMODULE_BRANCH="beta"
-          fi
+          TARGET_BRANCH="main"
+          DEFAULT_SUBMODULE_BRANCH="main"
 
           update_submodule() {
             local path="$1"
-            local preferred_branch="$2"
-            local fallback_branch="main"
-            local branch=""
+            local branch="$2"
 
             if [[ ! -d "$path" ]]; then
               echo "Skipping missing submodule: $path"
@@ -83,12 +72,6 @@ jobs:
             echo "Updating $path"
 
             git -C "$path" fetch origin --tags
-
-            if git -C "$path" ls-remote --exit-code --heads origin "$preferred_branch" >/dev/null 2>&1; then
-              branch="$preferred_branch"
-            else
-              branch="$fallback_branch"
-            fi
 
             echo "Using branch $branch for $path"
 
@@ -124,7 +107,7 @@ jobs:
             exit 0
           fi
 
-          TARGET_BRANCH="${{ github.event.inputs.target_branch || 'beta' }}"
+          TARGET_BRANCH="main"
           SELECTED="${{ github.event.inputs.submodules || 'all' }}"
 
           git commit -m "chore: update $SELECTED submodules on $TARGET_BRANCH"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,15 @@ in the same breath. Those two drifting apart is the failure mode that matters mo
 
 ## Git
 
-**Never push to `main` or `beta`.** Both are long-lived — `beta` backs the `latest-beta`
-container images. Always work on a branch and open a PR.
+**Never push to `main`.** It's the only long-lived branch. Always work on a branch and open
+a PR.
+
+There used to be a `beta` branch too. It's gone. Beta is a release *channel* now, picked
+from a dropdown when you dispatch `Release Client` or `Release Server`, and it still
+produces `1.2.3-beta.N` versions and `latest-beta` container images. The branch never
+isolated anything — the client submodule was force-moved to `client:main` on every release
+regardless — so all it did in practice was pin stale `server` and `sfu` gitlinks against a
+current client.
 
 Branch naming is `claude/<id>-<slug>`, matching the existing `copilot/*` branches:
 


### PR DESCRIPTION
Groundwork for dropping the `beta` branch. **This PR does not delete anything** — the branch deletion waits until a beta release from `main` has proven the new path.

## The problem

`release-client.yml` force-moves the client submodule on every run, whichever branch you dispatch from:

```yaml
git -C packages/client fetch origin main
git -C packages/client checkout -B main origin/main
```

The `client` repo has no `beta` branch at all, so beta and stable have always built identical client code. The branch only ever changed labelling.

Except it also supplied the `server` and `sfu` gitlinks, and `gryt:beta` was 12 commits behind with both stale:

| Package | `main` | `beta` |
|---|---|---|
| `server` | `d8160c99` | `201dc59c` |
| `sfu` | `85649f5a` | `1352a7b9` |

The client bundles both via `build:embedded-server`, so a beta release shipped a current client against an old embedded server and SFU. That's the actual bug here — the branch wasn't giving you isolation, it was giving you a mismatch.

## The change

- **Both release workflows** take an explicit `channel` dropdown (defaulting to `beta`, the safer accident) and refuse to run from anything but `main`. Everything downstream is untouched: `1.2.3-beta.N` versioning, `:latest-beta` tags, the prerelease flag, the Discord embeds.
- **`update-submodules.yml`** loses its `target_branch` input. It defaulted to `beta` and is where the `chore: update all submodules on beta` commits came from.
- **CLAUDE.md** no longer claims `beta` is long-lived or that it backs the `latest-beta` images.

## Worth a look

**The one real behaviour change: beta releases now bump `release.json` on `main`.** Previously a beta release read and wrote `release.json` on the `beta` branch, so `main`'s version only moved on a stable release. Now cutting a beta with `bump: patch` from `1.3.0` sets `main`'s `release.json` to `1.3.1` and tags `v1.3.1-beta.1`; the later stable release ships `1.3.1` with `bump: none`. I think that's more coherent than two diverging `release.json` files, but it is a change in how the version moves and it's the thing most worth disagreeing with.

Beta tag numbering is unaffected — `git tag --list` is repo-wide, not per-branch.

## Audit behind the decision

- All six beta-only commits are workflow-generated bookkeeping. No handwritten work. The `v1.3.1-beta.1` tags capture those states and survive branch deletion.
- `ops/deploy/compose/beta.yml` and `beta.local.yml` consume `latest-beta` **image tags**, not the git branch. The beta deployment on `dev.lan` is unaffected.
- The published blog post `a-small-update.mdx` says "beta branch", but every instruction in it is about image tags and `beta.yml`, and it links to `beta.yml` on `main`. Its instructions keep working. The wording could be tightened separately.
- `gryt:beta` has no branch protection.

## Not verifiable before merge

`workflow_dispatch` inputs only exist once the file is on the default branch, so the new dropdown can't be exercised from this branch. YAML validated for all three workflows; the logic changes are small and readable in the diff.

## After merge

1. Cut a beta release from `main` and confirm the version, tag, `:latest-beta` image and Discord embed all look right.
2. Only then delete `gryt:beta` and `server:beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)