### PR TITLE
Require a task for anything deferred in a PR body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,21 @@ Dropping a task into **Done** sets its `done` flag automatically — no separate
 If something merges outside a PR, or CI fails, **check the Review column at the start of
 Vikunja work and close anything whose PR has landed.**
 
+### Anything you defer gets a task
+
+If you write "separate decision", "out of scope", "your call" or "follow-up" in a PR
+body, **open a task for it in the same breath and link it.** A merged PR is where notes
+go to die: it drops off the open list, nobody reads it again, and the thing you carefully
+identified is gone.
+
+That is not hypothetical. The decision about whether to purge the SVG uploads already on
+disk — left over from a stored-XSS fix — lived only in the body of a merged PR and an
+untracked local file for a week. It surfaced again by accident, during an unrelated audit.
+
+The bar is low: a title and a paragraph saying what was found, what was decided, and what
+is still open. If it isn't worth a task, it probably wasn't worth a paragraph in the PR
+either.
+
 ## Submodules
 
 `packages/*` are separate repositories. Commit and push the **submodule first**, then the


### PR DESCRIPTION
I audited every repo — commit messages, PR bodies, Vikunja descriptions, code comments — for work parked because of the review-required rule.

**The rule wasn't the problem.** Four deferrals mentioned it, and three were already resolved: [client#31](https://github.com/Gryt-chat/client/pull/31)/[server#13](https://github.com/Gryt-chat/server/pull/13) split GRYT-58 for reviewability and *both landed*, and gryt#47 asked a question that merging answered. The fourth was mine and is fixed.

**What the audit actually found was worse.** Things deferred with "separate decision" in a PR body and recorded nowhere else.

The clearest case: whether to purge the SVG uploads still sitting on disk after the stored-XSS fix in [server#16](https://github.com/Gryt-chat/server/pull/16). That's a genuine decision about deleting other people's files, and it existed only in the body of a merged PR and an untracked local handoff file. It resurfaced by accident, a week later, while I was looking for something else. It's now GRYT-79.

A merged PR drops off the open list and nobody reads it again. So:

> **Anything you defer gets a task.** If you write "separate decision", "out of scope", "your call" or "follow-up" in a PR body, open a task for it in the same breath and link it.

With the bar stated plainly — *"If it isn't worth a task, it probably wasn't worth a paragraph in the PR either"* — so this doesn't turn into task spam for every passing thought.

Sits under Task tracking rather than the review-required rules, because it isn't about those paths. It applies to anything deferred anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)