### PR TITLE
Somewhere to put a sponsor's name (GRYT-271)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ See the [contributing guide](https://docs.gryt.chat/docs/guide/contributing) for
 
 Nothing security-relevant merges without being read line by line — the SFU, authentication, identity, the image worker and the data layer only change through a reviewed pull request. See the [AI policy](https://docs.gryt.chat/docs/guide/ai) for the exact paths, how to verify it, and the disclosure rules for contributions.
 
+## Sponsors
+
+Gryt is one person's project, and the bills are real — a domain, a box, the Apple
+and Windows signing certificates that stop the installer warning people off. If you
+run Gryt or just want it to keep going, [GitHub Sponsors](https://github.com/sponsors/Gryt-chat)
+is where that happens.
+
+<!-- sponsors:start -->
+
+Nobody yet. This is where names go.
+
+<!-- sponsors:end -->
+
+Sponsoring at $25 a month puts your name or handle here. At $100 a month a logo goes
+on [gryt.chat](https://gryt.chat), linked wherever you want. A one-off at $50 gets you
+a line in the notes for the next release.
+
+To be listed, or to change how you are listed, say so on the sponsorship or open a
+pull request against this section — nothing is published automatically, and nothing
+about you is used beyond what you write here.
+
 ## Acknowledgments
 
 Gryt wouldn't exist without these projects and resources. I'm forever grateful to the people behind them for sharing their work with the world.

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ Nothing security-relevant merges without being read line by line — the SFU, au
 
 ## Sponsors
 
-Gryt is one person's project, and the bills are real — a domain, a box, the Apple
-and Windows signing certificates that stop the installer warning people off. If you
-run Gryt or just want it to keep going, [GitHub Sponsors](https://github.com/sponsors/Gryt-chat)
-is where that happens.
+Sponsoring pays for a domain, the box the auth stack runs on, and the Apple and
+Windows signing certificates that stop the installer warning people off their own
+download. That is the whole list — there is nothing to buy inside Gryt, and no part
+of it is held back for people who pay.
+[GitHub Sponsors](https://github.com/sponsors/Gryt-chat) is where it goes.
 
 <!-- sponsors:start -->
 
@@ -90,9 +91,11 @@ Sponsoring at $25 a month puts your name or handle here. At $100 a month a logo 
 on [gryt.chat](https://gryt.chat), linked wherever you want. A one-off at $50 gets you
 a line in the notes for the next release.
 
+Everyone who has sponsored, including one-off payments and when each arrived, is at
+[gryt.chat/sponsors](https://gryt.chat/sponsors).
+
 To be listed, or to change how you are listed, say so on the sponsorship or open a
-pull request against this section — nothing is published automatically, and nothing
-about you is used beyond what you write here.
+pull request. Nothing is published automatically.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ Nothing security-relevant merges without being read line by line — the SFU, au
 ## Sponsors
 
 <!-- sponsors:start -->
+<!-- Monthly sponsors only, which is what the $25 and $500 tiers promise. A
+     one-off payment is credited in the release notes and listed on
+     gryt.chat/sponsors, not here. -->
 
-**Sponsored once** — Carlo, March 2026.
+Nobody sponsoring monthly yet.
 
 <!-- sponsors:end -->
 

--- a/README.md
+++ b/README.md
@@ -75,29 +75,15 @@ Nothing security-relevant merges without being read line by line — the SFU, au
 
 ## Sponsors
 
-Sponsoring pays for a domain, the box the auth stack runs on, and the Apple and
-Windows signing certificates that stop the installer warning people off their own
-download. That is the whole list — there is nothing to buy inside Gryt, and no part
-of it is held back for people who pay.
-[GitHub Sponsors](https://github.com/sponsors/Gryt-chat) is where it goes.
-
 <!-- sponsors:start -->
 
 **Sponsored once** — Carlo, March 2026.
 
-Nobody is sponsoring monthly yet. That list goes here when there is one.
-
 <!-- sponsors:end -->
 
-Sponsoring at $25 a month puts your name or handle here. At $100 a month a logo goes
-on [gryt.chat](https://gryt.chat), linked wherever you want. A one-off at $50 gets you
-a line in the notes for the next release.
-
-Everyone who has sponsored, including one-off payments and when each arrived, is at
-[gryt.chat/sponsors](https://gryt.chat/sponsors).
-
-To be listed, or to change how you are listed, say so on the sponsorship or open a
-pull request. Nothing is published automatically.
+What sponsoring pays for, the tiers, and everyone who has sponsored:
+[gryt.chat/sponsors](https://gryt.chat/sponsors). To sponsor:
+[GitHub Sponsors](https://github.com/sponsors/Gryt-chat).
 
 ## Acknowledgments
 
@@ -118,13 +104,6 @@ Gryt wouldn't exist without these projects and resources. I'm forever grateful t
 - [WebRTC Simulcast Playground](https://orphis.github.io/webrtc-sandbox/simulcast-playground.html) by Orphis — Invaluable for understanding simulcast, SVC scalability modes, and encoder behavior
 - [mediasoup documentation](https://mediasoup.org/documentation/) — Excellent SFU architecture reference that shaped how I think about track forwarding
 - [Microsoft Application Loopback Audio Capture sample](https://learn.microsoft.com/en-us/samples/microsoft/windows-classic-samples/applicationloopbackaudio-sample/) — The WASAPI example that showed how to capture per-process audio on Windows while excluding Gryt's own audio
-
-**People:**
-
-- **Carlo** — asked the question that became portable guest identity. It started
-  as a conversation about federation, and the smaller question inside it — whether
-  you can be the same person on two servers without an account — turned out to be
-  the answerable one. The design was worked out with him in the Gryt Discord
 
 **Projects that inspired the journey:**
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ of it is held back for people who pay.
 
 <!-- sponsors:start -->
 
-Nobody yet. This is where names go.
+**Sponsored once** — Carlo, March 2026.
+
+Nobody is sponsoring monthly yet. That list goes here when there is one.
 
 <!-- sponsors:end -->
 
@@ -116,6 +118,13 @@ Gryt wouldn't exist without these projects and resources. I'm forever grateful t
 - [WebRTC Simulcast Playground](https://orphis.github.io/webrtc-sandbox/simulcast-playground.html) by Orphis — Invaluable for understanding simulcast, SVC scalability modes, and encoder behavior
 - [mediasoup documentation](https://mediasoup.org/documentation/) — Excellent SFU architecture reference that shaped how I think about track forwarding
 - [Microsoft Application Loopback Audio Capture sample](https://learn.microsoft.com/en-us/samples/microsoft/windows-classic-samples/applicationloopbackaudio-sample/) — The WASAPI example that showed how to capture per-process audio on Windows while excluding Gryt's own audio
+
+**People:**
+
+- **Carlo** — asked the question that became portable guest identity. It started
+  as a conversation about federation, and the smaller question inside it — whether
+  you can be the same person on two servers without an account — turned out to be
+  the answerable one. The design was worked out with him in the Gryt Discord
 
 **Projects that inspired the journey:**
 

--- a/patch-notes-style.md
+++ b/patch-notes-style.md
@@ -123,8 +123,8 @@ Sections like Security and Under the hood get nothing.
 ## Sponsors
 
 The $50 one-time tier on GitHub Sponsors promises a name in the notes for the next
-release. Nothing enforces that, and a promise nobody remembers is worse than one
-never made — so it belongs in the checklist here rather than in somebody's head.
+release. Nothing enforces it, and nobody drafting a set of notes has any reason to
+go and look, so it belongs in this checklist rather than in somebody's memory.
 
 Before publishing a note, check
 [the sponsors list](https://github.com/sponsors/Gryt-chat) for one-time sponsorships
@@ -135,13 +135,13 @@ list, with nothing more than their names:
 Thanks to <name> and <name> for sponsoring this release.
 ```
 
-Use whatever name they sponsored under, or the one they asked for. No logos, no
-links, no thank-you paragraph — this is a credit, not an advertisement, and the
-tier says a name.
+Use whatever name they sponsored under, or the one they asked for. The tier says a
+name, so a name is what goes in. Logos and links have their own places, in the
+README and on gryt.chat/sponsors.
 
 Recurring sponsors are not credited per release. They are listed in the README and
-on the site, which is what those tiers promise, and repeating them in every note
-would turn the notes into a sponsor page.
+on gryt.chat/sponsors, which is what those tiers promise. Repeating them in every
+note would turn the notes into a sponsor page.
 
 Nothing to credit is the normal case. Say nothing at all rather than writing that
 there were no sponsors.

--- a/patch-notes-style.md
+++ b/patch-notes-style.md
@@ -120,6 +120,32 @@ obvious, and no codec puts back detail that was never captured.
 
 Sections like Security and Under the hood get nothing.
 
+## Sponsors
+
+The $50 one-time tier on GitHub Sponsors promises a name in the notes for the next
+release. Nothing enforces that, and a promise nobody remembers is worse than one
+never made — so it belongs in the checklist here rather than in somebody's head.
+
+Before publishing a note, check
+[the sponsors list](https://github.com/sponsors/Gryt-chat) for one-time sponsorships
+since the last one went out. If there are any, credit them at the end, above the recap
+list, with nothing more than their names:
+
+```mdx
+Thanks to <name> and <name> for sponsoring this release.
+```
+
+Use whatever name they sponsored under, or the one they asked for. No logos, no
+links, no thank-you paragraph — this is a credit, not an advertisement, and the
+tier says a name.
+
+Recurring sponsors are not credited per release. They are listed in the README and
+on the site, which is what those tiers promise, and repeating them in every note
+would turn the notes into a sponsor page.
+
+Nothing to credit is the normal case. Say nothing at all rather than writing that
+there were no sponsors.
+
 ## Betas
 
 Not every beta deserves notes. If a release contains nothing above **Under the


### PR DESCRIPTION
Part of GRYT-271. Companion to Gryt-chat/site#27 (gryt.chat + the /sponsors page) and Gryt-chat/.github#14 (org profile).

## What was wrong

The Sponsors listing is public and live, with six tiers. Three promise a placement that did not exist:

| tier | promises |
|---|---|
| $25/mo | name in the README, on every repo in the org |
| $50 one-time | name in the next release notes |
| $100/mo | logo on gryt.chat |
| $500/mo | logo at the top of the list, site **and** README |

Zero sponsor mentions across all ten repos and the site.

## The change

**`README.md`** gets a Sponsors section holding the one thing that has to live in this file — a name, which is what the $25 tier promises — between `<!-- sponsors:start -->` markers, plus two links.

It is deliberately thin. An earlier version of this PR had a paragraph on what the money pays for, the tiers written out, and instructions for being listed. All three are on gryt.chat/sponsors now, so keeping them here was a second copy that can drift. Sivert pushed back on it and he was right.

**`patch-notes-style.md`** gets the $50 tier written into the release-notes process.

## Worth looking at

**The $50 tier is the one that was going to get dropped**, and it is why the style guide is touched here. It is a process, not a page: nothing prompts whoever writes the next notes to go and look at the sponsors list. So it sits next to everything else that happens before publishing, with the wording, where it goes, and the instruction to say nothing at all when there is nobody to credit rather than writing that there were none.

**Recurring sponsors are deliberately not credited per release.** They are in the README and on the site, which is what those tiers promise. Repeating them every time would turn the notes into a sponsor page. Say if you disagree; it is a judgement call.

## Carlo

The first person to sponsor Gryt, in March 2026, through Ko-fi. Listed by first name with no link, which is what he asked for.

That also settles a design question by evidence: both GitHub Sponsors accounts report zero, including private sponsorships, so an API-driven list would show nobody. The file is the only thing that can be right.

An earlier version of this PR also credited him in Acknowledgments for the question that became portable guest identity. That is out — it read as a dedication sitting next to a list of libraries, and the credit already exists in the blog post for that release, where it is dated and has context around it.

## Still yours to do

The $25 tier says the name goes in the README **"on every repo in the org"**. That is ten READMEs to keep in step by hand, and it will rot the same way this did. The list lives in one place now; the wording needs to follow, and it costs nothing at zero sponsors. GRYT-294 covers the one-line link in the other eight repos.

It is your account, so I cannot change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)