### PR TITLE
Match the image rule to what the changelog page does

### DIFF
--- a/patch-notes-style.md
+++ b/patch-notes-style.md
@@ -104,8 +104,9 @@ rarely earns that. A picture of the new state alone is fine.
 The mechanics, all of which are handled by the changelog page rather than by the
 note:
 
-- **Capped at 440px and centred.** A full app window at column width dominates the
-  paragraph that just explained it. Click for full size.
+- **Full column width, centred.** These are screenshots of a whole app window;
+  any smaller and the detail being described cannot be made out. Click for full
+  size.
 - **Never upscaled.** A clip is drawn at its own pixels or smaller. Blowing up a
   screen capture makes it look worse than the interface it is showing.
 - **Clips play themselves, silently, on a loop, with no controls** — use `<Clip>`,


### PR DESCRIPTION
`patch-notes-style.md` says release-note screenshots are "capped at 440px and centred". The changelog page hasn't done that since the site redesign — `ChangelogEntry.module.css` draws images at full column width, and caps only clips, at `min(528px, 100%)`.

So the doc is describing CSS that no longer exists. Docs-only, no behaviour change.

Found while syncing local state at the start of a session: the edit was sitting uncommitted in the working tree from the session that redesigned the site, and would have been lost on the next checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)