### PR TITLE
Stop client and server releases racing each other to push main (GRYT-47)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -35,7 +35,10 @@ permissions:
   packages: write
 
 concurrency:
-  group: release-client-${{ github.ref }}
+  # Shared with release-server.yml on purpose. Both workflows commit to the same
+  # branch, so a per-workflow group only serialised releases of the same kind and
+  # let a client release and a server release race for the push.
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -413,21 +416,76 @@ jobs:
 
       - name: Commit release metadata and tag
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BASE_VERSION: ${{ steps.version.outputs.base_version }}
+          CHANNEL: ${{ steps.channel.outputs.channel }}
+          BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
-          VERSION="${{ steps.version.outputs.version }}"
-          CHANNEL="${{ steps.channel.outputs.channel }}"
+          # This branch can move under us between checkout and here — a merged PR,
+          # or a server release that got past the concurrency group. Rebasing our
+          # commit is not enough: release.json is four lines and the server writes
+          # "server" while we write "version", so the two hunks overlap and a
+          # replay conflicts even though the edits are independent.
+          #
+          # So re-apply what we own onto whatever the branch holds now, and retry.
+          # A reset reverts the tracked manifest, so keep a copy; the packages/client
+          # working tree is untouched by the reset, so re-staging it re-records the
+          # same commit. The release.json edit matches "Update monorepo release.json"
+          # above; keep them in step.
+          MANIFEST_BACKUP="${RUNNER_TEMP}/release-manifest.json"
+          cp .release/manifest.json "$MANIFEST_BACKUP"
 
-          git add release.json .release/manifest.json packages/client
+          apply_release_metadata() {
+            mkdir -p .release
+            cp "$MANIFEST_BACKUP" .release/manifest.json
 
-          if git diff --cached --quiet; then
-            echo "No release metadata changes to commit."
-          else
+            node -e '
+              const fs = require("fs");
+              const version = process.argv[1];
+              const path = "release.json";
+              const data = JSON.parse(fs.readFileSync(path, "utf8"));
+
+              data.product = data.product || "gryt";
+              data.version = version;
+
+              fs.writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
+            ' "$BASE_VERSION"
+          }
+
+          outcome=""
+          for attempt in 1 2 3 4 5; do
+            apply_release_metadata
+            git add release.json .release/manifest.json packages/client
+
+            if git diff --cached --quiet; then
+              echo "No release metadata changes to commit."
+              outcome="nothing-to-commit"
+              break
+            fi
+
             git commit -m "release: v$VERSION ($CHANNEL) [skip ci]"
-            git push origin HEAD:${{ github.ref_name }}
+
+            if git push origin "HEAD:${BRANCH}"; then
+              outcome="pushed"
+              break
+            fi
+
+            echo "Push rejected (attempt ${attempt}/5) — reapplying onto the current ${BRANCH}."
+            git fetch origin "${BRANCH}"
+            git reset --hard "origin/${BRANCH}"
+            sleep $(( attempt * 5 ))
+          done
+
+          if [[ -z "$outcome" ]]; then
+            echo "Could not push the release commit after 5 attempts." >&2
+            exit 1
           fi
 
+          # Tagged after the push succeeds, so the tag can never name a commit that
+          # is not on the branch.
           git tag "v$VERSION"
           git push origin "v$VERSION"
 

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -53,7 +53,10 @@ permissions:
   packages: write
 
 concurrency:
-  group: release-server-${{ github.ref }}
+  # Shared with release-client.yml on purpose. Both workflows commit to the same
+  # branch, so a per-workflow group only serialised releases of the same kind and
+  # let a client release and a server release race for the push.
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -552,20 +555,59 @@ jobs:
 
       - name: Commit monorepo release state
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BASE_VERSION: ${{ steps.version.outputs.base_version }}
+          CHANNEL: ${{ steps.channel.outputs.channel }}
+          BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
-          VERSION="${{ steps.version.outputs.version }}"
-          CHANNEL="${{ steps.channel.outputs.channel }}"
+          # This branch can move under us between checkout and here — a merged PR,
+          # or a client release that got past the concurrency group. Rebasing our
+          # commit is not enough: release.json is four lines and the client writes
+          # "version" while we write "server", so the two hunks overlap and a
+          # replay conflicts even though the edits are independent.
+          #
+          # So re-apply our own key to whatever the branch holds now, and retry.
+          # Same edit as "Update monorepo release.json" above; keep them in step.
+          apply_server_version() {
+            node -e '
+              const fs = require("fs");
+              const version = process.argv[1];
+              const path = "release.json";
+              const data = JSON.parse(fs.readFileSync(path, "utf8"));
 
-          git add release.json
+              data.product = data.product || "gryt";
+              data.server = version;
 
-          if git diff --cached --quiet; then
-            echo "No release.json changes to commit."
-          else
+              fs.writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
+            ' "$BASE_VERSION"
+          }
+
+          for attempt in 1 2 3 4 5; do
+            apply_server_version
+            git add release.json
+
+            if git diff --cached --quiet; then
+              echo "No release.json changes to commit."
+              exit 0
+            fi
+
             git commit -m "release: server v${VERSION} (${CHANNEL}) [skip ci]"
-            git push origin HEAD:${{ github.ref_name }}
-          fi
+
+            if git push origin "HEAD:${BRANCH}"; then
+              exit 0
+            fi
+
+            echo "Push rejected (attempt ${attempt}/5) — reapplying onto the current ${BRANCH}."
+            git fetch origin "${BRANCH}"
+            git reset --hard "origin/${BRANCH}"
+            sleep $(( attempt * 5 ))
+          done
+
+          echo "Could not push the release commit after 5 attempts." >&2
+          exit 1
 
       - name: Tag server repo
         shell: bash


### PR DESCRIPTION
Fixes GRYT-47. Found tonight: the server release failed at `Commit monorepo release state` after everything expensive had already succeeded.

```
21:05:48  server release starts   (checks out main)
21:05:59  client release starts
21:06:29  client pushes           release: v1.3.2-beta.1
21:09:38  server pushes           ! [rejected] HEAD -> main (fetch first)
```

Docker image pushed, Windows and Linux bundles built, manifest created — then the bookkeeping commit lost a race and the tag, GitHub Release and Discord notify were all skipped. An image landed in GHCR that nothing references.

## Why the existing guard missed it

Both workflows already declare `concurrency`, but with per-workflow groups:

```yaml
release-server:  group: release-server-${{ github.ref }}
release-client:  group: release-client-${{ github.ref }}
```

That only serialises two releases of the *same* kind. A client release and a server release were free to run side by side, and both end in a bare `git push origin HEAD:main` with no fetch, rebase or retry.

## Why a rebase isn't the fix

`release.json` is four lines, and the two workflows write adjacent ones:

```json
{
  "product": "gryt",
  "version": "1.3.1",   ← client
  "server":  "1.1.5"    ← server
}
```

With default diff context those hunks overlap, so replaying the commit conflicts even though the edits are independent. Simulated both paths on a scratch repo:

```
replay the server commit onto the moved main   ✗ CONFLICT
reset to main, re-apply our own key            ✓ clean
                                                  version 1.3.2 + server 1.2.0
```

## The change

**One shared concurrency group** across both workflows, so any release waits for any other.

**Re-apply-and-retry instead of replay.** On rejection each workflow resets to the current branch and re-applies only the key it owns, up to five times with backoff. The `release.json` edit is a copy of the one in `Update monorepo release.json` in the same file.

The concurrency group alone would handle two releases. The retry also covers a PR merging mid-release — which is what actually moved `main` here, since the gitlink bump (#40) landed minutes before these runs.

## What to look at

- **The client step does more than the server's.** It stages `.release/manifest.json` (tracked, so a reset reverts it — copied to `$RUNNER_TEMP` and restored) and the `packages/client` gitlink (the submodule working tree is untouched by a superproject reset, so re-staging re-records the same commit). Worth a second pair of eyes on the reset being safe there.
- **The client tags in the same step as the push.** I moved the tag after the retry loop so it can only name a commit that reached the branch — previously an early exit would have skipped tagging entirely. This changes the ordering of an existing step.
- **`git reset --hard` in a release workflow** is the sharpest edge in this diff. It runs only after a rejected push, and only tracked files are in play at that point, but it deserves scrutiny.

## Verified

Both files parse as YAML, both extracted `run:` scripts pass `bash -n`, and the conflict-vs-clean behaviour is the simulation above. **Not exercised against a real concurrent release** — that needs two dispatches racing, which I can't stage without publishing real artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)