### PR TITLE
Make the dev servers reachable on a LAN: HOST and SFU_PUBLIC_HOST (GRYT-44)

### DIFF
--- a/ops/start_dev.sh
+++ b/ops/start_dev.sh
@@ -26,8 +26,21 @@ S3_ENV="S3_ENDPOINT=http://127.0.0.1:9000 S3_REGION=us-east-1 S3_ACCESS_KEY_ID=$
 
 S3_DISABLE_ENV="DISABLE_S3=true"
 
+# The server hands SFU_PUBLIC_HOST straight to the client, which dials it — so
+# a placeholder here isn't inert, it guarantees a failed voice connect. Default
+# to this machine's LAN address so another machine can reach the SFU too;
+# SFU_WS_HOST stays loopback because that hop is server-to-SFU on this box.
+detect_lan_ip() {
+  if command -v ipconfig >/dev/null 2>&1; then
+    ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || true
+  else
+    hostname -I 2>/dev/null | awk '{print $1}' || true
+  fi
+}
+LAN_IP="${LAN_IP:-$(detect_lan_ip || true)}"
+
 SFU_WS_HOST="${SFU_WS_HOST:-ws://127.0.0.1:5005}"
-SFU_PUBLIC_HOST="${SFU_PUBLIC_HOST:-wss://sfu.example.com}"
+SFU_PUBLIC_HOST="${SFU_PUBLIC_HOST:-ws://${LAN_IP:-127.0.0.1}:5005}"
 STUN_SERVERS="${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
 # 3666 is the Vite dev server port (packages/client/vite.config.ts); the server
 # matches Origin exactly, so it must be listed verbatim.

--- a/ops/start_dev.sh
+++ b/ops/start_dev.sh
@@ -32,6 +32,10 @@ STUN_SERVERS="${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.c
 # 3666 is the Vite dev server port (packages/client/vite.config.ts); the server
 # matches Origin exactly, so it must be listed verbatim.
 CORS_ORIGIN="${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3666,http://127.0.0.1:3666,https://app.gryt.chat}"
+# Loopback by default so a dev server isn't exposed on whatever network you
+# happen to be on. Set HOST=0.0.0.0 in ops/.env to test LAN discovery, where
+# another machine has to reach ws1/ws2 over the wire.
+HOST="${HOST:-127.0.0.1}"
 GRYT_AUTH_MODE="${GRYT_AUTH_MODE:-required}"
 GRYT_OIDC_ISSUER="${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}"
 GRYT_OIDC_AUDIENCE="${GRYT_OIDC_AUDIENCE:-gryt-web}"
@@ -117,7 +121,7 @@ echo ""
 WS_S3_ENV="$S3_DISABLE_ENV"
 [[ "$DEV_WITH_S3" == "1" ]] && WS_S3_ENV="$S3_ENV"
 
-COMMON_ENV="CORS_ORIGIN=${CORS_ORIGIN} GRYT_AUTH_MODE=${GRYT_AUTH_MODE} GRYT_OIDC_ISSUER=${GRYT_OIDC_ISSUER} GRYT_OIDC_AUDIENCE=${GRYT_OIDC_AUDIENCE} JWT_SECRET=${JWT_SECRET} SERVER_PASSWORD=${SERVER_PASSWORD} SFU_WS_HOST=${SFU_WS_HOST} SFU_PUBLIC_HOST=${SFU_PUBLIC_HOST} STUN_SERVERS=${STUN_SERVERS} ${WS_S3_ENV}"
+COMMON_ENV="HOST=${HOST} CORS_ORIGIN=${CORS_ORIGIN} GRYT_AUTH_MODE=${GRYT_AUTH_MODE} GRYT_OIDC_ISSUER=${GRYT_OIDC_ISSUER} GRYT_OIDC_AUDIENCE=${GRYT_OIDC_AUDIENCE} JWT_SECRET=${JWT_SECRET} SERVER_PASSWORD=${SERVER_PASSWORD} SFU_WS_HOST=${SFU_WS_HOST} SFU_PUBLIC_HOST=${SFU_PUBLIC_HOST} STUN_SERVERS=${STUN_SERVERS} ${WS_S3_ENV}"
 
 # ── Create tmux session with separate windows ────────────────────────
 echo "Creating tmux session '$SESSION' with 5 windows..."


### PR DESCRIPTION
Part of GRYT-44, alongside Gryt-chat/client#17 and Gryt-chat/server#3. Dev script only — no gitlink bumps, those come after the others land.

Two defaults in `ops/start_dev.sh` that each made LAN dev impossible.

## 1. HOST was never passed through

`COMMON_ENV` didn't include `HOST`, so `ws1`/`ws2` bound `127.0.0.1` regardless of what `ops/.env` said. Both still advertise over mDNS, so another machine discovers them and gets refused by every one.

`HOST="${HOST:-127.0.0.1}"`, threaded into `COMMON_ENV`. Default unchanged — a dev server shouldn't land on whatever network you happen to be on just because you ran the script.

## 2. SFU_PUBLIC_HOST was a placeholder that guaranteed failure

```sh
SFU_PUBLIC_HOST="${SFU_PUBLIC_HOST:-wss://sfu.example.com}"
```

This one isn't inert. The server passes it verbatim to the client (`packages/server/src/socket/handlers/voice.ts:186-191`, no normalisation), and the client dials it. Every voice connect died:

```
Step 4: Room access granted   {sfu_url: 'wss://sfu.example.com'}
Step 7a: Opening WebSocket    {url: 'wss://sfu.example.com/'}
WebSocket connection to 'wss://sfu.example.com/' failed
Step X: CONNECTION FAILED     Failed to connect to SFU server
```

Now defaults to the detected LAN address. `SFU_WS_HOST` stays loopback — that hop is server-to-SFU on the same box.

## Verified

```
HOST=0.0.0.0 ./ops/start_dev.sh
  ws1 env            HOST=0.0.0.0  SFU_PUBLIC_HOST=ws://192.168.50.167:5005
  192.168.50.167:5001/health      200
  192.168.50.167:5002/health      200
  ws://192.168.50.167:5005/       WebSocket UPGRADED
  dns-sd -B _gryt._tcp            ws1, ws2

config block under set -euo pipefail
  no overrides       SFU_PUBLIC_HOST=ws://192.168.50.167:5005
  explicit override  SFU_PUBLIC_HOST=wss://sfu.gryt.chat   (respected)
```

`bash -n` clean.

## What to look at

- **`detect_lan_ip` picks `en0`, falling back to `en1`, then `hostname -I` off macOS.** On a machine with several interfaces — VPN, Docker bridges, the `192.168.x.0` ones this box has — `en0` is a guess, not a certainty. It's overridable via `LAN_IP` or `SFU_PUBLIC_HOST`, but the heuristic is the weakest part of this diff.
- **The `${LAN_IP:-127.0.0.1}` fallback is not exercised by my testing** — detection succeeded every run here, so the no-LAN-IP path is reasoned about rather than observed.
- No shellcheck on this machine, so that's unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)