### PR TITLE
Bind the NT beta server to all interfaces

### DIFF
--- a/ops/deploy/compose/beta.local.yml
+++ b/ops/deploy/compose/beta.local.yml
@@ -27,6 +27,16 @@ services:
       - "${NT_SERVER_PORT:-5011}:5000"
     environment:
       PORT: "5000"
+      # Bridge networking, so the server has to listen on all interfaces or the
+      # published port reaches nothing. The server binds 127.0.0.1 unless told
+      # otherwise, and inside a bridge-networked container that is the
+      # container's own loopback.
+      #
+      # prod.yml and prod.local.yml have always set this. beta never did, and it
+      # went unnoticed because the running image predated the default — it broke
+      # the first time beta was upgraded. The neighbouring `server` in beta.yml
+      # does not need it, because network_mode: host makes 127.0.0.1 the host's.
+      HOST: "0.0.0.0"
       NODE_ENV: production
       SERVER_NAME: ${NT_SERVER_NAME:-NT (Beta)}
       SERVER_DESCRIPTION: ${NT_SERVER_DESCRIPTION:-A Gryt voice chat server (beta)}


### PR DESCRIPTION
**NT beta is currently unreachable on the dev box because of this.** Found while upgrading the beta stack.

`server-nt` runs on the compose bridge with `5011:5000` published. The server binds `127.0.0.1` unless `HOST` says otherwise ([index.ts:429](https://github.com/Gryt-chat/server/blob/main/src/index.ts#L429)), and inside a bridge-networked container that's the container's own loopback — so the published port reaches nothing.

`prod.yml` and `prod.local.yml` have always set `HOST: "0.0.0.0"`. `beta.local.yml` never did.

### Why it went unnoticed

The beta stack was 7 weeks stale and running an image that predated the default. It broke on the first upgrade past it.

The nastier part: **the container reports healthy while being unreachable.** Its healthcheck curls `localhost:5000` from *inside* the container, which succeeds regardless of the bind address. `docker compose ps` showed `healthy` the whole time; only an external `curl` found it.

The server does log a warning at startup, which is what identified it:

```
WARN  Bound to 127.0.0.1, so only this machine can reach the server, but it is
      still advertised over mDNS. Clients on the LAN will discover it and then
      fail to connect. Set HOST=0.0.0.0 to accept LAN connections.
```

### Not changing beta.yml's `server`

That one is `network_mode: host`, so `127.0.0.1` is the host's own loopback and the tunnel reaches it there. Binding it to `0.0.0.0` would expose it more widely for no gain.

### Worth a follow-up, not in here

The healthcheck being unable to detect this is the real weakness — a bind-address bug is invisible to a check that runs inside the container. Pointing it at the container's routable address instead of `localhost` would catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)