### PR TITLE
Pin the Electron Windows build to windows-2022 (GRYT-25)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -478,7 +478,17 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
+          # Pinned, do not move back to windows-latest without checking first.
+          # windows-latest now ships Visual Studio 18, and node-gyp 11.5.0 cannot
+          # parse its version — it reports `unknown version "undefined"` and
+          # refuses the toolchain even when handed it directly via VCINSTALLDIR.
+          # That breaks the better-sqlite3 native build in the embedded server,
+          # which is the only thing here needing a C++ toolchain.
+          #
+          # Verified with windows-build-probe.yml: identical code and step order
+          # fails on windows-latest and passes on windows-2022. Unpin once
+          # node-gyp understands VS 18. See GRYT-26.
+          - windows-2022
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Unblocks Windows releases. Follows #35, which fixed a real ordering bug but couldn't fix this.

## What the probe proved

`windows-build-probe.yml` ran the identical code and step order on both images:

| Runner | `Build embedded server and SFU` |
|---|---|
| `windows-latest` | fails — runs [31008070421](https://github.com/Gryt-chat/gryt/actions/runs/31008070421), [31009696019](https://github.com/Gryt-chat/gryt/actions/runs/31009696019) |
| `windows-2022` | passes — probe [31010782049](https://github.com/Gryt-chat/gryt/actions/runs/31010782049), zero `find VS` errors |

Same commit, same MSVC ordering, only the image differs. That isolates it completely.

## Root cause

`windows-latest` now ships **Visual Studio 18**, and node-gyp 11.5.0 can't parse its version:

```
gyp ERR! find VS running in VS Command Prompt, installation path is:
gyp ERR! find VS "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS - will only use this version
gyp ERR! find VS unknown version "undefined" found at "...\Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
```

It finds the install, is told to use it, then rejects it. #35 got node-gyp all the way to `will only use this version` and it still failed — which is what ruled out the workflow as the cause and pointed at node-gyp itself.

## Worth a look

**This is a stopgap and the comment in the diff says so.** A bare pin invites someone to "tidy it up" back to `windows-latest` in six months and reintroduce the bug, so the reasoning sits inline with a pointer to GRYT-26.

**`windows-2022` will be retired eventually**, so this buys time rather than solving it. GRYT-26 tracks the real options: a newer node-gyp if one supports VS 18, or dropping `--build-from-source` for `better-sqlite3` prebuilds so no C++ toolchain is needed at all. That second one is the proper fix but needs someone who knows why `--build-from-source` was chosen — likely ABI, and not my call to guess at.

**`release-server.yml` needs no change.** It runs entirely on `ubuntu-latest` and cross-compiles the Windows server zip via `build-selfhosted.sh`, so it never touches a Windows runner.

**Keeping the probe for now.** It should go once Windows has been green through an actual release, not before — it's the cheapest way to test GRYT-26's fix later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)