### PR TITLE
fix: pass GRYT_SERVER_ENABLED through Compose

### DIFF
--- a/ops/deploy/compose/.env.example
+++ b/ops/deploy/compose/.env.example
@@ -58,15 +58,13 @@ CORS_ORIGIN=http://127.0.0.1:15738,https://app.gryt.chat,https://beta.gryt.chat
 # until somebody clears their browser data.
 GRYT_IDENTITY_TIERS=account
 
-# Whether this server accepts joins at all.
-#   required — normal operation, the default
-#   disabled — every join is rejected, for taking a server out of service
-#              without stopping the container
-#
-# Despite the name, this decides nothing about accounts. Leave it alone unless
-# you are deliberately closing the server. What decides whether somebody needs
-# an account is GRYT_IDENTITY_TIERS above, and the two do not interact.
-GRYT_AUTH_MODE=required
+# Whether this server accepts joins at all. This is a maintenance switch and
+# does not decide whether somebody needs an account.
+#   true  normal operation, the default
+#   false reject every join without stopping the container
+# Also accepts on/off, yes/no, and 1/0. An empty value uses the default. An
+# unrecognized value rejects joins and reports the bad setting.
+GRYT_SERVER_ENABLED=true
 
 
 # ═════════════════════════════════════════════════════════════════════════════

--- a/ops/deploy/compose/beta.local.yml
+++ b/ops/deploy/compose/beta.local.yml
@@ -52,7 +52,7 @@ services:
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       SFU_UDP_PORT_MIN: ${SFU_UDP_MIN:-10020}
       SFU_UDP_PORT_MAX: ${SFU_UDP_MAX:-10039}
-      GRYT_AUTH_MODE: ${GRYT_AUTH_MODE:-required}
+      GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}
       # Which identities this server admits. Add "local" to let people

--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -127,7 +127,7 @@ services:
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       SFU_UDP_PORT_MIN: ${SFU_UDP_MIN:-10020}
       SFU_UDP_PORT_MAX: ${SFU_UDP_MAX:-10039}
-      GRYT_AUTH_MODE: ${GRYT_AUTH_MODE:-required}
+      GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}
       # Which identities this server admits. Add "local" to let people

--- a/ops/deploy/compose/dev.yml
+++ b/ops/deploy/compose/dev.yml
@@ -44,7 +44,7 @@ services:
       - STUN_SERVERS=stun:stun.l.google.com:19302
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3777,http://127.0.0.1:15738,https://app.gryt.chat}
       - SERVER_PASSWORD=changeme-1
-      - GRYT_AUTH_MODE=required
+      - GRYT_SERVER_ENABLED=true
       - GRYT_OIDC_ISSUER=https://auth.gryt.chat/realms/gryt
       - GRYT_OIDC_AUDIENCE=gryt-web
       - NODE_ENV=development
@@ -91,7 +91,7 @@ services:
       - STUN_SERVERS=stun:stun.l.google.com:19302
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3777,http://127.0.0.1:15738,https://app.gryt.chat}
       - SERVER_PASSWORD=changeme-2
-      - GRYT_AUTH_MODE=required
+      - GRYT_SERVER_ENABLED=true
       - GRYT_OIDC_ISSUER=https://auth.gryt.chat/realms/gryt
       - GRYT_OIDC_AUDIENCE=gryt-web
       - NODE_ENV=development

--- a/ops/deploy/compose/prod.local.yml
+++ b/ops/deploy/compose/prod.local.yml
@@ -43,7 +43,7 @@ services:
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       SFU_UDP_PORT_MIN: ${SFU_UDP_MIN:-}
       SFU_UDP_PORT_MAX: ${SFU_UDP_MAX:-}
-      GRYT_AUTH_MODE: ${GRYT_AUTH_MODE:-required}
+      GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}
       # Which identities this server admits. Add "local" to let people

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -115,7 +115,7 @@ services:
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       SFU_UDP_PORT_MIN: ${SFU_UDP_MIN:-}
       SFU_UDP_PORT_MAX: ${SFU_UDP_MAX:-}
-      GRYT_AUTH_MODE: ${GRYT_AUTH_MODE:-required}
+      GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}
       # Which identities this server admits. Add "local" to let people
@@ -267,7 +267,7 @@ services:
   #     SFU_WS_HOST: ws://sfu:${SFU_PORT:-5005}
   #     SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
   #     STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
-  #     GRYT_AUTH_MODE: ${GRYT_AUTH_MODE:-required}
+  #     GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
   #     GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
   #     GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}
   #     GRYT_IDENTITY_TIERS: ${GRYT_IDENTITY_TIERS:-account}


### PR DESCRIPTION
## What changed

- rename the maintenance switch in `ops/deploy/compose/.env.example`
- pass `GRYT_SERVER_ENABLED` through production, beta, local-overlay, and development Compose files
- fall back to `GRYT_AUTH_MODE` when only the old variable is set
- let `GRYT_SERVER_ENABLED` win when both variables are present

## Why

Server PR #49 reads the new variable, but the Compose files still injected only `GRYT_AUTH_MODE`. Setting `GRYT_SERVER_ENABLED=false` in the example would therefore have had no effect inside the container.

## Checks

- `docker compose config` for production and beta
- `docker compose config` with both local overlays
- verified old-only `GRYT_AUTH_MODE=disabled` resolves to `GRYT_SERVER_ENABLED=disabled`
- verified an explicitly set new value wins over the old value
- `git diff --check`

Task: GRYT-281
Server change: https://github.com/Gryt-chat/server/pull/49
Documentation: https://github.com/Gryt-chat/docs/pull/26