### PR TITLE
Do not call a recreate "already current" (GRYT-291)

### DIFF
--- a/ops/internal/refresh-web-client.sh
+++ b/ops/internal/refresh-web-client.sh
@@ -42,7 +42,8 @@ refresh() {
   local stack="$1"
   local container="gryt-${stack}-${SERVICE}"
   local -a args=()
-  local config_files env_file working_dir f before after free_gb
+  local config_files env_file working_dir f free_gb
+  local image_before image_after id_before id_after
 
   # Read the stack's shape off the container rather than guessing at it.
   #
@@ -82,7 +83,13 @@ refresh() {
     return 1
   fi
 
-  before=$(docker inspect --format '{{.Image}}' "$container" 2>/dev/null || echo none)
+  # Both, because they answer different questions. The image id says whether a
+  # new release arrived; the container id says whether compose replaced the
+  # container at all, which it also does when the service definition changes
+  # underneath it. Watching only the image made a recreate report "already
+  # current" — true of the image and wrong about what had just happened.
+  image_before=$(docker inspect --format '{{.Image}}' "$container" 2>/dev/null || echo none)
+  id_before=$(docker inspect --format '{{.Id}}' "$container" 2>/dev/null || echo none)
 
   # `--progress quiet` on both calls, because this runs every ten minutes and
   # journald does not need three lines of "Pulling / Pulled / Running" each time
@@ -107,12 +114,15 @@ refresh() {
     return 1
   fi
 
-  after=$(docker inspect --format '{{.Image}}' "$container" 2>/dev/null || echo none)
+  image_after=$(docker inspect --format '{{.Image}}' "$container" 2>/dev/null || echo none)
+  id_after=$(docker inspect --format '{{.Id}}' "$container" 2>/dev/null || echo none)
 
-  if [[ "$before" == "$after" ]]; then
-    log "[$stack] already current (${after:0:19})"
+  if [[ "$image_before" != "$image_after" ]]; then
+    log "[$stack] new image ${image_before:0:19} -> ${image_after:0:19}"
+  elif [[ "$id_before" != "$id_after" ]]; then
+    log "[$stack] recreated on the same image (${image_after:0:19}) — the service definition changed"
   else
-    log "[$stack] ${before:0:19} -> ${after:0:19}"
+    log "[$stack] already current (${image_after:0:19})"
   fi
 }
 


### PR DESCRIPTION
Follow-up to #85, found while deploying it.

## What was wrong

The script compared the container's image id before and after, and reported `already current` when it had not moved. True of the image, wrong about what happened: compose also recreates a container when the service definition changes underneath it.

Which is exactly what #86 did. First run after both merged:

```
2026-08-17T11:29:52+02:00  [prod] already current (sha256:3a0e535739c6)
2026-08-17T11:29:56+02:00  [beta] already current (sha256:26e1d727fcf7)
```

Both containers had just been replaced to pick up `GRYT_IDENTITY_URL`. `StartedAt` on both was inside that run.

Not harmful — the recreate was correct and wanted. But this runs unattended every ten minutes and its journal is the only account of what it did, so a line reading "no change" on a run that replaced two containers is the wrong thing to leave behind.

## The change

It watches the container id as well. The two answer different questions: image id says whether a new release arrived, container id says whether compose replaced the container at all. Three outcomes instead of two, and the middle one names its cause:

```
[prod] new image sha256:3a0e535739c6 -> sha256:68da86b37b74
[prod] recreated on the same image (sha256:3a0e535739c6) — the service definition changed
[prod] already current (sha256:3a0e535739c6)
```

## Verification

On the box. No-op path unchanged, both stacks reporting `already current`.

For the recreate path, rather than mutate a live service definition to provoke one, the assumption the new branch rests on was measured directly — `up -d --force-recreate --no-deps client` on beta:

```
image changed: no
container id changed: yes
=> the branch that would fire: recreated-same-image
```

`gryt-beta-client` came back healthy in 17 seconds. prod was not touched.

## Also worth knowing

`GRYT_IDENTITY_URL` is now on both client containers, but `config.js` does not carry it yet — the running images predate Gryt-chat/client#165, and the entrypoint that writes the sixth key ships with the next client release. The compose half is live and waiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)