### PR TITLE
Hand the snap over and stop watching it (GRYT-310)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1339,11 +1339,12 @@ jobs:
     # release red.
     continue-on-error: true
 
-    # Previous Gryt Store reviews have approached/exceeded the old 90-minute
-    # limit. Give Canonical enough room to finish a legitimately slow automated
-    # review, while still preventing a genuinely wedged process from occupying
-    # a runner indefinitely.
-    timeout-minutes: 180
+    # A backstop, not the mechanism. The upload step below stops waiting on its
+    # own well before this, so reaching 25 minutes means something is wrong
+    # rather than merely slow. The old value was 180, and on 2026-08-17 a run
+    # sat here for three hours polling the Store once a second before it was
+    # cancelled.
+    timeout-minutes: 25
 
     env:
       OWNER: Gryt-chat
@@ -1380,6 +1381,9 @@ jobs:
         shell: bash
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          # Long enough that a ~100MB upload finishes on a slow runner, short
+          # enough that we are not paying to watch a review queue.
+          WAIT_SECONDS: "600"
         run: |
           set -euo pipefail
 
@@ -1397,20 +1401,54 @@ jobs:
           fi
 
           echo "Uploading $SNAP to latest/stable."
-          echo
-          echo "NOTE:"
-          echo "  Snapcraft waits for the Snap Store to process/review the upload."
-          echo "  Gryt uploads have previously spent tens of minutes in this step."
-          echo "  A quiet/long-running command here does not by itself mean it is stuck."
-          echo
 
-          # Verbose Store diagnostics are intentional. The previous command
-          # could sit silently for an hour and leave us with almost nothing to
-          # distinguish a slow Store review from an actual network/API failure.
-          snapcraft upload \
-            --release=stable \
-            --verbosity=debug \
-            "$SNAP"
+          # Hand the snap over, then stop caring.
+          #
+          # `snapcraft upload` blocks until the Store finishes its automated
+          # review and has no flag to return early. Gryt reviews have taken 25
+          # and 77 minutes, and on 2026-08-17 one polled the Store once a second
+          # for three hours before the job was cancelled, writing about 28000
+          # lines of HTTP GET on the way.
+          #
+          # Waiting buys nothing. `--release=stable` is honoured by the Store
+          # rather than by this client: the snap is released to the channel if
+          # the review passes, whether or not anyone is still watching. Nothing
+          # downstream depends on it either, since the .snap is already attached
+          # to the GitHub release.
+          #
+          # --verbosity=debug went with it. It was there to tell a slow review
+          # apart from a hung one, which is a question we have stopped asking.
+          set +e
+          timeout --signal=INT "$WAIT_SECONDS" \
+            snapcraft upload --release=stable "$SNAP" 2>&1 | tee upload.log
+          rc=${PIPESTATUS[0]}
+          set -e
 
-          echo
-          echo "Snap Store upload/release completed successfully."
+          if [[ $rc -eq 0 ]]; then
+            echo
+            echo "Store finished while we watched. Released to latest/stable."
+            exit 0
+          fi
+
+          # Timing out is the expected path for a slow review, but only if the
+          # upload itself landed. Otherwise there is nothing for the Store to
+          # review and exiting 0 would hide a real failure.
+          #
+          # The Store hands back a build to poll once it has accepted the file,
+          # so any status line at all is proof the upload completed.
+          if [[ $rc -eq 124 ]] && grep -qiE 'Status: (processing|reviewing)|Revision [0-9]+ created' upload.log; then
+            echo
+            echo "Stopped waiting after ${WAIT_SECONDS}s. The upload landed and the Store is"
+            echo "still reviewing it; it releases to latest/stable on its own from here."
+            echo "Check https://snapcraft.io/gryt/releases if it never appears."
+            exit 0
+          fi
+
+          if [[ $rc -eq 124 ]]; then
+            echo "::error::Gave up after ${WAIT_SECONDS}s without the upload being accepted."
+            echo "No revision or status line in the output, so the file never reached the Store."
+            exit 1
+          fi
+
+          echo "::error::snapcraft upload failed with exit code $rc."
+          exit $rc


### PR DESCRIPTION
The 2026-08-17 release polled the Snap Store once a second **for three hours**, then was cancelled, having written roughly 28000 lines of `HTTP 'GET' … Status: processing` and nothing else.

## Two causes

`snapcraft upload` blocks until the Store finishes its automated review and has no flag to return early, so this job's only real control is how long it is willing to wait. It was willing to wait **180 minutes**.

`--verbosity=debug` produced the volume. It was added to tell a slow review apart from a hung one — a question worth dropping rather than answering, since the answer never changed what we did next.

## Waiting was never buying anything

From the [snapcraft docs](https://ubuntu.com/docs/snapcraft/stable/reference/commands/upload/):

> By passing `--release` with a comma-separated list of channels the snap **would be released to the selected channels if the store review passes**

So the channel move is performed by the Store, not by this client. It happens whether or not a runner is still watching. The `.snap` is already attached to the GitHub release by the time this job runs, and nothing downstream depends on it — the job is already `continue-on-error: true` for exactly that reason.

## The change

Wait ten minutes, then leave. `timeout-minutes` drops from 180 to 25, as a backstop rather than the mechanism.

Leaving early must not paper over an upload that never landed, so the exit code is read rather than assumed. The Store hands back a build to poll once it has accepted the file, so a status or revision line in the output is proof it arrived:

| outcome | result |
|---|---|
| `rc=0` | success, Store finished while we watched |
| `rc=124` + `Status: processing` | success, landed; Store finishes the release alone |
| `rc=124` + `Revision 42 created` | success, same |
| `rc=124` + nothing useful | **fails the step** — the file never reached the Store |
| `rc=2` | propagated |

## Worth looking at

- **The 600s wait is a guess at "long enough to finish a ~100MB upload on a slow runner"**. If a real upload ever takes longer than that, the marker check turns it into a loud failure rather than a silent one, which is the right way round — but the number may want tuning once we see a few runs.
- **The marker patterns** (`Status: processing|reviewing`, `Revision N created`) are matched against snapcraft's normal-verbosity output. Taken from the log you pasted, but if snapcraft changes its wording a slow review starts failing the step. That is the fragile part.
- `PIPESTATUS[0]` is bash-specific; the step is already `shell: bash`.

## Testing

`bash -n` on the step, and every branch exercised against an injected exit code — neither snapcraft nor GNU `timeout` exists on macOS, so a stubbed end-to-end run was not meaningful. The table above is that test's output.

Not exercised in a real release. The next stable release is the real test, and by design a failure here cannot turn the release red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
