### PR TITLE
Set up MSVC before the embedded server build, add a Windows probe (GRYT-25)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -619,6 +619,21 @@ jobs:
           set -euo pipefail
           npx eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0
 
+      # Must precede the embedded server build. That step runs
+      # `npm rebuild better-sqlite3 --build-from-source`, which needs a C++
+      # toolchain, and this action is what sets VCINSTALLDIR. node-gyp checks
+      # that variable before falling back to enumerating installs with
+      # PowerShell — a fallback that now fails outright, because the runner
+      # image ships Visual Studio 18 and node-gyp 11.5.0 reports it as
+      # `unknown version "undefined"`.
+      #
+      # The ordering was wrong before too. It only worked because the older
+      # runner image had a Visual Studio that the PowerShell fallback could
+      # identify without help.
+      - name: Set up MSVC Build Tools Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Build embedded server and SFU
         working-directory: packages/client
         shell: bash
@@ -673,10 +688,6 @@ jobs:
         run: |
           set -euo pipefail
           bash native/audio-capture/build.sh
-
-      - name: Set up MSVC Build Tools Windows
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build native Windows binaries
         if: runner.os == 'Windows'

--- a/.github/workflows/windows-build-probe.yml
+++ b/.github/workflows/windows-build-probe.yml
@@ -1,0 +1,144 @@
+name: Windows build probe
+
+# Reproduces the embedded-server build on a Windows runner in isolation, so the
+# better-sqlite3 native build can be iterated on without cutting a release each
+# time. Everything after that step — lint, typecheck, electron packaging, docker,
+# signing — is skipped, which takes a ~25 minute release run down to a few minutes.
+#
+# Deliberately NOT in the Discord CI notification watch list. This workflow is
+# expected to fail while it is being used for its purpose, and those failures
+# should not reach #ci.
+#
+# Delete it once the Windows build is stable again.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner image to probe
+        required: true
+        default: windows-latest
+        type: choice
+        options:
+          - windows-latest
+          - windows-2022
+          - windows-2025
+
+      msvc_position:
+        description: Where to run the MSVC setup relative to the build
+        required: true
+        default: before
+        type: choice
+        options:
+          - before
+          - after
+          - none
+
+jobs:
+  probe:
+    name: Probe ${{ inputs.runner }} / msvc=${{ inputs.msvc_position }}
+    runs-on: ${{ inputs.runner }}
+
+    steps:
+      - name: Checkout monorepo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Checkout required submodules
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git submodule sync -- packages/client packages/server packages/sfu
+          git submodule update --init --force -- packages/client packages/server packages/sfu
+
+      - name: Report toolchain the runner actually has
+        shell: pwsh
+        run: |
+          Write-Host "Runner image: ${{ inputs.runner }}"
+          $vs = "C:\Program Files\Microsoft Visual Studio"
+          if (Test-Path $vs) {
+            Write-Host "Visual Studio installs found:"
+            Get-ChildItem $vs -Directory | ForEach-Object { Write-Host "  $($_.Name)" }
+          } else {
+            Write-Host "No Visual Studio directory at $vs"
+          }
+          Write-Host "VCINSTALLDIR = $env:VCINSTALLDIR"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "yarn"
+          cache-dependency-path: packages/client/yarn.lock
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: true
+          cache-dependency-path: packages/sfu/go.sum
+
+      - name: Install client dependencies
+        working-directory: packages/client
+        shell: bash
+        run: |
+          set -euo pipefail
+          yarn install --frozen-lockfile --ignore-engines
+
+      - name: Install server dependencies
+        working-directory: packages/server
+        shell: bash
+        run: |
+          set -euo pipefail
+          yarn install --frozen-lockfile --ignore-engines
+
+      - name: Install SFU dependencies
+        working-directory: packages/sfu
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -f go.mod ]]; then
+            go mod download
+          fi
+
+      - name: Set up MSVC Build Tools (before)
+        if: inputs.msvc_position == 'before'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Confirm MSVC environment
+        shell: pwsh
+        run: |
+          Write-Host "VCINSTALLDIR = $env:VCINSTALLDIR"
+          if ($env:VCINSTALLDIR) {
+            Write-Host "node-gyp will take the VS Command Prompt path."
+          } else {
+            Write-Host "node-gyp will fall back to enumerating installs with PowerShell."
+          }
+
+      - name: Build embedded server and SFU
+        working-directory: packages/client
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run build:embedded-server
+
+      - name: Set up MSVC Build Tools (after)
+        if: inputs.msvc_position == 'after'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Verify embedded server dependencies
+        working-directory: packages/client
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! -d build/embedded-server/server/node_modules/better-sqlite3/build/Release ]]; then
+            echo "better-sqlite3 native build output is missing."
+            exit 1
+          fi
+
+          echo "better-sqlite3 built successfully."
+          ls build/embedded-server/server/node_modules/better-sqlite3/build/Release


### PR DESCRIPTION
Fixes the Windows failure in [run 31008070421](https://github.com/Gryt-chat/gryt/actions/runs/31008070421). Linux and macOS built fine, so `v1.3.1-beta.2` shipped without a Windows binary.

**Not a regression from #33 or #34** — the last four Release Client runs, all in May, succeeded, and nothing in that work goes near the build.

## Diagnosis

```
gyp ERR! find VS VCINSTALLDIR not set, not running in VS Command Prompt
gyp ERR! find VS could not use PowerShell to find Visual Studio 2017 or newer
gyp ERR! find VS Failure details: RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]
gyp ERR! find VS unknown version "undefined" found at "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! stack Error: Could not find any Visual Studio installation to use
```

Two causes:

1. **`Set up MSVC Build Tools Windows` ran four steps after `Build embedded server and SFU`**, which is what needs the C++ toolchain. So `VCINSTALLDIR` was never set. This ordering was always wrong.
2. **The runner image now ships Visual Studio 18**, which node-gyp 11.5.0 reports as `unknown version "undefined"`, and its PowerShell fallback dies on a stdio buffer overflow.

The image change is what unmasked the ordering bug — the old image had a Visual Studio the fallback could identify without help.

## The change

Move the MSVC setup above the embedded server build. node-gyp checks `VCINSTALLDIR` *before* falling back to PowerShell enumeration, so setting it should sidestep VS 18 detection entirely.

## Worth a look

**I can't prove this works.** It's Windows-only and can't be reproduced on macOS, and a local Windows PC wouldn't reproduce it either — the bug depends on the runner having VS 18, whereas a dev machine will typically have VS 2022 that node-gyp handles fine.

So this also adds **`windows-build-probe.yml`**: the failing step in isolation, with `runner` and `msvc_position` as dispatch inputs. It skips lint, typecheck, Electron packaging, Docker and signing, taking a ~25 minute release run down to a few minutes. It also prints which Visual Studio installs the runner actually has and whether `VCINSTALLDIR` ended up set.

Suggested sequence after merge:

| `runner` | `msvc_position` | Tests |
|---|---|---|
| `windows-latest` | `before` | whether the fix alone is enough |
| `windows-latest` | `after` | confirms the diagnosis by reproducing the failure |
| `windows-2022` | `before` | the fallback, if VS 18 is unworkable |

**The probe is deliberately not in the CI notifier's watch list.** It's expected to fail while being used for its purpose, and those failures shouldn't reach `#ci`. That's a conscious exception to the "add new workflows to the list" note in that file. Delete the probe once Windows is stable.

**If the reorder isn't enough**, the fallback is pinning that matrix entry to `windows-2022`. I didn't include it here because pinning a runner image is a decision with a longer tail than an ordering fix, and the probe can tell us whether it's needed rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)