### PR TITLE
Pull the web client that was already released (GRYT-291)

### DIFF
--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -72,3 +72,49 @@ All four should be **proxied** and routed through the same Cloudflare Tunnel.
 ## Downloads folder
 
 Static files placed in `ops/internal/downloads/` are served at `/downloads/*` on `gryt.chat`.
+
+## Keeping the hosted web clients current
+
+`app.gryt.chat` and `beta.gryt.chat` are not built from source like the sites above. They
+are the `ghcr.io/gryt-chat/client` image that `Release Client` pushes on every release,
+running as the `client` service of the `gryt-prod` and `gryt-beta` stacks in
+`ops/deploy/compose/`.
+
+Building and pushing that image was automated. Pulling it was not, so the web client only
+moved when somebody remembered. On 2026-08-17 `app.gryt.chat` was serving **1.5.6** against
+a desktop app on **1.6.15-beta.1** — ten releases, including the whole seed-derived guest
+identity feature set, which read from the outside as "that only works on desktop"
+(GRYT-291).
+
+[`refresh-web-client.sh`](refresh-web-client.sh) closes that. It pulls `latest` for prod and
+`latest-beta` for beta, and recreates the container only when the image id actually moved:
+
+```bash
+ops/internal/refresh-web-client.sh
+```
+
+It touches nothing but the `client` service — `--no-deps`, one service named, never a bare
+`up -d` — so the server, the SFU, the image worker and MinIO are never in its way. It
+refuses to run with less than 10GB free, since the auth database is on the same disk.
+
+A release-triggered deploy would be tighter, and is not what this is: `dev.lan` sits behind
+the Cloudflare tunnel with no self-hosted runner, so a job in `Release Client` would need
+inbound SSH and secrets before it could do anything at all. A timer needs neither.
+
+Installed as a systemd timer, firing every ten minutes:
+
+```bash
+sudo cp ops/internal/systemd/gryt-web-client-refresh.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now gryt-web-client-refresh.timer
+```
+
+Check on it with `systemctl list-timers gryt-web-client-refresh` and
+`journalctl -u gryt-web-client-refresh -n 50`.
+
+Superseded images are left dangling rather than removed — roughly 30MB a release. Cleaning
+them up stays something to do by hand, because the disk being freed is the one Keycloak
+lives on.
+
+The rest of the `gryt-prod` stack — server, SFU, image worker — is deliberately **not** in
+scope. Those carry data, and rolling them forward is a decision rather than a cron job.

--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -95,19 +95,49 @@ ops/internal/refresh-web-client.sh
 
 It touches nothing but the `client` service — `--no-deps`, one service named, never a bare
 `up -d` — so the server, the SFU, the image worker and MinIO are never in its way. It
-refuses to run with less than 10GB free, since the auth database is on the same disk.
+refuses to run with less than 10GB free, since the auth database is on the same disk. It
+only refreshes a container that is already running, and will not bring a missing one up.
 
-A release-triggered deploy would be tighter, and is not what this is: `dev.lan` sits behind
+Nothing in it is specific to one machine, and there are no paths to configure. Each stack's
+compose files, the order they were merged in and the env file they were read with all come
+off the running container's own labels. That is not a shortcut — the overlay list has to
+match what the stack came up with exactly, because compose merges left to right and a
+different list is a different config, which would make `up` recreate the container every
+ten minutes forever. Some of those overlays are untracked and exist only on the host, so
+no list committed here could be right.
+
+Three environment variables, none of them required:
+
+| | |
+|---|---|
+| `GRYT_STACKS` | stacks to refresh, space separated. Default `prod beta`; each `<s>` means the container `gryt-<s>-client` |
+| `GRYT_SERVICE` | the compose service, if it is not called `client` |
+| `GRYT_MIN_FREE_GB` | refuse to pull below this much free disk. Default `10` |
+
+A release-triggered deploy would be tighter, and is not what this is: the box sits behind
 the Cloudflare tunnel with no self-hosted runner, so a job in `Release Client` would need
 inbound SSH and secrets before it could do anything at all. A timer needs neither.
 
-Installed as a systemd timer, firing every ten minutes:
+### Installing the timer
+
+Symlink rather than copy, so `git pull` updates the script and nothing has to be installed
+twice. `ExecStart` needs a literal absolute path — systemd does not expand variables in the
+executable itself — so the symlink is what keeps the unit free of anybody's home directory.
 
 ```bash
+sudo ln -sfn "$PWD/ops/internal/refresh-web-client.sh" /usr/local/bin/gryt-web-client-refresh
 sudo cp ops/internal/systemd/gryt-web-client-refresh.{service,timer} /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now gryt-web-client-refresh.timer
 ```
+
+It fires every ten minutes and runs as root, which is the usual arrangement for a system
+unit talking to the Docker socket. To run as somebody else, drop in an override with
+`User=` and `SupplementaryGroups=docker` rather than editing the shipped unit.
+
+Anything that differs per machine goes in `/etc/default/gryt-web-client-refresh` — see
+[`gryt-web-client-refresh.env.example`](systemd/gryt-web-client-refresh.env.example). On a
+normal checkout none of it is needed.
 
 Check on it with `systemctl list-timers gryt-web-client-refresh` and
 `journalctl -u gryt-web-client-refresh -n 50`.

--- a/ops/internal/refresh-web-client.sh
+++ b/ops/internal/refresh-web-client.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Keep app.gryt.chat and beta.gryt.chat on the image the last release published.
+#
+# Both are nginx containers serving a build that `Release Client` already pushed
+# to GHCR. Nothing ever pulled it. On 2026-08-17 app.gryt.chat was serving 1.5.6
+# while the desktop app was on 1.6.15-beta.1, so every identity feature from
+# 1.6.0 — the derived seed, the 24-word backup, keychain sealing — looked like it
+# was desktop-only when it had simply never been deployed (GRYT-291).
+#
+# Run from the systemd timer beside this script. Safe to run by hand.
+#
+# Deliberately narrow. It pulls one service on two stacks and recreates it only
+# when the image actually moved. It does not touch the server, the SFU, the
+# image worker, MinIO or anything else on this box — those carry data, and a
+# roll-forward on them is a decision rather than a cron job.
+
+set -euo pipefail
+
+COMPOSE_DIR="${GRYT_COMPOSE_DIR:-/home/sivert/gryt/ops/deploy/compose}"
+MIN_FREE_GB="${GRYT_MIN_FREE_GB:-10}"
+
+log() { printf '%s  %s\n' "$(date -Is)" "$*"; }
+
+# The auth database lives on the same disk as everything else here, so a pull
+# that fills it takes Keycloak down with it. Cheap to check, and the failure it
+# prevents is not cheap at all.
+free_gb=$(df -BG --output=avail "$COMPOSE_DIR" | tail -1 | tr -dc '0-9')
+if (( free_gb < MIN_FREE_GB )); then
+  log "FATAL only ${free_gb}G free on $COMPOSE_DIR, want ${MIN_FREE_GB}G — refusing to pull"
+  exit 1
+fi
+
+# Which overlay files each stack was brought up with, in order. Order matters:
+# compose merges left to right, so a different order is a different config, and
+# `up` would then recreate the container to match something nobody asked for.
+#
+# The `.local` and `pp` overlays are untracked and live only on this box. A
+# missing one is normal and is skipped rather than being an error.
+stack_files() {
+  case "$1" in
+    prod) printf '%s\n' prod.yml prod.local.yml pp.yml ;;
+    beta) printf '%s\n' beta.yml beta.local.yml ;;
+    *)    log "FATAL unknown stack '$1'"; exit 1 ;;
+  esac
+}
+
+refresh() {
+  local stack="$1"
+  local container="gryt-${stack}-client"
+  local env_file="$COMPOSE_DIR/.env.${stack}"
+  local -a args=()
+  local f
+
+  if [[ ! -f "$env_file" ]]; then
+    log "[$stack] no $env_file — skipped"
+    return 0
+  fi
+  args+=(--env-file "$env_file")
+
+  while IFS= read -r f; do
+    [[ -f "$COMPOSE_DIR/$f" ]] && args+=(-f "$COMPOSE_DIR/$f")
+  done < <(stack_files "$stack")
+
+  # The base file is the one that names the project and defines the service.
+  # Without it the rest describe nothing, and compose would happily invent a
+  # project from the directory name.
+  if [[ " ${args[*]} " != *" $COMPOSE_DIR/${stack}.yml "* ]]; then
+    log "[$stack] no ${stack}.yml in $COMPOSE_DIR — skipped"
+    return 0
+  fi
+
+  local before after
+  before=$(docker inspect --format '{{.Image}}' "$container" 2>/dev/null || echo none)
+
+  # `--progress quiet` on both calls, because this runs every ten minutes and
+  # journald does not need three lines of "Pulling / Pulled / Running" each
+  # time to say nothing happened. Errors still come through.
+  if ! docker compose --progress quiet "${args[@]}" --profile web pull --quiet client; then
+    log "[$stack] pull failed — leaving the running container alone"
+    return 1
+  fi
+
+  # `--no-deps` because the client's `depends_on` reaches the server, and the
+  # server owns the sqlite database. Nothing about a new web bundle is a reason
+  # to go anywhere near it. A bare `up -d` here would take the whole stack.
+  #
+  # This is a no-op when the pull brought nothing new: compose only recreates a
+  # container whose image id has moved.
+  if ! docker compose --progress quiet "${args[@]}" --profile web up -d --no-deps client; then
+    log "[$stack] up failed"
+    return 1
+  fi
+
+  after=$(docker inspect --format '{{.Image}}' "$container" 2>/dev/null || echo none)
+
+  if [[ "$before" == "$after" ]]; then
+    log "[$stack] already current (${after:0:19})"
+  else
+    log "[$stack] ${before:0:19} -> ${after:0:19}"
+  fi
+}
+
+status=0
+for stack in prod beta; do
+  refresh "$stack" || status=1
+done
+
+# Nothing is removed here on purpose. Each superseded client image is left
+# dangling, which is about 30MB a release, and this box has no rule that lets a
+# script delete images — the disk it would be freeing is the one the auth
+# database sits on. Reclaiming it stays a decision somebody makes while looking
+# at `docker image ls`.
+
+exit "$status"

--- a/ops/internal/refresh-web-client.sh
+++ b/ops/internal/refresh-web-client.sh
@@ -1,82 +1,97 @@
 #!/usr/bin/env bash
 #
-# Keep app.gryt.chat and beta.gryt.chat on the image the last release published.
+# Keep the hosted web clients on the image the last release published.
 #
-# Both are nginx containers serving a build that `Release Client` already pushed
-# to GHCR. Nothing ever pulled it. On 2026-08-17 app.gryt.chat was serving 1.5.6
-# while the desktop app was on 1.6.15-beta.1, so every identity feature from
-# 1.6.0 — the derived seed, the 24-word backup, keychain sealing — looked like it
-# was desktop-only when it had simply never been deployed (GRYT-291).
+# app.gryt.chat and beta.gryt.chat are nginx containers serving a build that
+# `Release Client` already pushed to GHCR. Nothing ever pulled it. On 2026-08-17
+# app.gryt.chat was serving 1.5.6 while the desktop app was on 1.6.15-beta.1, so
+# every identity feature from 1.6.0 — the derived seed, the 24-word backup,
+# keychain sealing — looked like it was desktop-only when it had simply never
+# been deployed (GRYT-291).
 #
 # Run from the systemd timer beside this script. Safe to run by hand.
 #
-# Deliberately narrow. It pulls one service on two stacks and recreates it only
-# when the image actually moved. It does not touch the server, the SFU, the
-# image worker, MinIO or anything else on this box — those carry data, and a
-# roll-forward on them is a decision rather than a cron job.
+# Deliberately narrow. It refreshes one service on each stack and recreates the
+# container only when the image actually moved. It does not touch the server,
+# the SFU, the image worker, MinIO or anything else on the box — those carry
+# data, and a roll-forward on them is a decision rather than a cron job.
+#
+# It also only ever refreshes a container that is already there. It will not
+# bring a missing one up, because it does not know what that stack was supposed
+# to look like and guessing would be worse than saying so.
+#
+# Environment:
+#   GRYT_STACKS        stacks to refresh, space separated. Default "prod beta".
+#                      Each name <s> refreshes the container gryt-<s>-client.
+#   GRYT_SERVICE       compose service to refresh. Default "client".
+#   GRYT_MIN_FREE_GB   refuse to pull below this much free disk. Default 10.
 
 set -euo pipefail
 
-COMPOSE_DIR="${GRYT_COMPOSE_DIR:-/home/sivert/gryt/ops/deploy/compose}"
+STACKS="${GRYT_STACKS:-prod beta}"
+SERVICE="${GRYT_SERVICE:-client}"
 MIN_FREE_GB="${GRYT_MIN_FREE_GB:-10}"
 
 log() { printf '%s  %s\n' "$(date -Is)" "$*"; }
 
-# The auth database lives on the same disk as everything else here, so a pull
-# that fills it takes Keycloak down with it. Cheap to check, and the failure it
-# prevents is not cheap at all.
-free_gb=$(df -BG --output=avail "$COMPOSE_DIR" | tail -1 | tr -dc '0-9')
-if (( free_gb < MIN_FREE_GB )); then
-  log "FATAL only ${free_gb}G free on $COMPOSE_DIR, want ${MIN_FREE_GB}G — refusing to pull"
-  exit 1
-fi
-
-# Which overlay files each stack was brought up with, in order. Order matters:
-# compose merges left to right, so a different order is a different config, and
-# `up` would then recreate the container to match something nobody asked for.
-#
-# The `.local` and `pp` overlays are untracked and live only on this box. A
-# missing one is normal and is skipped rather than being an error.
-stack_files() {
-  case "$1" in
-    prod) printf '%s\n' prod.yml prod.local.yml pp.yml ;;
-    beta) printf '%s\n' beta.yml beta.local.yml ;;
-    *)    log "FATAL unknown stack '$1'"; exit 1 ;;
-  esac
+label() {
+  docker inspect --format "{{index .Config.Labels \"com.docker.compose.$2\"}}" "$1" 2>/dev/null || true
 }
 
 refresh() {
   local stack="$1"
-  local container="gryt-${stack}-client"
-  local env_file="$COMPOSE_DIR/.env.${stack}"
+  local container="gryt-${stack}-${SERVICE}"
   local -a args=()
-  local f
+  local config_files env_file working_dir f before after free_gb
 
-  if [[ ! -f "$env_file" ]]; then
-    log "[$stack] no $env_file — skipped"
+  # Read the stack's shape off the container rather than guessing at it.
+  #
+  # The overlay files and their order are not incidental: compose merges them
+  # left to right, so a different list is a different merged config, and `up`
+  # would then recreate the container to match something nobody asked for —
+  # every ten minutes, forever. Some of the overlays are untracked and exist
+  # only on the machine running this, so there is no list in the repo that
+  # could be right anyway. The labels are what the stack was actually brought
+  # up with, which is the only answer that cannot drift.
+  config_files=$(label "$container" "project.config_files")
+  if [[ -z "$config_files" ]]; then
+    log "[$stack] no container named $container — skipped"
     return 0
   fi
-  args+=(--env-file "$env_file")
+
+  working_dir=$(label "$container" "project.working_dir")
+  env_file=$(label "$container" "project.environment_file")
+
+  [[ -n "$env_file" ]] && args+=(--env-file "$env_file")
 
   while IFS= read -r f; do
-    [[ -f "$COMPOSE_DIR/$f" ]] && args+=(-f "$COMPOSE_DIR/$f")
-  done < <(stack_files "$stack")
+    [[ -z "$f" ]] && continue
+    if [[ ! -f "$f" ]]; then
+      log "[$stack] $f is gone since the stack came up — skipped"
+      return 1
+    fi
+    args+=(-f "$f")
+  done < <(tr ',' '\n' <<<"$config_files")
 
-  # The base file is the one that names the project and defines the service.
-  # Without it the rest describe nothing, and compose would happily invent a
-  # project from the directory name.
-  if [[ " ${args[*]} " != *" $COMPOSE_DIR/${stack}.yml "* ]]; then
-    log "[$stack] no ${stack}.yml in $COMPOSE_DIR — skipped"
-    return 0
+  # The auth database sits on the same disk as everything else, so a pull that
+  # fills it takes Keycloak down with it. Cheap to check, and the failure it
+  # prevents is not cheap at all.
+  free_gb=$(df -BG --output=avail "${working_dir:-/}" | tail -1 | tr -dc '0-9')
+  if (( free_gb < MIN_FREE_GB )); then
+    log "[$stack] only ${free_gb}G free, want ${MIN_FREE_GB}G — refusing to pull"
+    return 1
   fi
 
-  local before after
   before=$(docker inspect --format '{{.Image}}' "$container" 2>/dev/null || echo none)
 
   # `--progress quiet` on both calls, because this runs every ten minutes and
-  # journald does not need three lines of "Pulling / Pulled / Running" each
-  # time to say nothing happened. Errors still come through.
-  if ! docker compose --progress quiet "${args[@]}" --profile web pull --quiet client; then
+  # journald does not need three lines of "Pulling / Pulled / Running" each time
+  # to say nothing happened. Errors still come through.
+  #
+  # `--profile web` because the client service sits behind that profile in the
+  # compose files; naming a service in a profile that is not enabled is a no-op
+  # rather than an error, which would be a silent one.
+  if ! docker compose --progress quiet "${args[@]}" --profile web pull --quiet "$SERVICE"; then
     log "[$stack] pull failed — leaving the running container alone"
     return 1
   fi
@@ -87,7 +102,7 @@ refresh() {
   #
   # This is a no-op when the pull brought nothing new: compose only recreates a
   # container whose image id has moved.
-  if ! docker compose --progress quiet "${args[@]}" --profile web up -d --no-deps client; then
+  if ! docker compose --progress quiet "${args[@]}" --profile web up -d --no-deps "$SERVICE"; then
     log "[$stack] up failed"
     return 1
   fi
@@ -102,14 +117,14 @@ refresh() {
 }
 
 status=0
-for stack in prod beta; do
+for stack in $STACKS; do
   refresh "$stack" || status=1
 done
 
 # Nothing is removed here on purpose. Each superseded client image is left
-# dangling, which is about 30MB a release, and this box has no rule that lets a
-# script delete images — the disk it would be freeing is the one the auth
-# database sits on. Reclaiming it stays a decision somebody makes while looking
-# at `docker image ls`.
+# dangling, which is about 30MB a release, and no rule on this box lets a script
+# delete images — the disk it would be freeing is the one the auth database sits
+# on. Reclaiming it stays a decision somebody makes while looking at
+# `docker image ls`.
 
 exit "$status"

--- a/ops/internal/systemd/gryt-web-client-refresh.env.example
+++ b/ops/internal/systemd/gryt-web-client-refresh.env.example
@@ -1,0 +1,15 @@
+# Per-machine settings for gryt-web-client-refresh.service.
+# Install to /etc/default/gryt-web-client-refresh. Every line is optional, and
+# on the deployment this was written for none of them are needed — the script
+# reads each stack's compose files, their order and its env file off the
+# running container's own labels.
+
+# Stacks to refresh, space separated. Each name <s> refreshes the container
+# gryt-<s>-client. A stack with no such container is skipped.
+#GRYT_STACKS=prod beta
+
+# The compose service to refresh, if it is not called "client".
+#GRYT_SERVICE=client
+
+# Refuse to pull below this much free disk on the stack's filesystem.
+#GRYT_MIN_FREE_GB=10

--- a/ops/internal/systemd/gryt-web-client-refresh.service
+++ b/ops/internal/systemd/gryt-web-client-refresh.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Pull the released web client image for app.gryt.chat and beta.gryt.chat
+Documentation=https://github.com/Gryt-chat/gryt/blob/main/ops/internal/README.md
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=sivert
+ExecStart=/home/sivert/gryt/ops/internal/refresh-web-client.sh
+
+# One run should never sit on the docker socket for long. If GHCR is slow
+# enough to hit this, the next timer firing picks it up.
+TimeoutStartSec=600

--- a/ops/internal/systemd/gryt-web-client-refresh.service
+++ b/ops/internal/systemd/gryt-web-client-refresh.service
@@ -1,14 +1,34 @@
 [Unit]
-Description=Pull the released web client image for app.gryt.chat and beta.gryt.chat
+Description=Pull the released web client image for the hosted Gryt web clients
 Documentation=https://github.com/Gryt-chat/gryt/blob/main/ops/internal/README.md
 After=docker.service
 Requires=docker.service
 
 [Service]
 Type=oneshot
-User=sivert
-ExecStart=/home/sivert/gryt/ops/internal/refresh-web-client.sh
 
-# One run should never sit on the docker socket for long. If GHCR is slow
+# A symlink into the checkout rather than a copy, so `git pull` updates the
+# script and nothing has to be installed again. systemd needs a literal
+# absolute path here — it does not expand variables in the executable itself —
+# which is why the path is fixed and everything that varies per box lives in
+# the environment file below.
+ExecStart=/usr/local/bin/gryt-web-client-refresh
+
+# Optional, and the only file that should know anything about this particular
+# machine. See gryt-web-client-refresh.env.example. Nothing in it is needed for
+# the deployment this was written for — the script reads each stack's compose
+# files and env file off the running container's labels.
+EnvironmentFile=-/etc/default/gryt-web-client-refresh
+
+# Runs as root, which is what a system unit talking to the Docker socket
+# usually does. To run as someone else instead, drop in an override rather than
+# editing this file:
+#
+#   systemctl edit gryt-web-client-refresh.service
+#   [Service]
+#   User=youruser
+#   SupplementaryGroups=docker
+
+# One run should never sit on the Docker socket for long. If GHCR is slow
 # enough to hit this, the next timer firing picks it up.
 TimeoutStartSec=600

--- a/ops/internal/systemd/gryt-web-client-refresh.timer
+++ b/ops/internal/systemd/gryt-web-client-refresh.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Check GHCR for a newer web client every ten minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=10min
+
+# Ten minutes is about how long it is acceptable for app.gryt.chat to lag a
+# release. The check itself is a manifest request against GHCR and costs
+# nothing when the digest has not moved.
+RandomizedDelaySec=2min
+
+# Catch up after the box has been off rather than waiting out a full interval.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes GRYT-291.

## What was wrong

app.gryt.chat and beta.gryt.chat serve the `ghcr.io/gryt-chat/client` image that `Release Client` pushes on every release. Building and pushing it was automated. Pulling it was not, so the web client only moved when somebody remembered to log into the box.

Nobody had since 13 August. On the 17th:

| | version | image built |
|---|---|---|
| app.gryt.chat | 1.5.6 | 2026-08-13 |
| desktop | 1.6.15-beta.1 | — |

Ten releases, including everything from 1.6.0: the seed-derived guest identity, the 24-word backup, keychain sealing, server-lineage scoping. From the outside that reads as "portable identity is desktop-only", which is not true of a single line of the code — it is WebCrypto and IndexedDB throughout, and Electron's `safeStorage` is an optional upgrade with a documented fallback.

Confirmed rather than guessed: the bundle app.gryt.chat served was byte-identical to what `gryt-prod-client` served on :3666, its version string was `1.5.6`, and it contained no `identity-seed`, no 24-word strings and no `srv:` scoping.

## What this adds

`ops/internal/refresh-web-client.sh` on a systemd timer, every ten minutes. It pulls the tag each stack is pinned to and lets compose recreate the container only when the image id actually moved.

## Worth looking at

**It reads each stack's shape off the running container, and that is the part to check.** `com.docker.compose.project.config_files`, `.environment_file` and `.working_dir` give the overlay files, their order, and the env file the stack was actually brought up with.

The first version hardcoded that list — `prod.yml, prod.local.yml, pp.yml` — and it was wrong to. Compose merges overlays left to right, so the list is not decoration: if it differs from what the stack came up with, the merged config differs, and `up` recreates the container to match. Every ten minutes, forever. Worse, no list committed here could be right, because `prod.local.yml` and `pp.yml` are untracked and exist only on the host.

The trade: with no container there is nothing to read, so a stack whose client is missing is **skipped rather than brought up**. That seems right for something on a timer — it does not know what that stack was meant to look like — but it does mean this cannot recover from a removed container.

Other things:

- **`--no-deps` is load-bearing.** The `client` service `depends_on` the server, which owns the sqlite database. Without it a routine web-bundle update reaches into the data plane.
- **`--profile web`** is needed because the service sits behind that profile; naming a service in a profile that is not enabled is a silent no-op rather than an error.
- **It removes nothing.** Superseded images are left dangling, roughly 30MB a release, because the disk being freed is the one Keycloak sits on and CLAUDE.md does not let a script make that call.

## Deliberately out of scope

The rest of the prod stack is stale for exactly the same reason — server and SFU images from 13 August, image worker from the 8th. Those carry data and rolling them forward is a decision rather than a cron job, so this touches only `client`. Client-only was Sivert's call.

A deploy job in `Release Client` would be tighter and is not what this is. The box sits behind the Cloudflare tunnel with no self-hosted runner, so that job would need inbound SSH and secrets before it could do anything at all. A timer needs neither. Also his call.

## Verification

Both stacks were pulled by hand first, so app.gryt.chat is already on 1.6.14 and beta on 1.6.15-beta.1 — that part is done and is not waiting on this PR.

Then, on the box, with no configuration of any kind and run from `/tmp` and from `/`:

```
2026-08-17T11:01:38+02:00  [prod] already current (sha256:3a0e535739c6)
2026-08-17T11:01:40+02:00  [beta] already current (sha256:26e1d727fcf7)
exit=0
```

Run twice in a row, `gryt-prod-client`'s `StartedAt` was byte-identical before and after — that is the recreate loop the label-reading is there to rule out. An unknown stack name reports `no container named gryt-staging-client — skipped` and exits 0.

## After merge

The timer is not live yet — `ExecStart` points at a symlink that does not exist until the box has the file:

```bash
cd /path/to/gryt && git pull
sudo ln -sfn "$PWD/ops/internal/refresh-web-client.sh" /usr/local/bin/gryt-web-client-refresh
sudo cp ops/internal/systemd/gryt-web-client-refresh.{service,timer} /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now gryt-web-client-refresh.timer
```

A symlink rather than a copy so `git pull` updates the script. systemd will not expand variables in the executable path, which is why that one path is fixed and nothing else is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)