### PR TITLE
Remove identity config nothing reads (GRYT-166)

### DIFF
--- a/ops/deploy/compose/beta.local.yml
+++ b/ops/deploy/compose/beta.local.yml
@@ -55,8 +55,9 @@ services:
       GRYT_AUTH_MODE: ${GRYT_AUTH_MODE:-required}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}
-      GRYT_AUTH_API: ${GRYT_AUTH_API:-https://auth.gryt.chat}
-      GRYT_IDENTITY_JWKS_URL: ${GRYT_IDENTITY_JWKS_URL:-https://id.gryt.chat/.well-known/jwks.json}
+      # Which identities this server admits. Add "local" to let people
+      # join without a Gryt account — see docs.gryt.chat, Server → Identity.
+      GRYT_IDENTITY_TIERS: ${GRYT_IDENTITY_TIERS:-account}
       DATA_DIR: /data
       S3_ENDPOINT: http://minio:9000
       S3_REGION: auto

--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -130,8 +130,9 @@ services:
       GRYT_AUTH_MODE: ${GRYT_AUTH_MODE:-required}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}
-      GRYT_AUTH_API: ${GRYT_AUTH_API:-https://auth.gryt.chat}
-      GRYT_IDENTITY_JWKS_URL: ${GRYT_IDENTITY_JWKS_URL:-https://id.gryt.chat/.well-known/jwks.json}
+      # Which identities this server admits. Add "local" to let people
+      # join without a Gryt account — see docs.gryt.chat, Server → Identity.
+      GRYT_IDENTITY_TIERS: ${GRYT_IDENTITY_TIERS:-account}
       DATA_DIR: /data
       # ${MINIO_PORT} here is deliberate and is NOT the same as the plain
       # `minio:9000` the image-worker uses. This service is `network_mode: host`
@@ -234,6 +235,7 @@ services:
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_REALM: ${GRYT_OIDC_REALM:-gryt}
       GRYT_OIDC_CLIENT_ID: ${GRYT_OIDC_CLIENT_ID:-gryt-web}
+      GRYT_AUTH_API: ${GRYT_AUTH_API:-https://auth.gryt.chat}
     depends_on:
       server:
         condition: service_healthy

--- a/ops/deploy/compose/prod.local.yml
+++ b/ops/deploy/compose/prod.local.yml
@@ -46,8 +46,9 @@ services:
       GRYT_AUTH_MODE: ${GRYT_AUTH_MODE:-required}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}
-      GRYT_AUTH_API: ${GRYT_AUTH_API:-https://auth.gryt.chat}
-      GRYT_IDENTITY_JWKS_URL: ${GRYT_IDENTITY_JWKS_URL:-https://id.gryt.chat/.well-known/jwks.json}
+      # Which identities this server admits. Add "local" to let people
+      # join without a Gryt account — see docs.gryt.chat, Server → Identity.
+      GRYT_IDENTITY_TIERS: ${GRYT_IDENTITY_TIERS:-account}
       DATA_DIR: /data
       S3_ENDPOINT: http://minio:9000
       S3_REGION: auto

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -118,8 +118,9 @@ services:
       GRYT_AUTH_MODE: ${GRYT_AUTH_MODE:-required}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}
-      GRYT_AUTH_API: ${GRYT_AUTH_API:-https://auth.gryt.chat}
-      GRYT_IDENTITY_JWKS_URL: ${GRYT_IDENTITY_JWKS_URL:-https://id.gryt.chat/.well-known/jwks.json}
+      # Which identities this server admits. Add "local" to let people
+      # join without a Gryt account — see docs.gryt.chat, Server → Identity.
+      GRYT_IDENTITY_TIERS: ${GRYT_IDENTITY_TIERS:-account}
       DATA_DIR: /data
       # ${MINIO_PORT} here is deliberate and is NOT the same as the plain
       # `minio:9000` the image-worker uses. This service is `network_mode: host`
@@ -220,6 +221,7 @@ services:
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_REALM: ${GRYT_OIDC_REALM:-gryt}
       GRYT_OIDC_CLIENT_ID: ${GRYT_OIDC_CLIENT_ID:-gryt-web}
+      GRYT_AUTH_API: ${GRYT_AUTH_API:-https://auth.gryt.chat}
     depends_on:
       server:
         condition: service_healthy


### PR DESCRIPTION
Found while removing the built-in CA in GRYT-158, filed rather than bundled.

## Removed

`GRYT_IDENTITY_JWKS_URL` was set on the **server** service in all four compose files and read by nothing — not the server, not the identity service, not anything (checked all eight packages: zero source references).

What actually configures which CAs a server trusts is `GRYT_TRUSTED_CERT_ISSUERS`, which **no compose file sets**. So every deployment has been relying on the server's built-in default of `https://id.gryt.chat`. That's correct, but not because of this variable — anyone who set it expecting to point at a different CA changed nothing and would only find out when a join failed.

## Moved

`GRYT_AUTH_API` was on the server service too, which also never reads it. It's a **client** variable — the web container's entrypoint uses it to generate `config.js`. It's now on the `client` service, where `GRYT_OIDC_REALM` and `GRYT_OIDC_CLIENT_ID` already sit, so a documented knob does something for the first time.

The compose default is identical to the one baked into the client image, so nothing changes unless somebody actually sets it — at which point it now works as `.env.example` has always implied.

## Added

`GRYT_IDENTITY_TIERS` on the server service. Without it the setting can't be reached from these compose files at all, which would have made the docs from GRYT-169 wrong for exactly the people following them. Defaults to `account`, so no deployment changes behaviour.

## Verified

`docker compose config` on prod and beta, with `--profile web` so the client service is included and with dummy secrets so interpolation completes:

```
prod.yml: 1 tiers, 1 auth_api, 0 dead-jwks
beta.yml: 1 tiers, 1 auth_api, 0 dead-jwks
```

Tiers resolve on the server, `GRYT_AUTH_API` on the client, dead variable gone. `dev.yml` untouched and still valid.

Note the `.local` variants have no `client` service, so they only get the two server-side changes.

## Not touched

The deployed `.env` files on dev.lan may still name `GRYT_IDENTITY_JWKS_URL`. Harmless — it was doing nothing before and does nothing now — but worth a glance next time you're on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)