### PR TITLE
Retry the release steps that reach the network (GRYT-212)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -948,13 +948,37 @@ jobs:
             ARGS+=(-t "$TAG")
           done
 
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            --cache-from type=registry,ref=${IMAGE}:buildcache \
-            --cache-to type=registry,ref=${IMAGE}:buildcache,mode=max \
-            "${ARGS[@]}" \
-            --push \
-            .
+          # A push that reaches GHCR and is refused is usually the secondary
+          # rate limit rather than anything about this build. That is what took
+          # v1.5.0-beta.1 down: the version tag had already gone up and
+          # latest-beta came back 403, so the image was half published.
+          #
+          # Retried rather than failed, because giving up costs the whole
+          # release and not just the tag — this job failing skips Publish
+          # release, and the release then sits as a draft nobody can install.
+          # Layer cache makes a second attempt cheap.
+          pushed=""
+          for attempt in 1 2 3 4 5; do
+            if docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --cache-from type=registry,ref=${IMAGE}:buildcache \
+              --cache-to type=registry,ref=${IMAGE}:buildcache,mode=max \
+              "${ARGS[@]}" \
+              --push \
+              .
+            then
+              pushed="yes"
+              break
+            fi
+
+            echo "Docker build/push failed (attempt ${attempt}/5) — retrying."
+            sleep $(( attempt * 20 ))
+          done
+
+          if [[ -z "$pushed" ]]; then
+            echo "Could not build and push the image after 5 attempts." >&2
+            exit 1
+          fi
 
       - name: Install Snapcraft
         if: runner.os == 'Linux'
@@ -987,14 +1011,38 @@ jobs:
             exit 1
           fi
 
-          npx electron-builder \
-            $TARGETS \
-            --publish always \
-            -c.extraMetadata.version="$VERSION" \
-            -c.publish.provider=github \
-            -c.publish.owner="$OWNER" \
-            -c.publish.repo="$REPO" \
-            -c.publish.releaseType="$RELEASE_TYPE"
+          # electron-builder fetches the Electron binary on first use, and
+          # app-builder asks for it through DownloadNoRetry — so a connection
+          # that drops mid-download fails the build outright with no second
+          # attempt. That is what took v1.5.2-beta.1 down on Windows:
+          # `Get "…/electron-v40.6.1-win32-x64.zip": EOF`.
+          #
+          # Three attempts rather than five. A genuine packaging failure repeats
+          # the whole build each time, and the download failures seen so far all
+          # land in the first minute.
+          published=""
+          for attempt in 1 2 3; do
+            if npx electron-builder \
+              $TARGETS \
+              --publish always \
+              -c.extraMetadata.version="$VERSION" \
+              -c.publish.provider=github \
+              -c.publish.owner="$OWNER" \
+              -c.publish.repo="$REPO" \
+              -c.publish.releaseType="$RELEASE_TYPE"
+            then
+              published="yes"
+              break
+            fi
+
+            echo "electron-builder failed (attempt ${attempt}/3) — retrying."
+            sleep $(( attempt * 20 ))
+          done
+
+          if [[ -z "$published" ]]; then
+            echo "Could not package and publish after 3 attempts." >&2
+            exit 1
+          fi
 
       - name: Package macOS app
         if: runner.os == 'macOS'

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -468,12 +468,31 @@ jobs:
             ARGS+=(-t "$TAG_VALUE")
           done
 
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            --build-arg VERSION="$VERSION" \
-            "${ARGS[@]}" \
-            --push \
-            .
+          # Same retry as the client workflow, for the same reason: a refused
+          # push is usually GitHub's secondary rate limit, and this job failing
+          # costs the whole release rather than the one tag that was refused.
+          # See v1.5.0-beta.1, where the client image went up half published.
+          pushed=""
+          for attempt in 1 2 3 4 5; do
+            if docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --build-arg VERSION="$VERSION" \
+              "${ARGS[@]}" \
+              --push \
+              .
+            then
+              pushed="yes"
+              break
+            fi
+
+            echo "Docker build/push failed (attempt ${attempt}/5) — retrying."
+            sleep $(( attempt * 20 ))
+          done
+
+          if [[ -z "$pushed" ]]; then
+            echo "Could not build and push the image after 5 attempts." >&2
+            exit 1
+          fi
 
       - name: Build Windows self-hosted server bundle
         if: github.event.inputs.build_windows == 'true'


### PR DESCRIPTION
Two releases in a row today were taken down by a transient fetch, and both times
the knock-on cost far more than the failure itself.

| | v1.5.0-beta.1 | v1.5.2-beta.1 |
|---|---|---|
| What failed | GHCR secondary rate limit on the second of four tags | Connection dropped fetching the Electron zip |
| What it cost | Linux build missing, release stuck as a draft, image half published | Windows build and `latest.yml` missing, release stuck as a draft |

Re-running the failed job fixed both, which is the argument for retrying: nothing
was wrong with the build either time.

```
⨯ Get "https://github.com/electron/electron/releases/download/v40.6.1/electron-v40.6.1-win32-x64.zip": EOF
```

app-builder requests that through `DownloadNoRetry`, so there is no second attempt
inside electron-builder to rely on.

## What's here

The attempt loop already used for the release commit push in this file, wrapped
around the two steps that reach the network: `docker buildx build --push` in both
release workflows, and the `electron-builder` invocation in the client one.

**Five attempts for docker, three for electron-builder.** The layer cache makes a
docker retry cheap. A retried electron-builder repeats the whole package step, so
a genuine build failure would burn three full builds before failing — the download
failures seen so far all land inside the first minute, so three is the compromise.

## What to look at

**`electron-builder --publish always` may not be cleanly idempotent.** If an
attempt dies *after* uploading some assets, the retry re-uploads over a release
that already has them. I could not test that path, and it is the one way this
change could make things worse rather than better: today's failure happened before
any upload, so the retry would have been clean, but a later-stage failure is
untested. If it turns out to conflict, the retry needs to delete the partial asset
first.

**Deliberately not bundled:** `Publish release` depends on every matrix leg, so one
platform's bad luck still hides a finished release from the other two. Letting it
publish on partial success sounds obvious but is worse than it looks — a release
missing a platform's channel yml makes clients on that platform 404, which
`isReleaseNotReadyYet` turns into a silent "up to date". They would quietly stop
being offered updates instead of being told anything. That needs a real decision,
and it stays on GRYT-212.

## Verified

Both workflows parse as YAML, and the retry blocks pass `bash -n`. **Not executed** —
the only way to exercise these is a real release, and the failure paths need a real
network failure. The retry logic is verified by inspection against the existing
loop it copies.

Task: GRYT-212

🤖 Generated with [Claude Code](https://claude.com/claude-code)