### PR TITLE
Say which auth compose project must not be touched

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,10 @@ unrelated projects on **one Docker daemon**. There are no off-box backups.
 
 - Never `docker system prune`, never `compose down -v`, never remove volumes or images
 - Target services by name — `up -d --no-deps docs site`, never a bare `up -d`
-- Never touch the `auth` compose project (Keycloak + Postgres)
+- Never touch the running `auth` compose project (Keycloak + Postgres) **on this box**.
+  That is about the deployment, not the source: editing `packages/auth`, including its
+  compose file, is ordinary work. It goes through review like everything else in a
+  review-required path, and deploying it is Sivert's call — but write it.
 - Check `df -h` before builds; a full disk takes down the auth database
 - `docs.gryt.chat` and `gryt.chat` build from submodule source via
   `ops/internal/docker-compose.yml` — `git pull` in the submodule before rebuilding


### PR DESCRIPTION
Four lines, and your call entirely — it changes a rule rather than any code.

Under **Production server** the list reads:

> - Never touch the `auth` compose project (Keycloak + Postgres)

Everything around it is about `dev.lan` — `docker system prune`, `df -h`, targeting services
by name. But the line names the compose project without saying *where*, and I read it as
covering `packages/auth` in the repo. So I stopped short of writing the compose change
GRYT-180 needed, twice, in two sessions, and wrote the reasoning down both times as though it
were the rule rather than my misreading of it.

This makes it say the running deployment, and says the source is ordinary work — still
review-required, still yours to merge and yours to deploy, but written rather than skipped.

Sits next to the "Review-required is not hands off" paragraph, which already makes the same
point about the listed paths generally. This is the one place that contradicted it.

No behaviour change, and nothing else in the file is touched — the worktree rule from #70 is
intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
