### PR TITLE
Add the ui submodule (GRYT-142)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -30,6 +30,15 @@
       "port": 3000
     },
     {
+      "name": "ui-docs",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-lc",
+        "cd packages/ui/apps/docs && bunx vite dev --port 3010"
+      ],
+      "port": 3010
+    },
+    {
       "name": "sfu",
       "runtimeExecutable": "bash",
       "runtimeArgs": [

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -34,6 +34,7 @@ on:
           - docs
           - site
           - auth
+          - ui
 
 permissions:
   contents: write
@@ -87,7 +88,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth"
+          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui"
 
           # Clone straight from the URL rather than `git submodule update`,
           # which insists on the recorded gitlink and so fails on a broken one.
@@ -176,6 +177,10 @@ jobs:
             update_submodule "packages/auth" "$DEFAULT_SUBMODULE_BRANCH"
           fi
 
+          if [[ "$SELECTED" == "all" || "$SELECTED" == "ui" ]]; then
+            update_submodule "packages/ui" "$DEFAULT_SUBMODULE_BRANCH"
+          fi
+
       - name: Commit changes
         shell: bash
         run: |
@@ -206,7 +211,7 @@ jobs:
             git fetch origin "$TARGET_BRANCH"
             git reset --hard "origin/$TARGET_BRANCH"
 
-            for path in packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth; do
+            for path in packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui; do
               [[ -d "$path" ]] || continue
               git -C "$path" fetch origin main
               git -C "$path" checkout -B main origin/main

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,7 @@
 	path = packages/image-worker
 	url = https://github.com/Gryt-chat/image-worker.git
 	branch = main
+[submodule "ui"]
+	path = packages/ui
+	url = https://github.com/Gryt-chat/ui.git
+	branch = main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Working rules for Gryt
 
 Gryt is a WebRTC voice chat platform maintained by one person. It's a superproject with
-seven git submodules under `packages/`. Read these rules before making changes.
+eight git submodules under `packages/`. Read these rules before making changes.
 
 ## Review-required paths
 
@@ -89,8 +89,10 @@ kanban board is the state: **To-Do → Doing → Review → Done**.
 | PR merged | Move to **Done**, which sets the task's done flag | CI |
 
 CI covers the last two through `.github/workflows/vikunja-task-done.yml`, which calls a
-reusable workflow in `Gryt-chat/.github`. All eight repos have it, so you don't normally
-need to touch a task after opening the PR.
+reusable workflow in `Gryt-chat/.github`. Eight of the nine repos have it, so you don't
+normally need to touch a task after opening the PR. `ui` is the exception — it was added
+as a submodule later and still needs the workflow (GRYT-143), so move its tasks by hand
+until that lands.
 
 Moving a task is not exposed by the Vikunja MCP server, so use the REST API directly:
 


### PR DESCRIPTION
Adds [Gryt-chat/ui](https://github.com/Gryt-chat/ui) as the eighth submodule at `packages/ui`, so `@gryt/ui` can be developed alongside the client instead of in a checkout off to the side. No client code changes here — this is the plumbing.

## What is in the repo

A bun workspace publishing `@gryt/ui`, currently `0.1.3` on npm, released through changesets on push to `main`. MUI v7 + Emotion + Tailwind 4 (compiled to `dist/styles.css`, so consumers do not need Tailwind), Phosphor icons, ~26 exported components plus `GrytProvider` and `createGrytTheme`.

## Source only, not a build dependency

The client will depend on the published npm package, not on this path. Client CI builds from `Gryt-chat/client` on its own and never sees a sibling submodule, so a workspace link would work locally and break in CI. For local iteration on the library the answer is `yarn link`, not a path dependency.

That is also why `ui` stays out of `release-client.yml` and `release-server.yml`: those list the repos whose commits go into a release bundle and get pinned in `manifest.json`, and `ui` is not one of them. It did need adding to `update-submodules.yml`, in all four places that name the submodules one at a time — the dispatch dropdown, `SUBMODULES`, the per-submodule `if` chain, and the retry loop.

## Worth a look

- The submodule is added with `--name ui` so `.gitmodules` matches the existing short-name convention. `git submodule add` would otherwise have written `[submodule "packages/ui"]` next to seven entries that read `[submodule "auth"]`.
- `CLAUDE.md` says eight submodules now, and the task-tracking section is corrected: `ui` has no `vikunja-task-done.yml`, so board moves for its PRs are manual until GRYT-143 lands.

## Follow-ups opened

- **GRYT-143** — add `vikunja-task-done.yml` to `ui`.

## On replacing Radix

The client has 97 files importing `@radix-ui/themes`. Counting individual components, the four most-used are `Flex` (71), `Text` (57), `Box` (14) and `Heading` (13) — 155 usages, and `@gryt/ui` exports no equivalent for any of them. The library covers the widgets (Button, IconButton, Tooltip, Dialog, Card, Badge, TextField, Avatar, Select, Switch, Slider, Checkbox, Tabs, Skeleton) and is missing the layout and typography primitives that hold every screen together, plus `AlertDialog` (10), `ContextMenu` (3), `SegmentedControl` (2), `Link` (2) and `ScrollArea` (1).

So the first real migration step is in `ui`, not in the client: decide whether `@gryt/ui` re-exports MUI's `Box`/`Stack`/`Typography` under Gryt names or the client imports those from `@mui/material` directly. Until that is settled, any file-by-file swap leaves both libraries loaded. Not doing that here — flagging it before someone starts at the top of the file list.