### PR TITLE
Two things the timer docs said that were not true (GRYT-291)

### DIFF
--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -139,8 +139,21 @@ Anything that differs per machine goes in `/etc/default/gryt-web-client-refresh`
 [`gryt-web-client-refresh.env.example`](systemd/gryt-web-client-refresh.env.example). On a
 normal checkout none of it is needed.
 
-Check on it with `systemctl list-timers gryt-web-client-refresh` and
-`journalctl -u gryt-web-client-refresh -n 50`.
+Check on it with `systemctl list-timers gryt-web-client-refresh`, and read what it
+did with:
+
+```bash
+sudo journalctl -u gryt-web-client-refresh -n 50
+```
+
+The `sudo` is not optional. The service runs as root, and `journalctl` without it
+shows only your own messages, so the plain command prints nothing at all and looks
+like the timer never ran. `id -nG` will tell you whether you are in `adm` or
+`systemd-journal`; on this box the answer is no.
+
+Immediately after `enable --now`, `list-timers` shows `NEXT` and `LEFT` as `-`.
+That is the first run still going, not a timer that failed to schedule: the next
+elapse appears once the service goes inactive, a few seconds later.
 
 Superseded images are left dangling rather than removed — roughly 30MB a release. Cleaning
 them up stays something to do by hand, because the disk being freed is the one Keycloak

--- a/ops/internal/systemd/gryt-web-client-refresh.timer
+++ b/ops/internal/systemd/gryt-web-client-refresh.timer
@@ -2,6 +2,9 @@
 Description=Check GHCR for a newer web client every ten minutes
 
 [Timer]
+# Monotonic, so there is no Persistent= here. That setting only does anything
+# for OnCalendar= timers, and a line claiming to catch up missed runs while
+# doing nothing is worse than no line.
 OnBootSec=5min
 OnUnitActiveSec=10min
 
@@ -9,9 +12,6 @@ OnUnitActiveSec=10min
 # release. The check itself is a manifest request against GHCR and costs
 # nothing when the digest has not moved.
 RandomizedDelaySec=2min
-
-# Catch up after the box has been off rather than waiting out a full interval.
-Persistent=true
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Follow-up to #85, found while installing it on the box.

**The timer itself is fine.** It fired on `enable --now`, exited 0, and correctly did nothing because both clients were already current:

```
NEXT  Mon 2026-08-17 13:16:56 CEST  10min left
Result=success   ExecMainStatus=0
```

`gryt-prod-client` and `gryt-beta-client` both still show the `StartedAt` from this morning's manual deploy, so the no-op path did what it was built to do.

## What was wrong

**`journalctl -u gryt-web-client-refresh -n 50` prints nothing.** That is the command the README gives as the way to see what the timer did. The service runs as root, and `journalctl` without `sudo` shows only the caller's own messages unless they are in `adm` or `systemd-journal`. `id -nG` on the box:

```
sivert cdrom floppy sudo audio dip video plugdev users netdev bluetooth lpadmin scanner docker
```

Neither group. So the documented way to confirm the timer is working is **indistinguishable from a timer that never ran** — which is a bad failure mode for the one command somebody reaches for when they are already suspicious.

**`Persistent=true` did nothing.** It only has an effect on `OnCalendar=` timers; this one is monotonic (`OnBootSec` + `OnUnitActiveSec`). The comment above it claimed it caught up on missed runs after the box had been off. It did not.

## The change

- README says `sudo journalctl …`, and says why, with `id -nG` as the check.
- `Persistent=true` and its comment are gone rather than left describing behaviour the unit does not have.
- Documented the one genuinely confusing moment during install: right after `enable --now`, `list-timers` shows `NEXT` and `LEFT` as `-`. That reads as a timer that failed to schedule, and it is just the first run still executing. The next elapse appears a few seconds later once the service goes inactive. I checked this myself before working out what it was.

## Not changed

Adding `sivert` to `systemd-journal` would make the original command work and is arguably the nicer fix. It is a change to the user's groups on a box running the auth stack, so it is Sivert's call rather than something to slip into a docs PR. `sudo` works today and costs five characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)