### PR TITLE
Mention the CLI under Self-Hosting (GRYT-321)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@
 
 See the **[Quick Start guide](https://docs.gryt.chat/docs/guide/quick-start)** to self-host Gryt with Docker Compose — two files, one command, no cloning required.
 
+Or manage servers from a terminal with the **[Gryt CLI](https://docs.gryt.chat/docs/cli)**, which writes the compose file for you:
+
+```bash
+curl -fsSL https://get.gryt.chat | sh
+```
+
 ## Development
 
 ```bash


### PR DESCRIPTION
The Self-Hosting section named Docker Compose as the only route. The CLI is now a second one, and this README is where most people arrive first.

Adds the one-line install and a link to [the docs page](https://docs.gryt.chat/docs/cli).

Last of GRYT-321. The others: [CLI README](https://github.com/Gryt-chat/cli/pull/4), [docs deployment list](https://github.com/Gryt-chat/docs/pull/32), [org profile](https://github.com/Gryt-chat/.github/pull/16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)