### PR TITLE
Check the push credential before publishing anything (GRYT-300)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -113,6 +113,77 @@ jobs:
 
           git -C packages/client remote set-url origin "https://x-access-token:${RELEASE_PAT}@github.com/Gryt-chat/client.git"
 
+      - name: Verify push access before anything is published
+        shell: bash
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+          MONOREPO_TOKEN: ${{ github.token }}
+          MONOREPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # `Release Server` died on its last push during the GitHub incident on
+          # 2026-08-17 and left an image on GHCR for a version with no tag and
+          # no release page. This workflow uses the same credential at the same
+          # kind of step, and has more to lose: installers for three platforms
+          # and a push to the Snap Store. GRYT-300.
+          #
+          # `ls-remote` would not have caught it. That talks to upload-pack, so
+          # it only proves the credential can read, and a token that has lost
+          # its write scope still answers it happily. Push is authorised
+          # against git-receive-pack, so ask that service for its ref
+          # advertisement instead — same request a real push starts with, and
+          # it changes nothing on the remote.
+          #
+          # This narrows the window rather than closing it. GitHub can still
+          # fall over later in the run. What it does remove is the run that was
+          # never going to finish — an expired credential, or a GitHub that is
+          # already unhealthy — and that run is now a no-op.
+          probe() {
+            local repo="$1" token="$2" code attempt
+
+            for attempt in 1 2 3; do
+              code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+                -u "x-access-token:${token}" \
+                "https://github.com/${repo}.git/info/refs?service=git-receive-pack" \
+                || echo 000)
+
+              case "$code" in
+                200)
+                  echo "  ${repo}: can push"
+                  return 0
+                  ;;
+                401 | 403)
+                  # A definite no. Retrying will not turn it into a yes.
+                  echo "  ${repo}: credential is not allowed to push (HTTP ${code})" >&2
+                  return 1
+                  ;;
+                *)
+                  echo "  ${repo}: no usable answer (HTTP ${code}), attempt ${attempt}/3" >&2
+                  sleep $(( attempt * 5 ))
+                  ;;
+              esac
+            done
+
+            echo "  ${repo}: could not confirm push access" >&2
+            return 1
+          }
+
+          failed=0
+          probe "Gryt-chat/client" "$RELEASE_PAT" || failed=1
+          probe "$MONOREPO" "$MONOREPO_TOKEN" || failed=1
+
+          if (( failed )); then
+            echo "" >&2
+            echo "Stopping before anything is published." >&2
+            echo "" >&2
+            echo "Check https://www.githubstatus.com first. If Git Operations are" >&2
+            echo "degraded then this is not the credential, and the fix is to wait" >&2
+            echo "and dispatch again. If GitHub is healthy, RELEASE_PAT has expired" >&2
+            echo "or lost write access to the repo named above." >&2
+            exit 1
+          fi
+
       - name: Move release submodules to their main
         shell: bash
         run: |
@@ -539,8 +610,30 @@ jobs:
 
           # Tagged after the push succeeds, so the tag can never name a commit that
           # is not on the branch.
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
+          #
+          # Same idempotency as `Tag server repo`: a re-dispatch of a version
+          # that already got this far finds its own tag on the remote, and that
+          # used to fail the step on "tag already exists". Accept the tag when
+          # it already names this commit; refuse to move one that names another.
+          # GRYT-300.
+          HEAD_SHA="$(git rev-parse HEAD)"
+          REMOTE_SHA="$(git ls-remote origin "refs/tags/v${VERSION}" | awk '{ print $1 }')"
+
+          if [[ -n "$REMOTE_SHA" && "$REMOTE_SHA" != "$HEAD_SHA" ]]; then
+            echo "v${VERSION} already exists on the remote at ${REMOTE_SHA}," >&2
+            echo "but this release built ${HEAD_SHA}." >&2
+            echo "" >&2
+            echo "Refusing to move a published tag. Either delete the remote tag" >&2
+            echo "and dispatch again, or release a new version." >&2
+            exit 1
+          fi
+
+          if [[ -n "$REMOTE_SHA" ]]; then
+            echo "v${VERSION} is already on the remote at ${HEAD_SHA}."
+          else
+            git tag -f "v$VERSION" "$HEAD_SHA"
+            git push origin "v$VERSION"
+          fi
 
       - name: Determine checkout ref
         id: ref

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -119,6 +119,80 @@ jobs:
 
           git -C packages/server remote set-url origin "https://x-access-token:${RELEASE_PAT}@github.com/Gryt-chat/server.git"
 
+      - name: Verify push access before anything is published
+        shell: bash
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+          MONOREPO_TOKEN: ${{ github.token }}
+          MONOREPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # This run pushes an image to GHCR and commits release.json to the
+          # monorepo long before it first pushes to Gryt-chat/server, and that
+          # last push is the step that failed on 2026-08-17, during a GitHub
+          # incident with Git Operations degraded. What it left behind was
+          # 1.4.4 on GHCR with no tag, no release page and no self-hosted
+          # bundles — a version that exists as an image and nowhere else.
+          # GRYT-300.
+          #
+          # `ls-remote` would not have caught it. That talks to upload-pack, so
+          # it only proves the credential can read, and a token that has lost
+          # its write scope still answers it happily. Push is authorised
+          # against git-receive-pack, so ask that service for its ref
+          # advertisement instead — same request a real push starts with, and
+          # it changes nothing on the remote.
+          #
+          # This narrows the window rather than closing it. GitHub can still
+          # fall over between here and the tag push twenty minutes later. What
+          # it does remove is the run that was never going to finish — an
+          # expired credential, or a GitHub that is already unhealthy — and
+          # that run is now a no-op instead of a half-release.
+          probe() {
+            local repo="$1" token="$2" code attempt
+
+            for attempt in 1 2 3; do
+              code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+                -u "x-access-token:${token}" \
+                "https://github.com/${repo}.git/info/refs?service=git-receive-pack" \
+                || echo 000)
+
+              case "$code" in
+                200)
+                  echo "  ${repo}: can push"
+                  return 0
+                  ;;
+                401 | 403)
+                  # A definite no. Retrying will not turn it into a yes.
+                  echo "  ${repo}: credential is not allowed to push (HTTP ${code})" >&2
+                  return 1
+                  ;;
+                *)
+                  echo "  ${repo}: no usable answer (HTTP ${code}), attempt ${attempt}/3" >&2
+                  sleep $(( attempt * 5 ))
+                  ;;
+              esac
+            done
+
+            echo "  ${repo}: could not confirm push access" >&2
+            return 1
+          }
+
+          failed=0
+          probe "Gryt-chat/server" "$RELEASE_PAT" || failed=1
+          probe "$MONOREPO" "$MONOREPO_TOKEN" || failed=1
+
+          if (( failed )); then
+            echo "" >&2
+            echo "Stopping before anything is published." >&2
+            echo "" >&2
+            echo "Check https://www.githubstatus.com first. If Git Operations are" >&2
+            echo "degraded then this is not the credential, and the fix is to wait" >&2
+            echo "and dispatch again. If GitHub is healthy, RELEASE_PAT has expired" >&2
+            echo "or lost write access to the repo named above." >&2
+            exit 1
+          fi
+
       - name: Move release submodules to their main
         shell: bash
         run: |
@@ -683,7 +757,39 @@ jobs:
 
           TAG="${{ steps.version.outputs.tag }}"
 
-          git -C packages/server tag "$TAG"
+          # A retried release arrives here with the tag already on the remote.
+          # That is not an edge case, it is what `bump=none` is for: after a run
+          # that failed somewhere later, `Determine server version` reads the
+          # version back out of release.json and redoes it. Everything else in
+          # that path is idempotent — the Docker push overwrites, the zips get
+          # rebuilt — and this step was the one that stopped, on "tag already
+          # exists", under `set -euo pipefail`. GRYT-300.
+          #
+          # So accept a tag that already names this commit and refuse one that
+          # names a different commit, rather than force-moving a tag people may
+          # already have fetched.
+          HEAD_SHA="$(git -C packages/server rev-parse HEAD)"
+          REMOTE_SHA="$(git -C packages/server ls-remote origin "refs/tags/${TAG}" | awk '{ print $1 }')"
+
+          if [[ -n "$REMOTE_SHA" ]]; then
+            if [[ "$REMOTE_SHA" == "$HEAD_SHA" ]]; then
+              echo "${TAG} is already on the remote at ${HEAD_SHA} — nothing to do."
+              exit 0
+            fi
+
+            echo "${TAG} already exists on the remote at ${REMOTE_SHA}," >&2
+            echo "but this release built ${HEAD_SHA}." >&2
+            echo "" >&2
+            echo "Refusing to move a published tag. Either delete the remote tag" >&2
+            echo "and dispatch again, or release a new version." >&2
+            exit 1
+          fi
+
+          # Nothing on the remote, so any local tag of that name is a leftover
+          # and safe to overwrite — `Fetch server tags` runs before the version
+          # is even chosen, so it can have brought in a tag that was later
+          # deleted from the remote by hand.
+          git -C packages/server tag -f "$TAG" "$HEAD_SHA"
           git -C packages/server push origin "$TAG"
 
       - name: Create GitHub Release in server repo


### PR DESCRIPTION
Closes GRYT-300.

## What happened

The stable server release on 2026-08-17 got to the end and failed pushing the tag to `Gryt-chat/server`. GitHub was in an unresolved incident from 13:40 UTC with Git Operations degraded, and the run went through the middle of it.

By then the release had already pushed `1.4.4` and `:latest` to GHCR and committed `release.json` to `main`. What it left behind was a published image for a version with no tag, no release page, no Discord post and no self-hosted bundles — those were built and went with the runner.

**A note on the task description:** GRYT-300 says the shape of the failure "points straight at the token". That turned out to be wrong. `Release Server` succeeded on 16 August with the same `RELEASE_PAT`, and `gryt-actions-submodules` runs to May 2027. It was the incident. The fix is the same either way, but the diagnosis in the task is worth not trusting.

## What changed

Neither workflow touches the cross-repo credential until that last step. That is the actual problem — the run cannot discover it will fail until after it has published.

**Fail early.** A new step right after the credential is configured, before Docker and before `release.json`, asks GitHub whether it could push.

It probes the `git-receive-pack` ref advertisement rather than using `ls-remote`. The task suggested `ls-remote`, but that talks to `upload-pack` and only proves the credential can *read* — a token that has lost its write scope still answers it. `git-receive-pack` is what a real push authorises against, and asking for its advertisement changes nothing on the remote.

**Make the tag idempotent.** `Tag server repo` did a bare `git tag` + push, so re-dispatching a version that already got this far failed on "tag already exists" under `set -euo pipefail`. Everything else in that path already tolerates a retry — the Docker push overwrites, the zips get rebuilt — so this step was the odd one out. It now accepts a tag that already names the built commit and refuses one naming a different commit, rather than force-moving a tag people may have fetched. The client's superproject tag gets the same treatment.

## Worth looking at

- **The probe's HTTP mapping** is the part I'd check first. Verified against real repos: `200` where the token can push, `403` read-only, `404` for a repo it can't see. `401`/`403` fail immediately; everything else retries three times, on the theory that a definite no won't become a yes but a blip might.
- **`404` retries three times before failing.** Arguably it should fail fast, but a 404 can also mean the token can't see the repo, so I left it in the retry path. Costs 30s in a case that's already broken.
- **This narrows the window, it does not close it.** GitHub can still fall over between the check and the push twenty minutes later. What it removes is the run that was never going to finish.
- **The probe function is duplicated across both workflows** rather than extracted into a composite action. That matches how the retry loops from GRYT-212 are already duplicated in this file; extracting all of it is a bigger change than this one should carry.
- I could not exercise this against a real GitHub outage, so the `000`/timeout path is tested with a stubbed `curl`, not observed in production.

## Testing

- Both files parse as YAML; every `run:` block passes `bash -n`.
- Probe branching, with a stubbed `curl`: `200` → pass, `401`/`403` → immediate fail, `000` → three attempts then fail.
- Tag logic against a real temp repo, all three cases: no tag on remote → creates and pushes; tag already at the built commit → no-op, exit 0; tag at a different commit → refuses, exit 1.

## Consequence for the half-finished 1.4.4

The recovery in the 2026-08-17 handoff said to delete the remote `v1.4.4` tag before re-dispatching. With this merged that is no longer needed — `bump=none` will find the tag already pointing at the right commit and carry on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
