### PR TITLE
Say when ICE_ADVERTISE_IP can be left empty in words that mean something

### DIFF
--- a/ops/deploy/compose/.env.example
+++ b/ops/deploy/compose/.env.example
@@ -27,13 +27,23 @@ SERVER_DESCRIPTION=A Gryt voice chat server
 #  cannot work out what address the outside world reaches it on, so you tell it.
 # ═════════════════════════════════════════════════════════════════════════════
 
-# The address to put in ICE candidates. Your public IP if people join over the
-# internet, your LAN IP if they are in the room. Both, comma-separated, if some
-# of each — the client measures every candidate and uses whichever answers
-# fastest, so listing more is not a cost.
-#   Public IP:  curl -4 ifconfig.me
-#   LAN IP:     hostname -I | awk '{print $1}'
-# Leave empty only if the SFU has a direct, unmapped path to the internet.
+# The address people reach your server on, which is the address voice traffic
+# will be told to use. Set it.
+#
+#   Joining over the internet   your public IP    curl -4 ifconfig.me
+#   Joining from the same room  your LAN IP       hostname -I | awk '{print $1}'
+#   Some of each                both, separated by a comma
+#
+# Listing two costs nothing: the client tries every address it is given and
+# keeps whichever answers fastest.
+#
+# Why it has to be set at all: the SFU runs in a container and can only see the
+# container's own address, which is a private one nobody outside can reach. It
+# will happily hand that address out, and everyone will fail to connect to it.
+#
+# Empty is right in one case only — the machine holds the public address on its
+# own network interface, with no router or Docker port mapping in between. Bare
+# metal, or a VPS using host networking.
 ICE_ADVERTISE_IP=
 
 # Where browsers and clients open the SFU WebSocket. Same addresses as above,


### PR DESCRIPTION
Follow-up to #80. That line was bad and also wrong.

> Leave empty only if the SFU has a direct, unmapped path to the internet.

Nobody can check that. "Direct, unmapped path" isn't a thing you can look at your setup and answer.

It's also borrowed from the wrong place: `DISABLE_STUN` further down says *"only disable when the SFU has a direct, port-preserving path to the internet"*, which is a real caveat about STUN and port preservation. I pasted a mangled version of it onto a setting it doesn't describe.

Now it answers the two questions somebody actually has:

**Which address?** Public IP for internet, LAN IP for the same room, both comma-separated for a mix, with the command to find each. Plus the note that listing two costs nothing, since the client keeps whichever answers fastest.

**Why doesn't the server already know?** Because the SFU sees its container's own address, which is private, and will hand it out to everyone. That's the sentence that makes the setting make sense, and it was missing.

So the empty case becomes checkable: the machine holds the public address on its own interface with no router or Docker mapping in between. Bare metal, or a VPS on host networking.

Verified with `docker compose config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)