### PR TITLE
Add packages/voice as a submodule (GRYT-334)

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -36,6 +36,7 @@ on:
           - auth
           - ui
           - cli
+          - voice
 
 permissions:
   contents: write
@@ -89,7 +90,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli"
+          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice"
 
           # Clone straight from the URL rather than `git submodule update`,
           # which insists on the recorded gitlink and so fails on a broken one.
@@ -186,6 +187,10 @@ jobs:
             update_submodule "packages/cli" "$DEFAULT_SUBMODULE_BRANCH"
           fi
 
+          if [[ "$SELECTED" == "all" || "$SELECTED" == "voice" ]]; then
+            update_submodule "packages/voice" "$DEFAULT_SUBMODULE_BRANCH"
+          fi
+
       - name: Commit changes
         shell: bash
         run: |
@@ -216,7 +221,7 @@ jobs:
             git fetch origin "$TARGET_BRANCH"
             git reset --hard "origin/$TARGET_BRANCH"
 
-            for path in packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli; do
+            for path in packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice; do
               [[ -d "$path" ]] || continue
               git -C "$path" fetch origin main
               git -C "$path" checkout -B main origin/main

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,7 @@
 	path = packages/cli
 	url = https://github.com/Gryt-chat/cli.git
 	branch = main
+[submodule "packages/voice"]
+	path = packages/voice
+	url = https://github.com/Gryt-chat/voice.git
+	branch = main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Working rules for Gryt
 
 Gryt is a WebRTC voice chat platform maintained by one person. It's a superproject with
-eight git submodules under `packages/`. Read these rules before making changes.
+ten git submodules under `packages/`. Read these rules before making changes.
 
 ## Review-required paths
 


### PR DESCRIPTION
`Gryt-chat/voice` exists and needs wiring in before the extraction has anywhere to land.

## The bit worth checking

`update-submodules.yml` enumerates the submodule list in **four separate places**, and misses none of them loudly — a path in the dispatch options but not in `SUBMODULES` simply never updates, and nothing says so. All four now carry `voice`:

| line | what |
|---|---|
| 39 | `workflow_dispatch` choices |
| 93 | `SUBMODULES` |
| 190 | its own `update_submodule` block |
| 224 | the re-apply loop in the push retry |

## A stale count fixed on the way past

`CLAUDE.md` said **eight** submodules. That was already wrong before this PR — `cli` was added and the count never followed — so it now reads **ten** rather than nine.

## Deliberately not touched

`release-client.yml` and `release-server.yml` both list the submodules they check out to build. `voice` does not belong there: submodules are not path dependencies in this repo, each one's CI builds alone, and the client will consume `@gryt/voice` from npm. Adding it to the release checkout would clone a package the build never reads.

## Testing

YAML parses, every `run:` block passes `bash -n`. The gitlink points at `627ecec` — README, AGPL licence and the Vikunja workflow. No code yet; [voice#1](https://github.com/Gryt-chat/voice/pull/1) carries the interfaces and is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
