### PR TITLE
Make GRYT_TRUSTED_PROXY_HOPS reachable everywhere (GRYT-206)

### DIFF
--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -121,6 +121,23 @@ services:
       # Which identities this server admits. Add "local" to let people
       # join without a Gryt account — see docs.gryt.chat, Server → Identity.
       GRYT_IDENTITY_TIERS: ${GRYT_IDENTITY_TIERS:-account}
+      # Which certificate authority an identity may have been signed by. The
+      # server defaults to this same value; it is here so it can be pointed
+      # somewhere else without a code change.
+      GRYT_TRUSTED_CERT_ISSUERS: ${GRYT_TRUSTED_CERT_ISSUERS:-https://id.gryt.chat}
+      # How many people one invite may admit per hour.
+      GRYT_INVITE_MAX_JOINS_PER_HOUR: ${GRYT_INVITE_MAX_JOINS_PER_HOUR:-60}
+      # How many proxies in front of this server may be believed when they say
+      # who a client is. One, because this deployment sits behind the
+      # Cloudflare tunnel: the edge appends the visitor's address to the right
+      # of x-forwarded-for and nothing else in the path touches the header, so
+      # counting one from the right lands on the real client and anything a
+      # client put in that header stays to the left, where it is ignored.
+      #
+      # Leaving this unset is not neutral. The server falls back to the
+      # connection's own address, which is the tunnel's, so every client shares
+      # one rate-limit bucket and the per-IP invite lockout goes server-wide.
+      GRYT_TRUSTED_PROXY_HOPS: ${GRYT_TRUSTED_PROXY_HOPS:-1}
       DATA_DIR: /data
       # ${MINIO_PORT} here is deliberate and is NOT the same as the plain
       # `minio:9000` the image-worker uses. This service is `network_mode: host`

--- a/ops/deploy/host/.env.example
+++ b/ops/deploy/host/.env.example
@@ -43,6 +43,17 @@ GRYT_AUTH_MODE=required
 GRYT_OIDC_ISSUER=https://auth.gryt.chat/realms/gryt
 GRYT_OIDC_AUDIENCE=gryt-web
 
+# How many proxies in front of this server may be believed when they say who a
+# client is. Zero means the connection's own address is used and
+# x-forwarded-for is ignored, which is right when the server is exposed
+# directly — that header is one any client can set to anything.
+#
+# SET THIS TO 1 IF YOU FOLLOWED THE CLOUDFLARE TUNNEL GUIDE, or put any other
+# reverse proxy in front. Otherwise every client arrives wearing the proxy's
+# address and shares one rate-limit bucket, so one person tripping a limit
+# throttles everybody. Only go above 1 if you have genuinely chained proxies.
+GRYT_TRUSTED_PROXY_HOPS=0
+
 # REQUIRED: session token signing key (generate with: openssl rand -base64 48)
 JWT_SECRET=CHANGEME
 

--- a/ops/helm/gryt/templates/configmaps/configmap.yaml
+++ b/ops/helm/gryt/templates/configmaps/configmap.yaml
@@ -17,6 +17,7 @@ data:
   SERVER_PORT: {{ .Values.server.service.port | quote }}
   NODE_ENV: {{ .Values.server.env.NODE_ENV | quote }}
   SERVER_NAME: {{ .Values.server.env.SERVER_NAME | quote }}
+  GRYT_TRUSTED_PROXY_HOPS: {{ .Values.server.env.GRYT_TRUSTED_PROXY_HOPS | default "0" | quote }}
   GRYT_AUTH_API: {{ .Values.gryt.auth.apiUrl | quote }}
   
   # Nginx Configuration

--- a/ops/helm/gryt/templates/deployments/server-deployment.yaml
+++ b/ops/helm/gryt/templates/deployments/server-deployment.yaml
@@ -56,6 +56,11 @@ spec:
             configMapKeyRef:
               name: {{ include "gryt.fullname" . }}-config
               key: SERVER_NAME
+        - name: GRYT_TRUSTED_PROXY_HOPS
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "gryt.fullname" . }}-config
+              key: GRYT_TRUSTED_PROXY_HOPS
         - name: GRYT_AUTH_API
           valueFrom:
             configMapKeyRef:

--- a/ops/helm/gryt/values.yaml
+++ b/ops/helm/gryt/values.yaml
@@ -105,6 +105,20 @@ server:
     PORT: "5000"
     NODE_ENV: "production"
     SERVER_NAME: "Gryt Production Server"
+    # How many proxies in front of the server may be believed when they say who
+    # a client is. The server counts from the right of x-forwarded-for, because
+    # that is the end infrastructure writes; the left end is whatever the client
+    # claimed.
+    #
+    # One matches this chart's default, which enables an nginx ingress — that
+    # controller appends the client address, and nothing else in the path
+    # touches the header.
+    #
+    # Set this to "0" if you turned the ingress off and publish the Service
+    # directly. At 0 the header is ignored entirely and the connection's own
+    # address is used. Leaving it at 1 with no proxy in front is the one
+    # genuinely unsafe combination: the client's own header would be believed.
+    GRYT_TRUSTED_PROXY_HOPS: "1"
   
   # Secrets (will be base64 encoded)
   secrets:


### PR DESCRIPTION
Follow-up to GRYT-205, which wired this into `beta.yml` only. Three other paths
still landed on 0 hops with nothing telling anyone — every client arrives wearing
the proxy's address, so they share one rate-limit bucket and the per-IP invite
lockout goes server-wide.

## The three

**`ops/helm` was the worst.** The server deployment builds a fixed env list out
of the ConfigMap with no `extraEnv` escape hatch, so the variable could not be
set at all without editing the chart — and a Kubernetes deployment is behind an
ingress controller by definition, so every Helm user had the broken behaviour.

**`ops/deploy/host`** already passes `.env` straight through via `env_file`, so
the value would have reached the container all along. Nothing said it existed, so
nobody set it. Documented in `.env.example`.

**`prod.yml`** gets the same three variables as beta. Nothing changes on the
running prod server — it is on the stable image, which does not read them yet.
This is so the stable release does not repeat the gap the beta had.

## What to look at

**The helm default is `1`, not `0`.** The chart ships `ingress.enabled: true`
with `className: nginx`, so a default install genuinely has exactly one proxy in
front and the controller appends the client address. The unsafe combination is
turning the ingress off and publishing the Service directly while leaving this at
1 — then the client's own header is believed. The comment in `values.yaml` says
so explicitly. Sivert's call: a config someone has changed themselves is on them.

The ConfigMap template defaults to `"0"` if the key is absent from values, so an
existing values file that predates this change fails safe rather than inheriting
1.

## Verification, and its limits

`helm` is not installed here, so **`helm template` was not run**. The wiring is
checked by the key matching across all three files — `values.yaml`, the ConfigMap,
and the deployment's `configMapKeyRef` — not by a render. Worth a
`helm template` before anyone trusts it.

The compose half is better evidenced: `docker compose config` was run against this
exact block on dev.lan and resolved `GRYT_TRUSTED_PROXY_HOPS=1`.

## Still open

The docs half — `deployment/cloudflare-tunnel.mdx` and `guide/configuration.mdx`
never mention the variable, and the tunnel page is what tells people to put a
proxy in front. That is a `packages/docs` change, so it lands as its own PR and
stays on GRYT-206 until it does.

Task: GRYT-206

🤖 Generated with [Claude Code](https://claude.com/claude-code)