### PR TITLE
Give beta its own MinIO port by default

### DIFF
--- a/ops/deploy/compose/.env.example
+++ b/ops/deploy/compose/.env.example
@@ -34,6 +34,9 @@ SFU_PUBLIC_HOST=ws://localhost:5005
 CLIENT_PORT=3666
 SERVER_PORT=5000
 SFU_PORT=5005
+# Host-published MinIO port. Must be unique per deployment on a shared host:
+# prod defaults to 9000 and beta to 9002. Only override if something else on
+# the box already has the port.
 MINIO_PORT=9000
 
 # Recommended: run WebRTC over a single UDP port (better on restrictive networks).

--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -7,7 +7,13 @@ services:
     container_name: gryt-beta-minio
     command: ["server", "/data", "--console-address", ":9001"]
     ports:
-      - "127.0.0.1:${MINIO_PORT:-9000}:9000"
+      # 9002, not 9000: beta and prod share one Docker host, and `server` runs
+      # with host networking and `minio` pointed at 127.0.0.1 (see below). A beta
+      # brought up without MINIO_PORT set would fail to publish 9000 — prod has
+      # it — and beta's server would then resolve minio:9000 to *prod's* object
+      # storage. That is a cross-environment data path, not just a port clash,
+      # so the default has to differ rather than relying on the env file.
+      - "127.0.0.1:${MINIO_PORT:-9002}:9000"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
@@ -116,7 +122,13 @@ services:
       GRYT_AUTH_API: ${GRYT_AUTH_API:-https://auth.gryt.chat}
       GRYT_IDENTITY_JWKS_URL: ${GRYT_IDENTITY_JWKS_URL:-https://id.gryt.chat/.well-known/jwks.json}
       DATA_DIR: /data
-      S3_ENDPOINT: http://minio:${MINIO_PORT:-9000}
+      # ${MINIO_PORT} here is deliberate and is NOT the same as the plain
+      # `minio:9000` the image-worker uses. This service is `network_mode: host`
+      # with `minio` mapped to 127.0.0.1, so it reaches MinIO through the port
+      # published on the host. The image-worker is on the compose bridge network,
+      # where `minio` is the container and the port is always 9000. Both are
+      # right; making them match would break one of them.
+      S3_ENDPOINT: http://minio:${MINIO_PORT:-9002}
       S3_REGION: auto
       S3_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-minioadmin}
       S3_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -117,6 +117,12 @@ services:
       GRYT_AUTH_API: ${GRYT_AUTH_API:-https://auth.gryt.chat}
       GRYT_IDENTITY_JWKS_URL: ${GRYT_IDENTITY_JWKS_URL:-https://id.gryt.chat/.well-known/jwks.json}
       DATA_DIR: /data
+      # ${MINIO_PORT} here is deliberate and is NOT the same as the plain
+      # `minio:9000` the image-worker uses. This service is `network_mode: host`
+      # with `minio` mapped to 127.0.0.1, so it reaches MinIO through the port
+      # published on the host. The image-worker is on the compose bridge network,
+      # where `minio` is the container and the port is always 9000. Both are
+      # right; making them match would break one of them.
       S3_ENDPOINT: http://minio:${MINIO_PORT:-9000}
       S3_REGION: auto
       S3_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-minioadmin}


### PR DESCRIPTION
`beta.yml` and `prod.yml` both defaulted `MINIO_PORT` to `9000`. They only differ live because beta's env file overrides it. Deploy beta on a host already running prod without that variable and the two collide.

**The consequence is worse than a failed port bind.** `server` runs `network_mode: host` with `minio` mapped to `127.0.0.1`, so it reaches object storage through whatever is published on the host. Beta losing the race for 9000 doesn't leave beta broken — it leaves **beta's server talking to prod's MinIO**. Cross-environment object storage, silently, on a box with no off-box backups.

Beta now defaults to `9002`, which is what the live override already sets, so this changes nothing about the current deployment — it just stops it depending on an env var being remembered.

## A correction worth recording

I first read `S3_ENDPOINT: http://minio:${MINIO_PORT}` as a bug, on the grounds that MinIO always listens on 9000 inside the compose network and interpolating the *host* port there must be wrong. **That was incorrect**, and I nearly "fixed" it into an outage.

Checked against the running host instead of assuming:

```
gryt-beta-server       NetworkMode: host   extra_hosts: minio:127.0.0.1   S3_ENDPOINT=http://minio:9002
gryt-beta-image-worker NetworkMode: gryt-beta_gryt-beta                    S3_ENDPOINT=http://minio:9000
docker port gryt-beta-minio  ->  9000/tcp -> 127.0.0.1:9002
```

Both are correct, via different addressing models: the server goes through the host-published port, the image-worker through the compose bridge where the container always listens on 9000. From inside the beta server container, `minio:9000` and `minio:9002` **both** answer — 9000 is prod's MinIO on the shared host loopback, which is exactly the hazard above.

So this PR also comments both files, because two lines that look inconsistent and aren't are precisely the kind of thing the next person "tidies up".

## Verified

`docker compose config` on both files with `MINIO_PORT` unset:

```
beta   published 127.0.0.1:9002 -> 9000   server: minio:9002   image-worker: minio:9000
prod   published 127.0.0.1:9000 -> 9000   server: minio:9000   image-worker: minio:9000
```

No collision, and identical to what the host runs today.

## Not merging this myself

It's a normal-review path so I could, but it changes production compose for a box with no off-box backups. Deploying it is your call, and nothing here takes effect until something re-creates those containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)