### PR TITLE
Take the Snap Store off the release's critical path (GRYT-258)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -980,20 +980,12 @@ jobs:
             exit 1
           fi
 
-      - name: Install Snapcraft
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo snap install snapcraft --classic
-
       - name: Package and publish Electron app
         if: runner.os != 'macOS'
         working-directory: packages/client
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
           OWNER: ${{ env.OWNER }}
           REPO: ${{ env.REPO }}
           CHANNEL: ${{ env.CHANNEL }}
@@ -1002,6 +994,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # -c.snap.publish=github below is what keeps the snap out of the
+          # store from here. electron-builder adds the Snap Store publisher on
+          # its own when it finds SNAPCRAFT_STORE_CREDENTIALS, and that upload
+          # blocks on the store's review queue — twenty-five minutes on v1.5.8,
+          # with publish-release waiting behind it, so a Windows download was
+          # held up by a Linux store scan. The .snap is attached to the release
+          # like everything else now, and the store push is its own job at the
+          # end.
           if [[ "$RUNNER_OS" == "Linux" ]]; then
             TARGETS="--linux AppImage deb snap"
           elif [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -1029,7 +1029,8 @@ jobs:
               -c.publish.provider=github \
               -c.publish.owner="$OWNER" \
               -c.publish.repo="$REPO" \
-              -c.publish.releaseType="$RELEASE_TYPE"
+              -c.publish.releaseType="$RELEASE_TYPE" \
+              -c.snap.publish=github
             then
               published="yes"
               break
@@ -1234,3 +1235,68 @@ jobs:
             -H "Content-Type: application/json" \
             -d "$PAYLOAD" \
             "$WEBHOOK_URL"
+
+  # After the release is out, not before it. The Snap Store scans an upload
+  # before it accepts it — twenty-five minutes on v1.5.8 — and while that ran
+  # inside the Linux build leg, publish-release sat behind it and the whole
+  # release stayed a draft. Nothing here is on the critical path: the .snap is
+  # already attached to the release, so this only decides whether the store gets
+  # the same file, and it can take as long as it likes.
+  publish-snap:
+    name: Publish snap to the Snap Store
+    needs: [prepare-release, publish-release]
+    runs-on: ubuntu-latest
+    # Long enough for a slow review queue, short enough that a wedged upload
+    # does not sit there for six hours.
+    timeout-minutes: 90
+
+    env:
+      OWNER: Gryt-chat
+      REPO: gryt
+      VERSION: ${{ needs.prepare-release.outputs.version }}
+      CHANNEL: ${{ needs.prepare-release.outputs.channel }}
+
+    steps:
+      - name: Install Snapcraft
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo snap install snapcraft --classic
+
+      - name: Download the snap from the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh release download "v$VERSION" \
+            --repo "$OWNER/$REPO" \
+            --pattern '*.snap' \
+            --dir .
+
+          ls -la ./*.snap
+
+      - name: Upload to the Snap Store
+        shell: bash
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SNAPCRAFT_STORE_CREDENTIALS:-}" ]]; then
+            echo "SNAPCRAFT_STORE_CREDENTIALS is not set, skipping the store."
+            exit 0
+          fi
+
+          # latest is this workflow's word for stable; the store's own word for
+          # it is stable, and beta is beta in both.
+          if [[ "$CHANNEL" == "beta" ]]; then
+            TRACK="beta"
+          else
+            TRACK="stable"
+          fi
+
+          SNAP="$(ls ./*.snap | head -n 1)"
+          echo "Uploading $SNAP to $TRACK."
+          snapcraft upload --release="$TRACK" "$SNAP"


### PR DESCRIPTION
v1.5.8 took thirty minutes. Twenty-five of them were the Linux leg sitting on `Status: processing` while the Snap Store scanned the upload — and it reads exactly like a hang, because the last useful line is `Uploading... (<---)` and then nothing moves for half an hour.

**Nothing was broken.** It finished, and the release published with every asset. AppImage built and uploaded fine; it was never the problem.

## What was wrong

electron-builder adds the Snap Store publisher on its own when it finds `SNAPCRAFT_STORE_CREDENTIALS` in the environment. That put the store upload inside the build job, and `publish-release` waits on that job before it takes the release out of draft — so a store review queue was holding up a Windows download.

## What changed

- The credential leaves the build job.
- `-c.snap.publish=github` attaches the `.snap` to the release like every other artefact. **It was never on the release before** — it only ever went to the store, so this is a new download for anyone who wants it.
- A new `publish-snap` job, after `publish-release`, downloads it from the release and pushes it to the store. Nothing waits on that job.

`latest` maps to the store's `stable`, `beta` to `beta`. Ninety minutes before the job gives up, and no credential means it skips rather than fails.

## Worth a look

- **The release is now considered done before the store has it.** If the store rejects an upload, the GitHub release is already public. That is the trade I think you want — the store is one channel of four and the slowest by an order of magnitude — but it is a change in what "released" means.
- The verify step's asset list is untouched, so a snap that fails to build will not block a release. Say the word and I will add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)