### PR TITLE
Pass the guest-identity env vars to the beta server (GRYT-205)

### DIFF
--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -133,6 +133,23 @@ services:
       # Which identities this server admits. Add "local" to let people
       # join without a Gryt account — see docs.gryt.chat, Server → Identity.
       GRYT_IDENTITY_TIERS: ${GRYT_IDENTITY_TIERS:-account}
+      # Which certificate authority an identity may have been signed by. The
+      # server defaults to this same value; it is here so it can be pointed
+      # somewhere else without a code change.
+      GRYT_TRUSTED_CERT_ISSUERS: ${GRYT_TRUSTED_CERT_ISSUERS:-https://id.gryt.chat}
+      # How many people one invite may admit per hour.
+      GRYT_INVITE_MAX_JOINS_PER_HOUR: ${GRYT_INVITE_MAX_JOINS_PER_HOUR:-60}
+      # How many proxies in front of this server may be believed when they say
+      # who a client is. One, because this deployment sits behind the
+      # Cloudflare tunnel: the edge appends the visitor's address to the right
+      # of x-forwarded-for and nothing else in the path touches the header, so
+      # counting one from the right lands on the real client and anything a
+      # client put in that header stays to the left, where it is ignored.
+      #
+      # Leaving this unset is not neutral. The server falls back to the
+      # connection's own address, which is the tunnel's, so every client shares
+      # one rate-limit bucket and the per-IP invite lockout goes server-wide.
+      GRYT_TRUSTED_PROXY_HOPS: ${GRYT_TRUSTED_PROXY_HOPS:-1}
       DATA_DIR: /data
       # ${MINIO_PORT} here is deliberate and is NOT the same as the plain
       # `minio:9000` the image-worker uses. This service is `network_mode: host`


### PR DESCRIPTION
Found while checking whether the 1.4.0 beta was safe to cut. It is, but this
wants to land alongside it.

## What is wrong

`GRYT-179` (server#45) stopped the server believing a client-supplied
`x-forwarded-for` unless `GRYT_TRUSTED_PROXY_HOPS` says how many proxies in
front of it may be believed. The default is 0, which is correct for a directly
exposed server and wrong for `dev.lan`, which is behind the Cloudflare tunnel.

The part that is easy to miss: `beta.yml` has no `env_file`, so the container
only gets the keys listed under `environment:`. `GRYT_TRUSTED_PROXY_HOPS` was
not one of them, so setting it in `.env` on the box would have done nothing at
all.

Confirmed on the box rather than assumed — every connection to the running
server logs `connected from 192.168.50.182`, the tunnel host's LAN address, and
Vikunja beside it logs the same `remote_ip`. So with 0 hops every client shares
one rate-limit bucket, and `SERVER_INVITE_IP_MAX_RETRIES` (20 bad invites per
IP) becomes a server-wide lockout instead of a per-person one.

## Why one hop

The tunnel ingress maps each hostname straight at `dev.lan:<port>` — no reverse
proxy in between — and Cloudflare appends the visitor's address to the **right**
of `x-forwarded-for` ([cloudflared#1426](https://github.com/cloudflare/cloudflared/issues/1426)).
The server counts from the right, so one hop lands on the real client and
anything a client stuffed into the header stays to the left, where it is
ignored.

One is also the safe direction to be wrong in. Too low degrades to today's
behaviour; too high starts reading the part of the header a client controls.

## What to look at

- The number itself, and the claim that nothing else in the path appends to the
  header.
- The default is `1` in the compose file rather than `0`, so a `up -d` picks it
  up with no `.env` edit. That is right for this file, which only ever describes
  the tunneled beta stack — it would be wrong to copy into a directly exposed
  deployment.

## Deliberately not here

- **prod.yml** — untouched at Sivert's call. Prod still runs the stable image,
  which does not read this variable, so it changes nothing until the stable
  release. It will need the same edit then.
- The other 25 variables the server reads and compose does not pass are tuning
  knobs at working defaults (`EMOJI_QUEUE_*`, `MEDIA_SWEEP_*`, `MAX_MEMBERS`,
  the five `SERVER_INVITE_*` cooldowns). Left alone.
- **`CF-Connecting-IP`** is what Cloudflare recommends over `x-forwarded-for`,
  since the edge sets it and a client cannot forge it. The server has no support
  for it. Noted in GRYT-205 rather than done here.
- The Cloudflare Tunnel deployment doc does not mention this variable, so a
  self-hoster following it gets the shared-bucket behaviour. Also on GRYT-205.

Task: GRYT-205

🤖 Generated with [Claude Code](https://claude.com/claude-code)