### PR TITLE
Let the gitlink sweep survive a broken pointer

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -56,7 +56,13 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          submodules: recursive
+          # Deliberately not `submodules: recursive`. That clones each submodule
+          # at the recorded gitlink, so a pointer at a commit which is not on the
+          # remote — an unpushed local commit, a force-pushed branch — kills the
+          # checkout before this job reaches the code that would repair it. That
+          # happened on 2026-08-06 and needed a manual fix. The job re-points
+          # every submodule anyway, so the recorded SHA is of no use here.
+          submodules: false
 
       - name: Set up Git user
         shell: bash
@@ -72,8 +78,31 @@ jobs:
 
           SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth"
 
+          # Clone straight from the URL rather than `git submodule update`,
+          # which insists on the recorded gitlink and so fails on a broken one.
+          # Nothing here reads that SHA — each submodule is moved to its own
+          # origin/main a moment later.
+          for path in $SUBMODULES; do
+            if [[ -e "$path/.git" ]]; then
+              continue
+            fi
+
+            name=$(git config -f .gitmodules --get-regexp '\.path$' \
+              | awk -v p="$path" '$2 == p { print $1 }' \
+              | sed 's/^submodule\.//; s/\.path$//')
+            url=$(git config -f .gitmodules --get "submodule.${name}.url")
+
+            if [[ -z "$url" ]]; then
+              echo "No URL in .gitmodules for $path — skipping."
+              continue
+            fi
+
+            echo "Cloning $path from $url"
+            rm -rf "$path"
+            git clone --quiet "$url" "$path"
+          done
+
           git submodule sync -- $SUBMODULES
-          git submodule update --init --force -- $SUBMODULES
 
       - name: Update selected submodules
         shell: bash


### PR DESCRIPTION
Follow-up to #48. The workflow that exists to fix gitlinks could be defeated by a bad one — which is exactly what happened today, and why #48 had to be done by hand.

## The failure

```
fatal: remote error: upload-pack: not our ref 17291fc13736dd29e210596865ab511ffdbfaf35
fatal: Fetched in submodule path 'packages/client', but it did not contain it
```

Both `actions/checkout` (with `submodules: recursive`) and `git submodule update --init` insist on resolving the recorded gitlink. A pointer at a commit that isn't on the remote — an unpushed local commit, a force-pushed branch — kills the job before it reaches the code that would repair it.

## Neither step needs that SHA

Every submodule is moved to its own `origin/main` moments later, so the recorded value is discarded anyway. So:

- **Checkout no longer fetches submodules** (`submodules: false`).
- **The init step clones from the URL in `.gitmodules`** rather than asking git to resolve the pointer. Existing clones are left alone; only missing ones are fetched.

## Verified

Against a real clone with the pointer poisoned to the same unreachable SHA:

```
poisoned client gitlink → 17291fc (unreachable)

old behaviour:
  fatal: remote error: upload-pack: not our ref 17291fc…      FAILED

new init step:
  Cloning packages/docs from https://github.com/Gryt-chat/docs.git
  packages/client → 2e7d77a
  packages/docs   → 4b334c5
  staged gitlinks: (none — already correct)
```

Both branches got exercised: `docs` took the clone path, `client` had a partial checkout from the failed attempt and recovered through fetch-and-checkout. YAML parses and every `run:` step passes `bash -n`, including the `.gitmodules` parsing with its escaping intact through YAML.

## What to look at

- **`rm -rf "$path"` before cloning.** Only reached when `$path/.git` is absent, so it clears a stray empty directory rather than a real checkout — but it is an `rm -rf` on a variable path in CI, and worth your eyes.
- **Submodule URL is resolved by matching `.path` in `.gitmodules`**, not by assuming the name equals the directory basename. They happen to match today for all seven; this does not rely on that.
- **`--depth` is not used**, so clones are full. Slower, but `update_submodule` fast-forwards and pushes, and shallow clones make that fiddlier than it's worth for seven small repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)