### PR TITLE
Pass the client the rest of what it reads (GRYT-292)

### DIFF
--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -252,7 +252,12 @@ services:
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_REALM: ${GRYT_OIDC_REALM:-gryt}
       GRYT_OIDC_CLIENT_ID: ${GRYT_OIDC_CLIENT_ID:-gryt-web}
+      # The certificate authority the client asks to vouch for its key, and the
+      # counterpart to the server's GRYT_TRUSTED_CERT_ISSUERS above — point one
+      # somewhere else without the other and the join fails. See prod.yml.
+      GRYT_IDENTITY_URL: ${GRYT_IDENTITY_URL:-https://id.gryt.chat}
       GRYT_AUTH_API: ${GRYT_AUTH_API:-https://auth.gryt.chat}
+      GRYT_AUTH_CALLBACK_URL: ${GRYT_AUTH_CALLBACK_URL:-https://gryt.chat/auth/callback}
     depends_on:
       server:
         condition: service_healthy

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -359,7 +359,17 @@ services:
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_REALM: ${GRYT_OIDC_REALM:-gryt}
       GRYT_OIDC_CLIENT_ID: ${GRYT_OIDC_CLIENT_ID:-gryt-web}
+      # The certificate authority the client asks to vouch for its key, and the
+      # counterpart to the server's GRYT_TRUSTED_CERT_ISSUERS above — point one
+      # somewhere else without the other and the join fails.
+      #
+      # Pointing at a different Keycloak and leaving this alone is GRYT-156:
+      # the token comes from your issuer and goes to Gryt's CA, which validates
+      # against its own and refuses it. The 401 says "no applicable key found in
+      # the JWKS", which is the symptom.
+      GRYT_IDENTITY_URL: ${GRYT_IDENTITY_URL:-https://id.gryt.chat}
       GRYT_AUTH_API: ${GRYT_AUTH_API:-https://auth.gryt.chat}
+      GRYT_AUTH_CALLBACK_URL: ${GRYT_AUTH_CALLBACK_URL:-https://gryt.chat/auth/callback}
     depends_on:
       server:
         condition: service_healthy


### PR DESCRIPTION
Part of GRYT-292. Companion to Gryt-chat/client#165 — that one adds `GRYT_IDENTITY_URL` to the image entrypoint, this one forwards it. Neither is enough alone.

## What was wrong

The `client` service in `prod.yml` and `beta.yml` forwarded four of the six keys the web client reads off `window.__GRYT_CONFIG__`:

```
GRYT_OIDC_ISSUER  GRYT_OIDC_REALM  GRYT_OIDC_CLIENT_ID  GRYT_AUTH_API
```

Missing: `GRYT_IDENTITY_URL` and `GRYT_AUTH_CALLBACK_URL`.

The identity URL is the one that matters. It names the certificate authority the client asks to vouch for its key, and it is the counterpart to the server service's `GRYT_TRUSTED_CERT_ISSUERS` two blocks up — move one without the other and the join fails. So somebody could point this stack at their own Keycloak, correctly, on both halves of the *server* config, and still have every token posted to Gryt's CA, which validates against its own issuer and refuses it. GRYT-156 again; the 401 reads `no applicable key found in the JWKS`, which is the symptom.

## The change

Two keys per stack, defaulting to the same values the image and `packages/client/src/config.ts` already fall back to. Nothing changes for a deployment that sets neither — the point is that setting them is now possible.

## Verification

`docker compose --env-file .env.<stack> -f <stack>.yml --profile web config` against the real env files on the deployment, both stacks, rendered identically:

```json
{
  "GRYT_AUTH_API": "https://auth.gryt.chat",
  "GRYT_AUTH_CALLBACK_URL": "https://gryt.chat/auth/callback",
  "GRYT_IDENTITY_URL": "https://id.gryt.chat",
  "GRYT_OIDC_CLIENT_ID": "gryt-web",
  "GRYT_OIDC_ISSUER": "https://auth.gryt.chat/realms/gryt",
  "GRYT_OIDC_REALM": "gryt"
}
```

## Worth knowing

Merging this changes the `client` service definition, so the next `up` recreates both client containers once. Expected, and harmless — they are stateless nginx.

## Not a problem after all

GRYT-293 noted these files still passed `GRYT_AUTH_MODE`. They do not: `main` already has `GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}`, which is the right shape. That observation came from a stale submodule checkout and is corrected on the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)