### PR TITLE
Let each server find its own image worker (GRYT-94)

### DIFF
--- a/ops/deploy/compose/beta.local.yml
+++ b/ops/deploy/compose/beta.local.yml
@@ -39,6 +39,10 @@ services:
       HOST: "0.0.0.0"
       NODE_ENV: production
       SERVER_NAME: ${NT_SERVER_NAME:-NT (Beta)}
+      # Where the image worker answers, so the server can ask it what version
+      # it is. Loopback because the server has host networking and the worker
+      # publishes there. Unset would simply mean no worker version is shown.
+      IMAGE_WORKER_URL: http://127.0.0.1:${IMAGE_WORKER_NT_HEALTH_PORT:-8084}
       SERVER_DESCRIPTION: ${NT_SERVER_DESCRIPTION:-A Gryt voice chat server (beta)}
       SERVER_PASSWORD: ${NT_SERVER_PASSWORD:-}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3667,https://app.gryt.chat,https://beta.gryt.chat}
@@ -89,6 +93,17 @@ services:
   image-worker-nt:
     image: ghcr.io/gryt-chat/image-worker:${IMAGE_WORKER_VERSION:-latest-beta}
     container_name: gryt-beta-image-worker-nt
+    # The server runs with host networking, so it cannot reach this container
+    # by service name — it has to come in through a published port. Bound to
+    # loopback: this is a health endpoint for the server beside it, not
+    # something the network needs.
+    #
+    # The default differs per stack on purpose. prod, prod-NT, beta and beta-NT
+    # all run a worker on one Docker host, and two of them defaulting to the
+    # same port means whichever comes up second fails to publish — or worse,
+    # a server reports the version of a different stack's worker.
+    ports:
+      - "127.0.0.1:${IMAGE_WORKER_NT_HEALTH_PORT:-8084}:8080"
     environment:
       DATA_DIR: /data
       S3_ENDPOINT: http://minio:9000

--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -113,6 +113,10 @@ services:
       HOST: "0.0.0.0"
       NODE_ENV: production
       SERVER_NAME: ${SERVER_NAME:-Gryt (Beta)}
+      # Where the image worker answers, so the server can ask it what version
+      # it is. Loopback because the server has host networking and the worker
+      # publishes there. Unset would simply mean no worker version is shown.
+      IMAGE_WORKER_URL: http://127.0.0.1:${IMAGE_WORKER_HEALTH_PORT:-8083}
       SERVER_DESCRIPTION: ${SERVER_DESCRIPTION:-A Gryt voice chat server (beta)}
       SERVER_PASSWORD: ${SERVER_PASSWORD:-}
       MDNS_INTERFACE: ${MDNS_INTERFACE:-}
@@ -171,6 +175,17 @@ services:
   image-worker:
     image: ghcr.io/gryt-chat/image-worker:${IMAGE_WORKER_VERSION:-latest-beta}
     container_name: gryt-beta-image-worker
+    # The server runs with host networking, so it cannot reach this container
+    # by service name — it has to come in through a published port. Bound to
+    # loopback: this is a health endpoint for the server beside it, not
+    # something the network needs.
+    #
+    # The default differs per stack on purpose. prod, prod-NT, beta and beta-NT
+    # all run a worker on one Docker host, and two of them defaulting to the
+    # same port means whichever comes up second fails to publish — or worse,
+    # a server reports the version of a different stack's worker.
+    ports:
+      - "127.0.0.1:${IMAGE_WORKER_HEALTH_PORT:-8083}:8080"
     environment:
       DATA_DIR: /data
       S3_ENDPOINT: http://minio:9000

--- a/ops/deploy/compose/prod.local.yml
+++ b/ops/deploy/compose/prod.local.yml
@@ -30,6 +30,10 @@ services:
       HOST: "0.0.0.0"
       NODE_ENV: production
       SERVER_NAME: ${NT_SERVER_NAME:-NT}
+      # Where the image worker answers, so the server can ask it what version
+      # it is. Loopback because the server has host networking and the worker
+      # publishes there. Unset would simply mean no worker version is shown.
+      IMAGE_WORKER_URL: http://127.0.0.1:${IMAGE_WORKER_NT_HEALTH_PORT:-8082}
       SERVER_DESCRIPTION: ${NT_SERVER_DESCRIPTION:-A Gryt voice chat server}
       SERVER_PASSWORD: ${NT_SERVER_PASSWORD:-}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3666,https://app.gryt.chat,https://beta.gryt.chat}
@@ -80,6 +84,17 @@ services:
   image-worker-nt:
     image: ghcr.io/gryt-chat/image-worker:${IMAGE_WORKER_VERSION:-latest}
     container_name: gryt-prod-image-worker-nt
+    # The server runs with host networking, so it cannot reach this container
+    # by service name — it has to come in through a published port. Bound to
+    # loopback: this is a health endpoint for the server beside it, not
+    # something the network needs.
+    #
+    # The default differs per stack on purpose. prod, prod-NT, beta and beta-NT
+    # all run a worker on one Docker host, and two of them defaulting to the
+    # same port means whichever comes up second fails to publish — or worse,
+    # a server reports the version of a different stack's worker.
+    ports:
+      - "127.0.0.1:${IMAGE_WORKER_NT_HEALTH_PORT:-8082}:8080"
     environment:
       DATA_DIR: /data
       S3_ENDPOINT: http://minio:9000

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -101,6 +101,10 @@ services:
       HOST: "0.0.0.0"
       NODE_ENV: production
       SERVER_NAME: ${SERVER_NAME:-My Gryt Server}
+      # Where the image worker answers, so the server can ask it what version
+      # it is. Loopback because the server has host networking and the worker
+      # publishes there. Unset would simply mean no worker version is shown.
+      IMAGE_WORKER_URL: http://127.0.0.1:${IMAGE_WORKER_HEALTH_PORT:-8081}
       SERVER_DESCRIPTION: ${SERVER_DESCRIPTION:-A Gryt voice chat server}
       SERVER_PASSWORD: ${SERVER_PASSWORD:-}
       MDNS_INTERFACE: ${MDNS_INTERFACE:-}
@@ -157,6 +161,17 @@ services:
   image-worker:
     image: ghcr.io/gryt-chat/image-worker:${IMAGE_WORKER_VERSION:-latest}
     container_name: gryt-prod-image-worker
+    # The server runs with host networking, so it cannot reach this container
+    # by service name — it has to come in through a published port. Bound to
+    # loopback: this is a health endpoint for the server beside it, not
+    # something the network needs.
+    #
+    # The default differs per stack on purpose. prod, prod-NT, beta and beta-NT
+    # all run a worker on one Docker host, and two of them defaulting to the
+    # same port means whichever comes up second fails to publish — or worse,
+    # a server reports the version of a different stack's worker.
+    ports:
+      - "127.0.0.1:${IMAGE_WORKER_HEALTH_PORT:-8081}:8080"
     environment:
       DATA_DIR: /data
       S3_ENDPOINT: http://minio:9000


### PR DESCRIPTION
The version panel cannot show the image worker under Docker. The server runs
with host networking and the worker sits on the compose bridge network, so
`image-worker:8080` does not resolve from it — there was nothing to point
`IMAGE_WORKER_URL` at, which is why Gryt-chat/server#25 shipped without wiring
this.

Each worker publishes its health port on loopback now, and each server is
pointed at its own.

| stack | worker | port |
|---|---|---|
| prod | image-worker | 8081 |
| prod NT | image-worker-nt | 8082 |
| beta | image-worker | 8083 |
| beta NT | image-worker-nt | 8084 |

## What to look at

- **The defaults differ per stack deliberately.** Four workers share one Docker
  host. Two defaulting to the same port means the second fails to publish — or
  worse, a server reports the version of another stack's worker. Same hazard the
  MinIO port comment in `beta.yml` already spells out.
- **8081–8084 were checked free on dev.lan** (`ss -tln`) before choosing them;
  8080 is taken by something else. All four are overridable via
  `IMAGE_WORKER_HEALTH_PORT` / `IMAGE_WORKER_NT_HEALTH_PORT`.
- **Bound to `127.0.0.1`**, so the health endpoint is reachable by the server
  beside it and not from the network.
- **Safe to merge before the worker release.** A worker without `/version`
  answers health there, which has no version field, and the server reads that
  as "cannot say" and shows no row — exactly today's behaviour.

## Applying

Needs a recreate of the worker and server in each stack to take effect, per
stack and by name. Not deployed by this PR.

## Testing

Rendered all four with `docker compose config`: ports 8081/8082 and 8083/8084
published on loopback, and each server carrying the matching
`IMAGE_WORKER_URL`. Not yet exercised against a running worker with `/version`,
since that needs the image-worker release.

Closes GRYT-94.