### PR TITLE
Say that Gryt does video (GRYT-352)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
 
 ## Features
 
-- Crystal-clear voice chat powered by WebRTC with Opus codec
+- Voice chat over WebRTC with the Opus codec
+- Video chat from your camera
 - Screen sharing with audio capture
 - Text chat with Markdown, mentions, and file sharing
 - Self-hostable with Docker Compose


### PR DESCRIPTION
The features list led with voice, mentioned screen sharing, and never mentioned the camera. Video has shipped for a long time — the client has a camera preview and a focused video view, the SFU forwards camera tracks, and the comparison table on gryt.chat already has a "Video and webcam" row.

```diff
-- Crystal-clear voice chat powered by WebRTC with Opus codec
-- Screen sharing with audio capture
+- Voice chat over WebRTC with the Opus codec
+- Video chat from your camera
+- Screen sharing with audio capture
```

Also drops "Crystal-clear" — the kind of adjective a reader discounts, and the two lines under it carry the actual news now.

## Already done, outside a PR

Repository and organisation descriptions aren't versioned, so I've updated them directly:

| Where | Was | Is |
|---|---|---|
| Org | "voice and text chat" | "voice, video and text chat" |
| `gryt` | "voice and text chat over WebRTC" | "voice, video and text chat over WebRTC" |
| `sfu` | "Relays **audio** between participants" | "Relays voice, camera and screen share" |
| `client` | noise suppression and VAD only | leads with voice, camera and screen share |

**The `sfu` one was the worst.** It wasn't just incomplete — its own README says "Forwards audio, camera, and screen-share tracks", so the repo contradicted itself on its own front page.

## Left alone deliberately

The site's meta tags, the Hero lede ("Voice, text and video on hardware you control") and the comparison table already say it. The org profile README and one site meta description still don't — separate PRs, since they're separate repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)