### PR TITLE
Publish snaps on stable only (GRYT-283)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1257,6 +1257,18 @@ jobs:
     name: Publish snap to the Snap Store
     needs: [prepare-release, publish-release]
     runs-on: ubuntu-latest
+    # Stable only. Every upload waits on the store's automated review — 25
+    # minutes on v1.5.8, 77 on v1.6.2-beta.1 — and betas ship often, so the
+    # store review queue ended up shadowing the whole beta cadence. Linux
+    # testers already get betas as the AppImage and .deb attached to the GitHub
+    # release, so the snap beta channel was a second path to the same build at
+    # the cost of an hour per release.
+    #
+    # `latest/beta` is closed in the store to match. Leaving it open but unfed
+    # would have served whatever was last pushed there forever, and somebody on
+    # `snap refresh --beta` would sit on a fossil without knowing. Closed, it
+    # falls through to `latest/stable`.
+    if: needs.prepare-release.outputs.channel != 'beta'
     # Long enough for a slow review queue, short enough that a wedged upload
     # does not sit there for six hours.
     timeout-minutes: 90
@@ -1265,7 +1277,6 @@ jobs:
       OWNER: Gryt-chat
       REPO: gryt
       VERSION: ${{ needs.prepare-release.outputs.version }}
-      CHANNEL: ${{ needs.prepare-release.outputs.channel }}
 
     steps:
       - name: Install Snapcraft
@@ -1300,14 +1311,9 @@ jobs:
             exit 0
           fi
 
-          # latest is this workflow's word for stable; the store's own word for
-          # it is stable, and beta is beta in both.
-          if [[ "$CHANNEL" == "beta" ]]; then
-            TRACK="beta"
-          else
-            TRACK="stable"
-          fi
-
+          # Always stable: the job does not run on beta at all, see the `if` on
+          # the job above. This used to pick a track from the channel, which
+          # read as though beta were still an option long after it was not.
           SNAP="$(ls ./*.snap | head -n 1)"
-          echo "Uploading $SNAP to $TRACK."
-          snapcraft upload --release="$TRACK" "$SNAP"
+          echo "Uploading $SNAP to stable."
+          snapcraft upload --release=stable "$SNAP"


### PR DESCRIPTION
Every snap upload waits on the Snap Store's automated review: **25 minutes** on v1.5.8, **77 minutes** on v1.6.2-beta.1. Betas ship several times a day, so the store's queue was shadowing the entire beta cadence, and every release run read as "in progress" for over an hour after everything that mattered had finished sixteen minutes in.

That cost us real time twice today — both of us went looking for a stuck build that wasn't stuck.

## It was also quietly fragile

v1.6.2-beta.1 **uploaded fine**. The revision is in the store, sitting unreleased with `CHANNELS: -`. The run was then cancelled before the channel assignment completed, so `latest/beta` silently stayed on 1.6.1-beta.1 while GitHub had the newer build. Nothing failed loudly; the store just quietly fell a release behind.

## What changed

`publish-snap` now runs only when the channel isn't beta. Linux testers already get betas from the AppImage and `.deb` attached to the GitHub release, so the snap beta channel was a second path to the same file at an hour's cost per release.

**`latest/beta` is closed in the store to match**, which is the part that matters. Left open and unfed, it would serve 1.6.1-beta.1 forever and anyone on `snap refresh --beta` would sit on a fossil without knowing. Closed, it falls through to `latest/stable`.

Also dropped the track-picking (`if beta then beta else stable`) and the now-unused `CHANNEL` env. It can no longer take the beta branch, and unreachable code that reads as live is exactly what made this confusing to begin with.

## Not fixed here

A **stable** release still holds its run open for the length of a store review. Moving the job out of the release run entirely needs the publish step to dispatch it explicitly with `RELEASE_PAT`, because GitHub deliberately won't start a workflow from a release published with `GITHUB_TOKEN` — the obvious `on: release: published` shape would silently never fire. Left on [GRYT-283](https://tasks.sivert.io/tasks/283).

Worth knowing separately: revision 66 in the store carries a warning marker neither of us has read yet. If that's a review flag rather than a lint note, it'll hit the next **stable** push too, and this change means you'd meet it during a stable release rather than a beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)