### PR TITLE
Share the push-access preflight between the two releases (GRYT-302)

### DIFF
--- a/.github/actions/verify-push-access/action.yml
+++ b/.github/actions/verify-push-access/action.yml
@@ -1,0 +1,93 @@
+name: Verify push access
+description: >
+  Check that the credentials a release will need can actually push, before the
+  release publishes anything.
+
+inputs:
+  repository:
+    description: The other repository this release pushes to, e.g. Gryt-chat/client.
+    required: true
+  token:
+    description: Credential for `repository`, normally secrets.RELEASE_PAT.
+    required: true
+  monorepo:
+    description: The superproject this release commits to, normally github.repository.
+    required: true
+  monorepo-token:
+    description: Credential for `monorepo`, normally github.token.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+        TOKEN: ${{ inputs.token }}
+        MONOREPO: ${{ inputs.monorepo }}
+        MONOREPO_TOKEN: ${{ inputs.monorepo-token }}
+      run: |
+        set -euo pipefail
+
+        # Both release workflows publish something well before they first push
+        # to the other repository. `Release Server` died on exactly that push on
+        # 2026-08-17, during a GitHub incident with Git Operations degraded, and
+        # left 1.4.4 on GHCR with no tag, no release page and no self-hosted
+        # bundles. `Release Client` has more to lose: installers for three
+        # platforms and a push to the Snap Store. GRYT-300.
+        #
+        # `ls-remote` would not have caught it. That talks to upload-pack, so it
+        # only proves the credential can read, and a token that has lost its
+        # write scope still answers it happily. Push is authorised against
+        # git-receive-pack, so ask that service for its ref advertisement
+        # instead: the same request a real push starts with, and it changes
+        # nothing on the remote.
+        #
+        # This narrows the window rather than closing it. GitHub can still fall
+        # over between here and the push later in the run. What it removes is
+        # the run that was never going to finish, and that run is now a no-op
+        # instead of a half-release.
+        probe() {
+          local repo="$1" token="$2" code attempt
+
+          for attempt in 1 2 3; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+              -u "x-access-token:${token}" \
+              "https://github.com/${repo}.git/info/refs?service=git-receive-pack" \
+              || echo 000)
+
+            case "$code" in
+              200)
+                echo "  ${repo}: can push"
+                return 0
+                ;;
+              401 | 403)
+                # A definite no. Retrying will not turn it into a yes.
+                echo "  ${repo}: credential is not allowed to push (HTTP ${code})" >&2
+                return 1
+                ;;
+              *)
+                echo "  ${repo}: no usable answer (HTTP ${code}), attempt ${attempt}/3" >&2
+                sleep $(( attempt * 5 ))
+                ;;
+            esac
+          done
+
+          echo "  ${repo}: could not confirm push access" >&2
+          return 1
+        }
+
+        failed=0
+        probe "$REPOSITORY" "$TOKEN" || failed=1
+        probe "$MONOREPO" "$MONOREPO_TOKEN" || failed=1
+
+        if (( failed )); then
+          echo "" >&2
+          echo "Stopping before anything is published." >&2
+          echo "" >&2
+          echo "Check https://www.githubstatus.com first. If Git Operations are" >&2
+          echo "degraded then this is not the credential, and the fix is to wait" >&2
+          echo "and dispatch again. If GitHub is healthy, the credential has" >&2
+          echo "expired or lost write access to the repo named above." >&2
+          exit 1
+        fi

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -114,75 +114,12 @@ jobs:
           git -C packages/client remote set-url origin "https://x-access-token:${RELEASE_PAT}@github.com/Gryt-chat/client.git"
 
       - name: Verify push access before anything is published
-        shell: bash
-        env:
-          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
-          MONOREPO_TOKEN: ${{ github.token }}
-          MONOREPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # `Release Server` died on its last push during the GitHub incident on
-          # 2026-08-17 and left an image on GHCR for a version with no tag and
-          # no release page. This workflow uses the same credential at the same
-          # kind of step, and has more to lose: installers for three platforms
-          # and a push to the Snap Store. GRYT-300.
-          #
-          # `ls-remote` would not have caught it. That talks to upload-pack, so
-          # it only proves the credential can read, and a token that has lost
-          # its write scope still answers it happily. Push is authorised
-          # against git-receive-pack, so ask that service for its ref
-          # advertisement instead — same request a real push starts with, and
-          # it changes nothing on the remote.
-          #
-          # This narrows the window rather than closing it. GitHub can still
-          # fall over later in the run. What it does remove is the run that was
-          # never going to finish — an expired credential, or a GitHub that is
-          # already unhealthy — and that run is now a no-op.
-          probe() {
-            local repo="$1" token="$2" code attempt
-
-            for attempt in 1 2 3; do
-              code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
-                -u "x-access-token:${token}" \
-                "https://github.com/${repo}.git/info/refs?service=git-receive-pack" \
-                || echo 000)
-
-              case "$code" in
-                200)
-                  echo "  ${repo}: can push"
-                  return 0
-                  ;;
-                401 | 403)
-                  # A definite no. Retrying will not turn it into a yes.
-                  echo "  ${repo}: credential is not allowed to push (HTTP ${code})" >&2
-                  return 1
-                  ;;
-                *)
-                  echo "  ${repo}: no usable answer (HTTP ${code}), attempt ${attempt}/3" >&2
-                  sleep $(( attempt * 5 ))
-                  ;;
-              esac
-            done
-
-            echo "  ${repo}: could not confirm push access" >&2
-            return 1
-          }
-
-          failed=0
-          probe "Gryt-chat/client" "$RELEASE_PAT" || failed=1
-          probe "$MONOREPO" "$MONOREPO_TOKEN" || failed=1
-
-          if (( failed )); then
-            echo "" >&2
-            echo "Stopping before anything is published." >&2
-            echo "" >&2
-            echo "Check https://www.githubstatus.com first. If Git Operations are" >&2
-            echo "degraded then this is not the credential, and the fix is to wait" >&2
-            echo "and dispatch again. If GitHub is healthy, RELEASE_PAT has expired" >&2
-            echo "or lost write access to the repo named above." >&2
-            exit 1
-          fi
+        uses: ./.github/actions/verify-push-access
+        with:
+          repository: Gryt-chat/client
+          token: ${{ secrets.RELEASE_PAT }}
+          monorepo: ${{ github.repository }}
+          monorepo-token: ${{ github.token }}
 
       - name: Move release submodules into place
         shell: bash

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -120,78 +120,12 @@ jobs:
           git -C packages/server remote set-url origin "https://x-access-token:${RELEASE_PAT}@github.com/Gryt-chat/server.git"
 
       - name: Verify push access before anything is published
-        shell: bash
-        env:
-          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
-          MONOREPO_TOKEN: ${{ github.token }}
-          MONOREPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # This run pushes an image to GHCR and commits release.json to the
-          # monorepo long before it first pushes to Gryt-chat/server, and that
-          # last push is the step that failed on 2026-08-17, during a GitHub
-          # incident with Git Operations degraded. What it left behind was
-          # 1.4.4 on GHCR with no tag, no release page and no self-hosted
-          # bundles — a version that exists as an image and nowhere else.
-          # GRYT-300.
-          #
-          # `ls-remote` would not have caught it. That talks to upload-pack, so
-          # it only proves the credential can read, and a token that has lost
-          # its write scope still answers it happily. Push is authorised
-          # against git-receive-pack, so ask that service for its ref
-          # advertisement instead — same request a real push starts with, and
-          # it changes nothing on the remote.
-          #
-          # This narrows the window rather than closing it. GitHub can still
-          # fall over between here and the tag push twenty minutes later. What
-          # it does remove is the run that was never going to finish — an
-          # expired credential, or a GitHub that is already unhealthy — and
-          # that run is now a no-op instead of a half-release.
-          probe() {
-            local repo="$1" token="$2" code attempt
-
-            for attempt in 1 2 3; do
-              code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
-                -u "x-access-token:${token}" \
-                "https://github.com/${repo}.git/info/refs?service=git-receive-pack" \
-                || echo 000)
-
-              case "$code" in
-                200)
-                  echo "  ${repo}: can push"
-                  return 0
-                  ;;
-                401 | 403)
-                  # A definite no. Retrying will not turn it into a yes.
-                  echo "  ${repo}: credential is not allowed to push (HTTP ${code})" >&2
-                  return 1
-                  ;;
-                *)
-                  echo "  ${repo}: no usable answer (HTTP ${code}), attempt ${attempt}/3" >&2
-                  sleep $(( attempt * 5 ))
-                  ;;
-              esac
-            done
-
-            echo "  ${repo}: could not confirm push access" >&2
-            return 1
-          }
-
-          failed=0
-          probe "Gryt-chat/server" "$RELEASE_PAT" || failed=1
-          probe "$MONOREPO" "$MONOREPO_TOKEN" || failed=1
-
-          if (( failed )); then
-            echo "" >&2
-            echo "Stopping before anything is published." >&2
-            echo "" >&2
-            echo "Check https://www.githubstatus.com first. If Git Operations are" >&2
-            echo "degraded then this is not the credential, and the fix is to wait" >&2
-            echo "and dispatch again. If GitHub is healthy, RELEASE_PAT has expired" >&2
-            echo "or lost write access to the repo named above." >&2
-            exit 1
-          fi
+        uses: ./.github/actions/verify-push-access
+        with:
+          repository: Gryt-chat/server
+          token: ${{ secrets.RELEASE_PAT }}
+          monorepo: ${{ github.repository }}
+          monorepo-token: ${{ github.token }}
 
       - name: Move release submodules to their main
         shell: bash


### PR DESCRIPTION
Closes GRYT-302.

GRYT-300 added the same ~70-line push-access check to both release workflows. Diffing them, the only functional difference was **one line** — the repository being probed. Everything else that differed was comments.

Now a composite action, called from both. **141 lines out, 12 in.**

## Local, not `Gryt-chat/.github`

The task worried that extracting this would make a release depend on another repo resolving at dispatch time, which is one more thing that can be down during exactly the incident GRYT-300 is about.

That concern does not apply to an action inside this repo. It arrives with the checkout that already runs first in both jobs — verified as step 0 with the default ref in each, so the file is on disk before the step runs.

## What I did not extract, and why

Measured rather than assumed:

| | lines | shared |
|---|---|---|
| client `Commit release metadata and tag` | 103 | 39 |
| server `Commit monorepo release state` | 61 | 39 |

48% similar. The client's version also backs up the manifest, tags, and stages four submodule paths. A shared version is a parameter list neither side wants to read, so the retry loops stay inline.

The **Snap Store credential** is unchanged too. It is the same shape of problem — a credential first exercised after something is published — but checking it early means installing snapcraft in `prepare-release` on every release, for a failure whose worst case is a published release missing its snap and a re-run to fix it. Recorded rather than silently dropped.

## Worth looking at

- **`release-server.yml` is CRLF and `release-client.yml` is LF.** My first attempt at this edit normalised the server file and rewrote all 1778 lines, burying the actual change. Caught it on the diff stat. Redone with line endings preserved; the diff is 12 insertions and 141 deletions. Worth knowing before anyone else edits that file.
- The action takes four inputs (`repository`, `token`, `monorepo`, `monorepo-token`) rather than a list, so each credential stays a distinct secret reference.

## Testing

- All three files parse as YAML; every `run:` block across both workflows passes `bash -n`.
- The extracted action tested with a stubbed `curl`, and it behaves exactly as the inline version did: `200` → exit 0, `401`/`403` → immediate fail, `000` → three attempts then fail.
- Not exercised in a real dispatch. The first release after this merges is the real test, and a failure there is a clean no-op by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
