### PR TITLE
Add Gryt CLI submodule

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -35,6 +35,7 @@ on:
           - site
           - auth
           - ui
+          - cli
 
 permissions:
   contents: write
@@ -88,7 +89,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui"
+          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli"
 
           # Clone straight from the URL rather than `git submodule update`,
           # which insists on the recorded gitlink and so fails on a broken one.
@@ -181,6 +182,10 @@ jobs:
             update_submodule "packages/ui" "$DEFAULT_SUBMODULE_BRANCH"
           fi
 
+          if [[ "$SELECTED" == "all" || "$SELECTED" == "cli" ]]; then
+            update_submodule "packages/cli" "$DEFAULT_SUBMODULE_BRANCH"
+          fi
+
       - name: Commit changes
         shell: bash
         run: |
@@ -211,7 +216,7 @@ jobs:
             git fetch origin "$TARGET_BRANCH"
             git reset --hard "origin/$TARGET_BRANCH"
 
-            for path in packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui; do
+            for path in packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli; do
               [[ -d "$path" ]] || continue
               git -C "$path" fetch origin main
               git -C "$path" checkout -B main origin/main

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,7 @@
 	path = packages/ui
 	url = https://github.com/Gryt-chat/ui.git
 	branch = main
+[submodule "cli"]
+	path = packages/cli
+	url = https://github.com/Gryt-chat/cli.git
+	branch = main


### PR DESCRIPTION
## Summary
- add the public Gryt-chat/cli repository at packages/cli
- pin the initial merged TUI implementation
- include CLI in automatic, scheduled, and manual submodule updates

## Validation
- Go tests pass
- Go vet passes
- CLI builds successfully
- update-submodules workflow parses as valid YAML
- git diff checks pass