### PR TITLE
Give the snap publisher the repo it uploads to (GRYT-263)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -994,14 +994,22 @@ jobs:
         run: |
           set -euo pipefail
 
-          # -c.snap.publish=github below is what keeps the snap out of the
-          # store from here. electron-builder adds the Snap Store publisher on
-          # its own when it finds SNAPCRAFT_STORE_CREDENTIALS, and that upload
-          # blocks on the store's review queue — twenty-five minutes on v1.5.8,
-          # with publish-release waiting behind it, so a Windows download was
-          # held up by a Linux store scan. The .snap is attached to the release
-          # like everything else now, and the store push is its own job at the
-          # end.
+          # The -c.snap.publish.* overrides below are what keeps the snap out
+          # of the store from here. electron-builder adds the Snap Store
+          # publisher on its own when it finds SNAPCRAFT_STORE_CREDENTIALS, and
+          # that upload blocks on the store's review queue — twenty-five
+          # minutes on v1.5.8, with publish-release waiting behind it, so a
+          # Windows download was held up by a Linux store scan. The .snap is
+          # attached to the release like everything else now, and the store
+          # push is its own job at the end.
+          #
+          # Spelled out per key rather than as `-c.snap.publish=github`. The
+          # shorthand replaces the publish config for this target instead of
+          # extending it, so owner and repo went missing and electron-builder
+          # fell back to inferring them from package.json — it tried to create
+          # the release in Gryt-chat/client, where this token cannot write, and
+          # got a 403 that no retry was ever going to clear. That is what left
+          # v1.5.9 a draft with no .snap on it.
           if [[ "$RUNNER_OS" == "Linux" ]]; then
             TARGETS="--linux AppImage deb snap"
           elif [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -1030,7 +1038,10 @@ jobs:
               -c.publish.owner="$OWNER" \
               -c.publish.repo="$REPO" \
               -c.publish.releaseType="$RELEASE_TYPE" \
-              -c.snap.publish=github
+              -c.snap.publish.provider=github \
+              -c.snap.publish.owner="$OWNER" \
+              -c.snap.publish.repo="$REPO" \
+              -c.snap.publish.releaseType="$RELEASE_TYPE"
             then
               published="yes"
               break


### PR DESCRIPTION
This is why v1.5.9 is still a draft with no `.snap` on it.

## What happened

From the Linux job log, two lines apart:

```
• publishing  publisher=Github (owner: Gryt-chat, project: gryt,   version: 1.5.9)   ← AppImage, fine
• publishing  publisher=Github (owner: Gryt-chat, project: client, version: 1.5.9)   ← snap
• creating GitHub release  reason=release doesn't exist tag=v1.5.9
⨯ 403 Forbidden
  method: post url: https://api.github.com/repos/Gryt-chat/client/releases
  {"message":"Resource not accessible by integration"}
```

`-c.snap.publish=github` sets the snap target's publish config to the bare string, which **replaces** the inherited object rather than extending it. `publish.owner` and `publish.repo` never reach the snap's publisher, so electron-builder infers the repo from `package.json` — `Gryt-chat/client` — and this workflow's token is scoped to `Gryt-chat/gryt`. It then tried to *create* a release there, which is the 403.

Everything else in that job published correctly, which is why the deb and AppImage are on the release and the snap is not.

The fix is to spell the four keys out under `-c.snap.publish.*`, matching what the other targets already get.

## What to look at

- **That `-c.snap.publish.provider=github` still suppresses the Snap Store publisher.** That is the whole reason the override exists — electron-builder adds the store publisher on its own when `SNAPCRAFT_STORE_CREDENTIALS` is set, and v1.5.8 spent twenty-five minutes in the store queue with `publish-release` waiting behind it. I am reasonably confident an explicit publish config still replaces the inferred one, but this is the part I would want to see in a real run rather than reason about.
- **This has never worked.** Handoff section 8 called the `.snap` "the one part of this that has never run" — so the next dispatch is the first time the whole path executes, and the store job after it is still unproven.
- **The retry loop.** GRYT-212 retried a permanent 403 three times, ~15 minutes. Whether the loop should skip non-transient statuses is noted on GRYT-263 rather than changed here.

Verifying this means dispatching another release, which is yours to decide — v1.5.9 is already burned and sitting as a draft.

Vikunja: GRYT-263

🤖 Generated with [Claude Code](https://claude.com/claude-code)