### PR TITLE
Bind the beta server to all interfaces (GRYT-92)

### DIFF
--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -104,6 +104,13 @@ services:
       - "minio:127.0.0.1"
     environment:
       PORT: ${SERVER_PORT:-5010}
+      # Every interface, not just loopback. The tunnel reaches this over the
+      # network as dev.lan:5010, and the server defaults to 127.0.0.1 — so
+      # without this it answers the healthcheck (which curls localhost on the
+      # same box) while the tunnel gets nothing, and beta.sivert.io serves a
+      # 502 next to a container `docker ps` calls healthy. Prod has always had
+      # it; server-nt got it in #56; this one was missed.
+      HOST: "0.0.0.0"
       NODE_ENV: production
       SERVER_NAME: ${SERVER_NAME:-Gryt (Beta)}
       SERVER_DESCRIPTION: ${SERVER_DESCRIPTION:-A Gryt voice chat server (beta)}


### PR DESCRIPTION
beta.sivert.io was serving 502 while `docker ps` called the container healthy,
and had done for four hours.

The server binds to `127.0.0.1` unless told otherwise, so it answered its
healthcheck — which curls localhost on the same box — and nothing else. The
tunnel reaches it as `dev.lan:5010` and got a closed port. From the host:

    127.0.0.1:5010/health  200
    dev.lan:5010/health    000
    ss: LISTEN 127.0.0.1:5010

Prod has always set `HOST`. `server-nt` got it in #56 today, from this exact
symptom. This is the same bug a third time, and the reason it keeps coming back
is that the healthcheck cannot tell the difference: it proves the process is
alive, not that anything can reach it.

## What to look at

The healthcheck is the real problem here and this does not fix it. It probes
`127.0.0.1` from inside the same network namespace, which is true whenever the
process is up, whichever interface it bound. A check that hit the address the
tunnel actually uses would have caught all three of these on deploy instead of
when someone visited the site. Worth its own task.

## Applied

Deployed to dev.lan on Sivert's go-ahead — `up -d --no-deps server` on the beta
stack only. Verified after: see the comment below.

Closes GRYT-92.