### PR TITLE
Verify sharp, not better-sqlite3, before packaging (GRYT-70)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -759,17 +759,20 @@ jobs:
           set -euo pipefail
           npx eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0
 
-      # Must precede the embedded server build. That step runs
-      # `npm rebuild better-sqlite3 --build-from-source`, which needs a C++
-      # toolchain, and this action is what sets VCINSTALLDIR. node-gyp checks
-      # that variable before falling back to enumerating installs with
-      # PowerShell — a fallback that now fails outright, because the runner
-      # image ships Visual Studio 18 and node-gyp 11.5.0 reports it as
-      # `unknown version "undefined"`.
+      # Still required, but no longer for the reason it was added. The embedded
+      # server used to run `npm rebuild better-sqlite3 --build-from-source`
+      # here, and node-gyp needed the VCINSTALLDIR this action sets. Both the
+      # server and the image worker are on node:sqlite now, so nothing in the
+      # embedded server build compiles C++ any more.
       #
-      # The ordering was wrong before too. It only worked because the older
-      # runner image had a Visual Studio that the PowerShell fallback could
-      # identify without help.
+      # What still needs a toolchain is "Build native Windows binaries" below —
+      # native/build.bat compiles the audio and screen capture helpers. Delete
+      # this step and that one breaks, so it stays.
+      #
+      # Whether the windows-2022 pin can be lifted is a separate question. It
+      # was pinned because node-gyp 11.5.0 could not parse Visual Studio 18, and
+      # node-gyp is no longer in this path — but native/build.bat has not been
+      # tried against VS 18. That is what GRYT-26's probe is for.
       - name: Set up MSVC Build Tools Windows
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
@@ -797,21 +800,29 @@ jobs:
             exit 1
           fi
 
-          if [[ ! -d build/embedded-server/server/node_modules/better-sqlite3 ]]; then
-            echo "Missing embedded better-sqlite3 dependency."
-            echo "The packaged app will crash with: Cannot find module 'better-sqlite3'"
+          # sharp is what this checks now. better-sqlite3 was the other one, and
+          # it is gone: the server and the image worker both moved to
+          # node:sqlite, which is part of the runtime and cannot be missing from
+          # a bundle. Leaving the old check here would fail every release.
+          #
+          # sharp is still worth asserting. It ships as a per-platform optional
+          # dependency that npm resolves by os/cpu, so a bundle built on the
+          # wrong host, or an install that quietly skipped optional deps, gets a
+          # server that starts and then throws the first time anyone uploads an
+          # image.
+          if [[ ! -d build/embedded-server/server/node_modules/sharp ]]; then
+            echo "Missing embedded sharp dependency."
+            echo "The packaged app will crash with: Cannot find module 'sharp'"
             exit 1
           fi
 
-          if [[ ! -d build/embedded-server/server/node_modules/better-sqlite3/build/Release ]]; then
-            echo "Missing better-sqlite3 native build output."
-            find build/embedded-server/server/node_modules/better-sqlite3 -maxdepth 4 -type f || true
+          if [[ ! -d build/embedded-server/worker/node_modules/sharp ]]; then
+            echo "Missing sharp in the image worker bundle."
+            echo "Image jobs would queue and never be processed."
             exit 1
           fi
 
           echo "Embedded server dependencies are present."
-          echo "better-sqlite3:"
-          find build/embedded-server/server/node_modules/better-sqlite3 -maxdepth 3 -type f | sed -n '1,50p'
 
       - name: Build native audio Linux
         if: runner.os == 'Linux'


### PR DESCRIPTION
**This blocks the next client release.** The "Verify embedded server dependencies" step does:

```bash
if [[ ! -d build/embedded-server/server/node_modules/better-sqlite3 ]]; then
  echo "Missing embedded better-sqlite3 dependency."
  exit 1
fi
```

`better-sqlite3` is gone as of [server#17](https://github.com/Gryt-chat/server/pull/17) and [image-worker#10](https://github.com/Gryt-chat/image-worker/pull/10), both merged. So a release dispatched today fails there, having already done the version bump, the push to `main` and the tag — the expensive, hard-to-undo half — before the build job gets far enough to notice.

### What replaces it

A check on `sharp`, in both the server and the worker bundle.

`node:sqlite` can't be missing from a bundle, so there is nothing to assert in its place. `sharp` still earns one: it ships as a per-platform optional dependency that npm resolves by `os`/`cpu`, so a bundle built on the wrong host — or an install that quietly skipped optional dependencies — produces a server that starts fine and then throws the first time anyone uploads an image. That is the failure mode this step exists to catch, and it is the one that survived the migration.

The worker bundle gets its own assertion, which it never had.

### The comment above the MSVC step

Corrected rather than removed. The step said it was there because the embedded server build runs `npm rebuild better-sqlite3 --build-from-source` and node-gyp needs `VCINSTALLDIR`. That's no longer true — nothing in the embedded server build compiles C++ any more.

The step is still required, for a different reason: `native/build.bat` compiles the audio and screen capture helpers. I'd rather the comment say so than leave a plausible-looking reason to delete a step that would break every Windows build.

**The `windows-2022` pin is deliberately left alone.** It was pinned because node-gyp 11.5.0 couldn't parse Visual Studio 18, and node-gyp is out of this path now — but `native/build.bat` has never been tried against VS 18. That is what GRYT-26's probe is for, and guessing here would be how the Windows builds break quietly.

### Verified

YAML parses. The substance can't be tested without dispatching a release, which is the awkward part of every change to this file — but the failing condition is not in doubt: I built the packaged app locally and `find gryt-chat.app -name "*better-sqlite3*"` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
