### PR TITLE
Add dev server launch config for AI tooling

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -28,6 +28,26 @@
         "cd packages/docs && yarn dev"
       ],
       "port": 3000
+    },
+    {
+      "name": "sfu",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-lc",
+        "export PATH=\"/usr/local/go/bin:$PATH\"; cd packages/sfu && ./start.sh"
+      ],
+      "port": 5005,
+      "autoPort": false
+    },
+    {
+      "name": "server",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-lc",
+        "cd packages/server && env PORT=5001 SERVER_NAME=ws1 SERVER_INSTANCE_ID=ws1 DATA_DIR=./data/ws1 DISABLE_S3=true JWT_SECRET=dev-secret-do-not-use-in-production CORS_ORIGIN=http://127.0.0.1:15738,http://localhost:3666,http://127.0.0.1:3666 SFU_WS_HOST=ws://127.0.0.1:5005 STUN_SERVERS=stun:stun.l.google.com:19302 yarn dev"
+      ],
+      "port": 5001,
+      "autoPort": false
     }
   ]
 }

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,33 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "client",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-lc",
+        "cd packages/client && yarn dev --host"
+      ],
+      "port": 3666,
+      "autoPort": false
+    },
+    {
+      "name": "site",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-lc",
+        "cd packages/site && yarn dev"
+      ],
+      "port": 5173
+    },
+    {
+      "name": "docs",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-lc",
+        "cd packages/docs && yarn dev"
+      ],
+      "port": 3000
+    }
+  ]
+}


### PR DESCRIPTION
One new file, `.claude/launch.json`. It lets a tool start any of the project's dev servers without being told how — today that means reading `ops/start_dev.sh` or guessing.

The premise, in Sivert's words: running things locally doesn't hurt anyone. What hurts is merging changes without reading them. So this covers everything a tool might want to start, and changes nothing about what can be merged.

| Name | Command | Port | |
|---|---|---|---|
| `client` | `packages/client` → `yarn dev --host` | 3666 | pinned |
| `site` | `packages/site` → `yarn dev` | 5173 | |
| `docs` | `packages/docs` → `next dev --turbo` | 3000 | |
| `sfu` | `packages/sfu` → `./start.sh` | 5005 | pinned |
| `server` | `packages/server` → `yarn dev` with dev env | 5001 | pinned |

## Verified

Both new entries were run from the config itself, on spare ports since the tmux stack holds the real ones:

```
server  →  Signaling server started at 127.0.0.1:5081     /health 200
sfu     →  Configuration: Port=5082 ... Starting HTTP server on port 5082
```

All five commands pass `bash -n`.

## The pinned ports, and why

- **`client` 3666** — Keycloak registers redirect URIs per port and only `http://localhost:3666/*` is whitelisted. A reassigned port fails sign-in with an invalid `redirect_uri`, which reads as broken auth rather than a wrong port. Same reason it's now commented in `vite.config.ts` (GRYT-37).
- **`sfu` 5005** — it's what `SFU_WS_HOST` points at.
- **`server` 5001** — what the dev client and `ops/start_dev.sh` expect.

`site` and `docs` don't care and are left unpinned.

## What to look at

- **The `server` entry duplicates dev values from `ops/start_dev.sh`** — the JWT secret (already public in that script), CORS origins, `SFU_WS_HOST`. JSON has no comments, so there's nothing in the file to say these two must stay in step. They can drift. I couldn't see a clean way to share them without a refactor, so this is the honest weak point.
- **It sets `DISABLE_S3=true`** so a standalone server runs without MinIO. That's a deliberate difference from `start_dev.sh`, which brings MinIO up — file uploads won't work under this entry.
- **`ops/start_dev.sh` is still the way to run the whole stack** — MinIO, two servers, SFU and the client in tmux. These entries start one service each and aren't a replacement.
- **`.claude/settings.local.json` is not committed.** It's personal and already covered by `.gitignore:14`. Only `launch.json` is here: commands and ports, no paths outside the repo, no tokens.

## Documented in the AI policy

Gryt-chat/docs#5 adds a "Tooling in the repo" section to the [AI policy](https://docs.gryt.chat/docs/guide/ai) covering this file and `CLAUDE.md`, stating plainly that neither grants anything — the review rules hold because PRs get read, not because a config file exists.

That's a **separate PR only because `packages/docs` is its own repository**; a docs change can't ride in a `Gryt-chat/gryt` PR. Treat the two as one change, and merge this one first or the docs describe a file that isn't there yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)