### PR TITLE
Serve the UI component docs at ui.gryt.chat (GRYT-160)

### DIFF
--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -1,5 +1,6 @@
 ##
-## ops/internal/.env  — internal hosted services (gryt.chat / docs.gryt.chat / feedback.gryt.chat)
+## ops/internal/.env  — internal hosted services (gryt.chat / docs.gryt.chat /
+## ui.gryt.chat / feedback.gryt.chat)
 ##
 ## Copy this file to ops/internal/.env and fill in values.
 ##
@@ -7,6 +8,7 @@
 # ── Host ports (must be unique) ───────────────────────────────────────────
 INTERNAL_SITE_HTTP_PORT=9472
 INTERNAL_DOCS_HTTP_PORT=9471
+INTERNAL_UI_HTTP_PORT=9475
 
 FIDER_HTTP_PORT=9473
 

--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -4,6 +4,7 @@ This folder contains **internal** infrastructure used to run:
 
 - `gryt.chat` (marketing site)
 - `docs.gryt.chat` (documentation)
+- `ui.gryt.chat` (the `@gryt/ui` component library docs)
 - `feedback.gryt.chat` (Fider feature requests board)
 
 It’s **not** intended for self-hosters. Self-hosting docs live under `ops/deploy/*` (Docker Compose) and `ops/helm/*` (Kubernetes).
@@ -23,6 +24,7 @@ You must use unique host ports. Configure them in `ops/internal/.env`:
 
 - `INTERNAL_SITE_HTTP_PORT` (default `9472`)
 - `INTERNAL_DOCS_HTTP_PORT` (default `9471`)
+- `INTERNAL_UI_HTTP_PORT` (default `9475`)
 - `FIDER_HTTP_PORT` (default `9473`)
 
 ## Fider auth: use Gryt Auth (Keycloak OIDC)
@@ -62,9 +64,10 @@ Use Fider’s **Test** button before enabling the provider.
 
 - `gryt.chat` → `http://127.0.0.1:<INTERNAL_SITE_HTTP_PORT>`
 - `docs.gryt.chat` → `http://127.0.0.1:<INTERNAL_DOCS_HTTP_PORT>`
+- `ui.gryt.chat` → `http://127.0.0.1:<INTERNAL_UI_HTTP_PORT>`
 - `feedback.gryt.chat` → `http://127.0.0.1:<FIDER_HTTP_PORT>`
 
-All three should be **proxied** and routed through the same Cloudflare Tunnel.
+All four should be **proxied** and routed through the same Cloudflare Tunnel.
 
 ## Downloads folder
 

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -18,6 +18,17 @@ services:
       - ./downloads:/usr/share/nginx/html/downloads:ro
     restart: unless-stopped
 
+  # Component library docs (ui.gryt.chat). Built from packages/ui, which is a
+  # bun workspace — the context is the workspace root because apps/docs
+  # resolves @gryt/ui from source rather than from npm.
+  ui:
+    build:
+      context: ../../packages/ui
+    platform: linux/amd64
+    ports:
+      - "${INTERNAL_UI_HTTP_PORT:-9475}:80"
+    restart: unless-stopped
+
   # Feature requests / user feedback (Fider)
   fider-db:
     image: postgres:17


### PR DESCRIPTION
Puts the `@gryt/ui` component docs on `ui.gryt.chat`, deployed the same way as `gryt.chat` and `docs.gryt.chat`: built on dev.lan from submodule source, published on a host port, fronted by Cloudflare Tunnel.

The tunnel route already exists — `ui.gryt.chat` → `http://127.0.0.1:9475`.

Pairs with **Gryt-chat/ui#10**, which adds the Dockerfile this builds.

## Changes

- `ops/internal/docker-compose.yml` — a `ui` service, context `../../packages/ui`, `${INTERNAL_UI_HTTP_PORT:-9475}:80`. Same shape as `site`.
- `ops/internal/.env.example`, `ops/internal/README.md` — port and forwarding entries.
- Gitlink bump for `packages/ui`.

9475 was picked because 9471–9474 are taken on the box (docs, site, fider, vikunja).

## Merge order

The gitlink currently points at `claude/GRYT-160-dockerfile` in the ui repo, not `main`. Gryt-chat/ui#10 should merge first; I'll then re-point the gitlink at `ui:main` before this merges. Merging this first would leave `main` pointing at a branch commit that a squash-merge is about to orphan.

Until the Dockerfile is on `ui:main`, `docker compose build ui` on dev.lan fails — nothing else is affected, since the service is new.

## Verified

The image was built and smoke-tested locally (details in Gryt-chat/ui#10): health endpoint, root, a deep route, and a missing asset all behave. `docker compose config` resolves the service cleanly as `internal-ui-1`.

Not yet deployed to dev.lan. When it is, the command is targeted, never a bare `up -d`:

```bash
docker compose --env-file ops/internal/.env -f ops/internal/docker-compose.yml up -d --no-deps --build ui
```

## Follow-up

The `ops/internal/README.md` start command is a bare `up -d --build`, which contradicts the dev.lan rule in CLAUDE.md about targeting services by name. Left alone here to keep this diff to one thing — GRYT-161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
