### PR TITLE
Fix the macOS updater repo and hold releases as drafts (GRYT-28, GRYT-27)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -450,12 +450,18 @@ jobs:
             echo "release_type=prerelease" >> "$GITHUB_OUTPUT"
           fi
 
+      # Created as a draft so nothing sees it until every platform has uploaded.
+      # The builds finish minutes apart — macOS trails Windows by about seven,
+      # because it signs and notarises first — and a client that checks in that
+      # gap gets a 404 on its own channel file while another platform is already
+      # updating happily. The publish-release job below flips it live.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: Gryt v${{ steps.version.outputs.version }}
           prerelease: ${{ steps.channel.outputs.channel == 'beta' }}
+          draft: true
           files: .release/manifest.json
           body: |
             Gryt v${{ steps.version.outputs.version }}
@@ -868,10 +874,21 @@ jobs:
 
           echo "${{ secrets.APPLE_API_KEY_P8_BASE64 }}" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
 
+          # The publish overrides matter even though this uploads separately with
+          # `gh release upload`. electron-builder bakes them into app-update.yml
+          # inside the packaged app, which is where the updater reads its repo
+          # from. Without them this inherited publish.repo from
+          # packages/client/electron-builder.yml, which named the client repo
+          # rather than this one, and every shipped macOS build asked an empty
+          # repository for updates. The other platforms always passed these,
+          # which is why only macOS was broken.
           npx electron-builder \
             --mac \
             --publish never \
-            -c.extraMetadata.version="$VERSION"
+            -c.extraMetadata.version="$VERSION" \
+            -c.publish.provider=github \
+            -c.publish.owner="$OWNER" \
+            -c.publish.repo="$REPO"
 
           rm -f "$RUNNER_TEMP/AuthKey.p8"
 
@@ -906,15 +923,77 @@ jobs:
 
           gh release upload "$TAG" "${ASSETS[@]}" --repo "$OWNER/$REPO" --clobber
 
+  # Runs only after every matrix leg succeeds. `needs` on a matrix job means a
+  # single failed platform skips this, which leaves the release as an
+  # unpublished draft rather than a half-built release nobody can install —
+  # v1.3.1-beta.2 and beta.3 both shipped without Windows assets that way.
+  publish-release:
+    name: Publish release
+    needs: [prepare-release, build-electron]
+    runs-on: ubuntu-latest
+
+    env:
+      OWNER: Gryt-chat
+      REPO: gryt
+      VERSION: ${{ needs.prepare-release.outputs.version }}
+      CHANNEL: ${{ needs.prepare-release.outputs.channel }}
+
+    steps:
+      - name: Verify every platform uploaded
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          TAG="v$VERSION"
+          ASSETS="$(gh release view "$TAG" --repo "$OWNER/$REPO" --json assets --jq '.assets[].name')"
+
+          echo "Assets on $TAG:"
+          printf '%s\n' "$ASSETS" | sed 's/^/  /'
+
+          # One installer per platform plus the three channel files. A client
+          # whose channel file is missing gets a 404 and reports the release as
+          # broken, so the channel files matter as much as the installers.
+          MISSING=0
+          for PATTERN in \
+            'win-x64\.exe$' \
+            'linux-x86_64\.AppImage$' \
+            'mac-arm64\.zip$' \
+            '^latest\.yml$' \
+            '^latest-linux\.yml$' \
+            '^latest-mac\.yml$'
+          do
+            if ! printf '%s\n' "$ASSETS" | grep -qE "$PATTERN"; then
+              echo "::error::No asset matching $PATTERN"
+              MISSING=1
+            fi
+          done
+
+          if [[ "$MISSING" -ne 0 ]]; then
+            echo "Leaving $TAG as a draft."
+            exit 1
+          fi
+
+          echo "All expected assets present."
+
+      - name: Publish the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh release edit "v$VERSION" --repo "$OWNER/$REPO" --draft=false
+          echo "Published v$VERSION."
+
+      # Moved here from the Linux build leg. Announcing from there fired while
+      # macOS was still signing, so #releases advertised a build that Mac users
+      # could not yet install.
       - name: Notify Discord
-        if: runner.os == 'Linux'
         shell: bash
         env:
           WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
-          VERSION: ${{ env.VERSION }}
-          CHANNEL: ${{ env.CHANNEL }}
-          OWNER: ${{ env.OWNER }}
-          REPO: ${{ env.REPO }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Two release-correctness fixes. Same file, so they're together — say the word and I'll split them.

## 1. macOS updater pointed at the wrong repo (GRYT-28) — the user-visible bug

macOS auto-update has **never worked**. Every check 404s while Windows updates fine from the same release.

The macOS build passed only `-c.extraMetadata.version`, so it inherited `publish.repo` from `packages/client/electron-builder.yml`, which named the **client** repo. Releases moved to this superproject at `v1.2.12`:

| Repo | Releases | Tags |
|---|---|---|
| `Gryt-chat/client` | **0** | `1.2.2` … `v1.2.11` |
| `Gryt-chat/gryt` | **30** | 39 `v*` |

The client repo's tags stop exactly where `gryt`'s releases begin, so `repo: client` was correct historically and went stale at that boundary. Windows and Linux were papered over by CLI overrides added in the same move; macOS never was, and shipped every build pointing at an empty repository.

This adds the same overrides to the macOS invocation. [client#11](https://github.com/Gryt-chat/client/pull/11) fixes the config itself so the default is right outside CI — either alone fixes the bug, both closes both paths.

**This rescues no existing macOS install.** The wrong URL is baked into every macOS build ever shipped. Every Mac user needs one manual DMG download, and only builds after this are updatable. Worth announcing rather than letting people find out.

## 2. Releases published before their assets exist (GRYT-27)

Measured on `v1.3.1-beta.4`:

```
13:44:46  release published
13:50:45  latest.yml         Windows updatable
13:53:51  latest-linux.yml   Linux updatable
13:57:48  latest-mac.yml     macOS updatable
```

macOS trails Windows by 7 minutes because it signs and notarises first. A client checking in that gap 404s on its own channel file.

Now: created as a draft, published by a new `publish-release` job that runs after the whole matrix and verifies one installer per platform plus all three channel files.

**Useful side effect** — `needs` on a matrix job means a single failed platform *skips* this job, so a broken build leaves an unpublished draft instead of a published partial release. `v1.3.1-beta.2` and `beta.3` both shipped without Windows assets exactly that way.

The Discord announcement moves into that job too; it previously fired from the Linux leg, announcing builds Mac users couldn't yet install.

## Worth a look

**The riskiest assumption:** Linux and Windows publish via `electron-builder --publish always`, not `gh release upload`. It should find the draft by tag and upload into it without changing its draft state — but I can't prove that without cutting a beta. If it un-drafts the release itself, this approach collapses and the fallback is uploading artifacts to the workflow and publishing from one final job.

**The asset patterns are a judgment call.** One installer per platform plus the three channel files — not every blockmap or the `.deb`/portable variants. Enough to catch a whole platform going missing, loose enough not to fail on a target being added. Verified against real data: passes on `beta.4`, catches the missing Windows assets on `beta.3`.

## Verification

YAML validated, all three new shell steps `bash -n` clean, asset patterns tested against both a complete and a partial release. The draft/publish flow itself needs a beta to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)