### PR TITLE
Reconcile release.json and refuse to release backwards (GRYT-24)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -238,6 +238,28 @@ jobs:
               ;;
           esac
 
+          # Refuse to publish behind what has already shipped. release.json used
+          # to be per-branch: main's copy tracked stable releases while beta's
+          # tracked the beta line. Moving the channel to a dispatch input merged
+          # those two lines, and the first release from main computed
+          # 1.3.0-beta.2 while v1.3.1-beta.1 already existed.
+          #
+          # Only base versions are compared, so beta.N increments within the same
+          # base are still fine — it is the x.y.z going backwards that is wrong.
+          HIGHEST_BASE="$(git tag --list 'v*' | sed 's/^v//; s/-.*$//' | sort -V | tail -n 1 || true)"
+
+          if [[ -n "$HIGHEST_BASE" && "$BASE_VERSION" != "$HIGHEST_BASE" ]]; then
+            OLDEST="$(printf '%s\n%s\n' "$HIGHEST_BASE" "$BASE_VERSION" | sort -V | head -n 1)"
+
+            if [[ "$OLDEST" == "$BASE_VERSION" ]]; then
+              echo "release.json is behind the tags."
+              echo "  release.json base version: $BASE_VERSION"
+              echo "  highest released base:     $HIGHEST_BASE"
+              echo "Bump release.json to at least $HIGHEST_BASE before releasing."
+              exit 1
+            fi
+          fi
+
           if [[ "$CHANNEL" == "beta" ]]; then
             LATEST_BETA_NUMBER="$(
               git tag --list "v${BASE_VERSION}-beta.*" \

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -245,6 +245,24 @@ jobs:
               ;;
           esac
 
+          # Refuse to publish behind what has already shipped. See the same guard
+          # in release-client.yml for why: release.json used to be per-branch, and
+          # merging the beta line into main can leave it trailing the tags.
+          # Base versions only, so beta.N increments stay fine.
+          HIGHEST_BASE="$(git -C packages/server tag --list 'v*' | sed 's/^v//; s/-.*$//' | sort -V | tail -n 1 || true)"
+
+          if [[ -n "$HIGHEST_BASE" && "$BASE_VERSION" != "$HIGHEST_BASE" ]]; then
+            OLDEST="$(printf '%s\n%s\n' "$HIGHEST_BASE" "$BASE_VERSION" | sort -V | head -n 1)"
+
+            if [[ "$OLDEST" == "$BASE_VERSION" ]]; then
+              echo "release.json server version is behind the server tags."
+              echo "  release.json base version: $BASE_VERSION"
+              echo "  highest released base:     $HIGHEST_BASE"
+              echo "Bump release.json to at least $HIGHEST_BASE before releasing."
+              exit 1
+            fi
+          fi
+
           if [[ "$CHANNEL" == "beta" ]]; then
             LATEST_BETA_NUMBER="$(
               git -C packages/server tag --list "v${BASE_VERSION}-beta.*" \

--- a/release.json
+++ b/release.json
@@ -1,5 +1,5 @@
 {
   "product": "gryt",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "server": "1.1.5"
 }


### PR DESCRIPTION
Fixes the version regression from the cancelled `v1.3.0-beta.2` run. **My mistake in #33**, and the failure mode is worth stating plainly because the guard here is shaped by it.

## What happened

`release.json` used to be effectively per-branch, and the two copies tracked different things:

| Branch | Tracked | Value |
|---|---|---|
| `main` | stable releases | `1.2.12` |
| `beta` | the beta line | `1.3.1` |

#33 moved the channel to a dispatch input, which merged those two lines without reconciling them. A `bump: minor` from `main` computed `1.2.12` → `1.3.0`, beta numbering found `v1.3.0-beta.1` already existed, and out came `v1.3.0-beta.2` — older than the `v1.3.1-beta.1` testers were already running.

Every step did exactly what it was written to do. I flagged "beta releases now bump release.json on main" as the thing to watch in #33, but didn't follow it through to the consequence that main's copy was already trailing. During the audit I compared submodule gitlinks between the branches and never compared `release.json`.

## The change

**`release.json` → `1.3.1`**, matching what the beta line actually reached.

**A guard in both release workflows** that refuses to run when the base version is behind the newest tag:

```
release.json is behind the tags.
  release.json base version: 1.3.0
  highest released base:     1.3.1
Bump release.json to at least 1.3.1 before releasing.
```

It compares **base versions only**, so `beta.N` increments inside a base are unaffected — it's the `x.y.z` going backwards that's wrong.

## Verification

Ran the guard logic against the repository's real tag list:

| Base version | Result |
|---|---|
| `1.3.0` | refused — this incident |
| `1.2.12` | refused — what `main` actually held |
| `1.3.1` | allowed — the reconciled value |
| `1.3.2` / `1.4.0` / `2.0.0` | allowed |

## Worth a look

**`sort -V` on base versions only** is the deliberate simplification. Comparing full prerelease strings drags in semver ordering rules (`1.3.1-beta.1` < `1.3.1`) that `sort -V` doesn't implement faithfully. Stripping everything after `-` sidesteps that entirely, at the cost of not catching a *beta number* regression — but the tag-already-exists checks below already cover that case.

**`1.3.1` is a judgment call.** It continues the existing line, so the next beta with `bump: none` becomes `1.3.1-beta.2`. If you'd rather start clean at `1.3.2`, change the one value and use `bump: none`.

## Residue not addressed here

`client:main` still has commit `8ee22ff` setting `package.json` to `1.3.0-beta.2`, a version that no longer exists. Separate one-line PR in that repo — it self-corrects on the next release either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)