### PR TITLE
Rebuild the sites built from source when their source moves (GRYT-360)

### DIFF
--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -161,3 +161,82 @@ lives on.
 
 The rest of the `gryt-prod` stack — server, SFU, image worker — is deliberately **not** in
 scope. Those carry data, and rolling them forward is a decision rather than a cron job.
+
+## Keeping the sites built from source current
+
+`docs.gryt.chat`, `gryt.chat` and `ui.gryt.chat` have the opposite problem. They are not
+images anybody pushed, they are the `build:` contexts above pointing at the `docs`, `site`
+and `ui` submodules, so merging a pull request changes nothing that is running until
+somebody rebuilds by hand. That is how the `@gryt/voice` documentation could merge and
+`docs.gryt.chat` still not have it (GRYT-360).
+
+[`refresh-sites.sh`](refresh-sites.sh) is the same idea as the web client refresh with a
+different question to ask. There is no registry to check a digest against, so it fetches
+each submodule and rebuilds the ones whose commit has moved:
+
+```bash
+ops/internal/refresh-sites.sh
+```
+
+A quiet ten minutes costs one `git fetch` per repository and nothing else. When something
+has moved it fast-forwards that submodule, runs `docker compose build` for that one
+service, and `up -d --no-deps` it.
+
+What it will not do:
+
+- It never runs a bare `up -d`. Fider and its Postgres are in the same compose file, and a
+  timer has no business recreating a database.
+- It leaves a submodule alone if it has tracked local modifications, rather than discarding
+  them. Untracked files are ignored, since these checkouts are full of `node_modules` and
+  build output and would otherwise read as permanently dirty.
+- It only refreshes a container that is already running, for the same reason the web client
+  script does: it does not know what a missing one was supposed to look like.
+- It refuses to build below 20GB free. Higher than the web client's 10, because these run
+  real builds rather than pulling a 30MB nginx image, and the disk is the one Keycloak
+  lives on.
+
+Neither the service list nor the source directories are written down in the script. The
+compose files, their order and the env file come off the running container's labels, and
+each service's build context comes out of the merged compose config, so moving a submodule
+is not also an edit here.
+
+The one thing it does keep on the machine is what it last built, one file per service under
+`/var/lib/gryt-sites-refresh`. There is no registry to ask, so the answer has to be written
+down somewhere. A missing file counts as unknown rather than as current, which means the
+first run after installing this rebuilds all three. That is the right answer anyway, since
+the running containers are of unknown vintage until something has built them.
+
+Five environment variables, none of them required:
+
+| | |
+|---|---|
+| `GRYT_SITES` | compose services to rebuild, space separated. Default `docs site ui` |
+| `GRYT_SITES_PROJECT` | the compose project they belong to. Default `internal`, so service `docs` is the container `internal-docs-1` |
+| `GRYT_SITES_BRANCH` | the branch to follow in each submodule. Default `main` |
+| `GRYT_SITES_STATE` | where the commit last built is remembered. Default `/var/lib/gryt-sites-refresh` |
+| `GRYT_MIN_FREE_GB` | refuse to build below this much free disk. Default `20` |
+
+It follows each submodule's own `origin/main` rather than the gitlink the superproject
+records. The gitlink lags behind `update-submodules.yml`, and none of these three sites has
+any reason to wait for a superproject bump. If you want them pinned to the gitlink instead,
+that is a different script rather than a flag.
+
+### Installing the timer
+
+```bash
+sudo ln -sfn "$PWD/ops/internal/refresh-sites.sh" /usr/local/bin/gryt-sites-refresh
+sudo cp ops/internal/systemd/gryt-sites-refresh.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now gryt-sites-refresh.timer
+```
+
+Same shape as the web client timer, including the symlink and the root-by-default. It fires
+every ten minutes with a randomised delay offset from that one, so a build and an image pull
+do not routinely land on the Docker daemon together. `TimeoutStartSec` is an hour rather
+than ten minutes, because three builds from a cold layer cache take a while.
+
+Read what it did with `sudo journalctl -u gryt-sites-refresh -n 50`. The `sudo` matters for
+the same reason it does above.
+
+The first run rebuilds all three and will take a few minutes. After that, most runs print
+three `already on <commit>` lines and stop.

--- a/ops/internal/refresh-sites.sh
+++ b/ops/internal/refresh-sites.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Rebuild the sites that are built from source when their source moves.
+#
+# docs.gryt.chat, gryt.chat and ui.gryt.chat are not images somebody pushed.
+# They are `build:` contexts in ops/internal/docker-compose.yml pointing at the
+# docs, site and ui submodules, so merging a pull request changes nothing that
+# is running until a person SSHes in and rebuilds. Merging the @gryt/voice
+# documentation and finding docs.gryt.chat unchanged afterwards is what
+# prompted this (GRYT-360).
+#
+# refresh-web-client.sh is the same idea for app.gryt.chat, and it can just ask
+# GHCR whether the digest moved. There is no registry to ask here, so this
+# fetches each submodule instead and remembers what it last built.
+#
+# Run from the systemd timer beside this script. Safe to run by hand.
+#
+# Deliberately narrow, for the same reasons as the web client script. It builds
+# and recreates one named service at a time, never a bare `up -d`: the same
+# compose file defines Fider and its Postgres, and a timer has no business
+# recreating a database. It only refreshes containers that are already running,
+# because it does not know what a missing one was supposed to look like.
+#
+# Environment:
+#   GRYT_SITES         compose services to refresh, space separated.
+#                      Default "docs site ui".
+#   GRYT_SITES_PROJECT compose project the containers belong to.
+#                      Default "internal".
+#   GRYT_SITES_BRANCH  branch to follow in each submodule. Default "main".
+#   GRYT_SITES_STATE   where to remember the commit last built per service.
+#                      Default /var/lib/gryt-sites-refresh.
+#   GRYT_MIN_FREE_GB   refuse to build below this much free disk. Default 20.
+
+set -euo pipefail
+
+SITES="${GRYT_SITES:-docs site ui}"
+PROJECT="${GRYT_SITES_PROJECT:-internal}"
+BRANCH="${GRYT_SITES_BRANCH:-main}"
+STATE_DIR="${GRYT_SITES_STATE:-/var/lib/gryt-sites-refresh}"
+
+# Higher than the web client's 10. That one pulls a 30MB nginx image; these run
+# a Next.js and a Bun build inside Docker, which wants room for a node_modules
+# tree and a layer cache. The disk it would be filling is the one the Keycloak
+# database sits on.
+MIN_FREE_GB="${GRYT_MIN_FREE_GB:-20}"
+
+log() { printf '%s  %s\n' "$(date -Is)" "$*"; }
+
+label() {
+  docker inspect --format "{{index .Config.Labels \"com.docker.compose.$2\"}}" "$1" 2>/dev/null || true
+}
+
+# The source directory for a service, taken from the merged compose config
+# rather than from a table in here. A map of service to submodule would be a
+# second place to change when one of them moves, and it would be the place
+# nobody remembers.
+build_context() {
+  docker compose "${@:2}" config --format json 2>/dev/null |
+    python3 -c '
+import json, sys
+service = sys.argv[1]
+config = json.load(sys.stdin)
+build = config.get("services", {}).get(service, {}).get("build") or {}
+print(build.get("context", ""))
+' "$1"
+}
+
+refresh() {
+  local service="$1"
+  local container="${PROJECT}-${service}-1"
+  local -a args=()
+  local config_files env_file working_dir f free_gb
+  local context repo head target built state
+
+  # Same trick as refresh-web-client.sh: the overlay list and its order decide
+  # what the merged config is, so anything other than what the stack actually
+  # came up with would make `up` recreate the container every ten minutes.
+  config_files=$(label "$container" "project.config_files")
+  if [[ -z "$config_files" ]]; then
+    log "[$service] no container named $container — skipped"
+    return 0
+  fi
+
+  working_dir=$(label "$container" "project.working_dir")
+  env_file=$(label "$container" "project.environment_file")
+
+  [[ -n "$env_file" ]] && args+=(--env-file "$env_file")
+
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    if [[ ! -f "$f" ]]; then
+      log "[$service] $f is gone since the stack came up — skipped"
+      return 1
+    fi
+    args+=(-f "$f")
+  done < <(tr ',' '\n' <<<"$config_files")
+
+  context=$(build_context "$service" "${args[@]}")
+  if [[ -z "$context" || ! -d "$context" ]]; then
+    log "[$service] no build context in the compose config — skipped"
+    return 1
+  fi
+
+  if ! repo=$(git -C "$context" rev-parse --show-toplevel 2>/dev/null); then
+    log "[$service] $context is not in a git repository — skipped"
+    return 1
+  fi
+
+  # Tracked changes only. These checkouts collect .next, node_modules and build
+  # output, so a plain porcelain would report every one of them as dirty
+  # forever and this would never run.
+  if [[ -n "$(git -C "$repo" status --porcelain --untracked-files=no)" ]]; then
+    log "[$service] $repo has local modifications — leaving it alone"
+    return 1
+  fi
+
+  if ! git -C "$repo" fetch --quiet origin "$BRANCH"; then
+    log "[$service] fetch failed — leaving the running container alone"
+    return 1
+  fi
+
+  head=$(git -C "$repo" rev-parse HEAD)
+  target=$(git -C "$repo" rev-parse FETCH_HEAD)
+
+  # No registry to ask what is deployed, so the answer is written down. Missing
+  # is treated as unknown rather than as up to date, which means the first run
+  # after installing this rebuilds once. That is the right answer anyway: the
+  # running container is of unknown vintage until something has built it.
+  state="${STATE_DIR}/${service}.commit"
+  built=$(cat "$state" 2>/dev/null || echo unknown)
+
+  if [[ "$built" == "$target" && "$head" == "$target" ]]; then
+    log "[$service] already on ${target:0:12}"
+    return 0
+  fi
+
+  free_gb=$(df -BG --output=avail "${working_dir:-/}" | tail -1 | tr -dc '0-9')
+  if (( free_gb < MIN_FREE_GB )); then
+    log "[$service] only ${free_gb}G free, want ${MIN_FREE_GB}G — refusing to build"
+    return 1
+  fi
+
+  if [[ "$head" != "$target" ]]; then
+    # Both shapes exist on the box: some submodules sit on a tracking branch and
+    # some are detached. Both of these refuse rather than discard anything, so a
+    # checkout that has been moved somewhere on purpose stays where it is.
+    if git -C "$repo" symbolic-ref --quiet HEAD >/dev/null; then
+      if ! git -C "$repo" merge --ff-only --quiet FETCH_HEAD; then
+        log "[$service] cannot fast-forward to ${target:0:12} — skipped"
+        return 1
+      fi
+    elif ! git -C "$repo" checkout --detach --quiet FETCH_HEAD; then
+      log "[$service] cannot check out ${target:0:12} — skipped"
+      return 1
+    fi
+    log "[$service] source ${head:0:12} -> ${target:0:12}"
+  else
+    log "[$service] source is ${target:0:12}, last built ${built:0:12} — rebuilding"
+  fi
+
+  if ! docker compose --progress quiet "${args[@]}" build "$service"; then
+    log "[$service] build failed — leaving the running container alone"
+    return 1
+  fi
+
+  # --no-deps and one named service, so Fider and its Postgres are never in the
+  # way of a documentation change.
+  if ! docker compose --progress quiet "${args[@]}" up -d --no-deps "$service"; then
+    log "[$service] up failed"
+    return 1
+  fi
+
+  # Only after `up` has succeeded. Writing it earlier would record a deploy that
+  # did not happen, and the next run would agree with it.
+  mkdir -p "$STATE_DIR"
+  printf '%s\n' "$target" > "$state"
+
+  log "[$service] deployed ${target:0:12}"
+}
+
+status=0
+for site in $SITES; do
+  refresh "$site" || status=1
+done
+
+# Superseded images are left dangling, the same as in refresh-web-client.sh, and
+# these are bigger. Reclaiming them stays something somebody does while looking
+# at `docker image ls`, because the disk being freed is the one Keycloak is on.
+
+exit "$status"

--- a/ops/internal/systemd/gryt-sites-refresh.env.example
+++ b/ops/internal/systemd/gryt-sites-refresh.env.example
@@ -1,0 +1,24 @@
+# Per-machine settings for gryt-sites-refresh.service.
+# Install to /etc/default/gryt-sites-refresh. Every line is optional, and on the
+# deployment this was written for none of them are needed — the script reads the
+# compose files, their order, the env file and each service's build context off
+# the running container's own labels and the merged compose config.
+
+# Compose services to rebuild, space separated. A service with no running
+# container is skipped.
+#GRYT_SITES=docs site ui
+
+# The compose project the containers belong to. Used to find them: service
+# "docs" in project "internal" is the container internal-docs-1.
+#GRYT_SITES_PROJECT=internal
+
+# The branch to follow in each submodule.
+#GRYT_SITES_BRANCH=main
+
+# Where the commit last built is remembered, one file per service. Has to be
+# writable by whoever the unit runs as.
+#GRYT_SITES_STATE=/var/lib/gryt-sites-refresh
+
+# Refuse to build below this much free disk on the compose project's
+# filesystem.
+#GRYT_MIN_FREE_GB=20

--- a/ops/internal/systemd/gryt-sites-refresh.service
+++ b/ops/internal/systemd/gryt-sites-refresh.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Rebuild docs.gryt.chat, gryt.chat and ui.gryt.chat when their source moves
+Documentation=https://github.com/Gryt-chat/gryt/blob/main/ops/internal/README.md
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+
+# A symlink into the checkout rather than a copy, so `git pull` updates the
+# script and nothing has to be installed again. systemd needs a literal
+# absolute path here, so the symlink is what keeps the unit free of anybody's
+# home directory.
+ExecStart=/usr/local/bin/gryt-sites-refresh
+
+# Optional, and the only file that should know anything about this particular
+# machine. See gryt-sites-refresh.env.example. Nothing in it is needed for the
+# deployment this was written for.
+EnvironmentFile=-/etc/default/gryt-sites-refresh
+
+# Runs as root, which is what a system unit talking to the Docker socket
+# usually does. To run as someone else instead, drop in an override rather than
+# editing this file:
+#
+#   systemctl edit gryt-sites-refresh.service
+#   [Service]
+#   User=youruser
+#   SupplementaryGroups=docker
+#
+# Whoever it runs as also has to be able to write GRYT_SITES_STATE.
+
+# Long, because this builds rather than pulls. A Next.js build from a cold
+# layer cache is minutes, and three of them run in one go. If a build is still
+# going when the timer next fires, systemd leaves the running one alone.
+TimeoutStartSec=3600

--- a/ops/internal/systemd/gryt-sites-refresh.timer
+++ b/ops/internal/systemd/gryt-sites-refresh.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Check the docs, site and ui submodules for new commits every ten minutes
+
+[Timer]
+# Monotonic, so there is no Persistent= here. That setting only does anything
+# for OnCalendar= timers, and a line claiming to catch up missed runs while
+# doing nothing is worse than no line.
+OnBootSec=10min
+OnUnitActiveSec=10min
+
+# Offset from gryt-web-client-refresh, which is also on a ten minute interval.
+# Nothing breaks if they overlap, but a build and an image pull competing for
+# the same Docker daemon and the same disk is worth avoiding for free.
+RandomizedDelaySec=3min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
`refresh-web-client.sh` has kept app.gryt.chat and beta.gryt.chat current since GRYT-291. The three sites built from source on the box had no equivalent, so docs.gryt.chat, gryt.chat and ui.gryt.chat only moved when somebody SSHed in and rebuilt. [GRYT-360](https://tasks.sivert.io/tasks/360).

That is not hypothetical: docs#39 merged and docs.gryt.chat still did not have the `@gryt/voice` documentation, which is what turned this up.

Adds `ops/internal/refresh-sites.sh` plus its unit, timer and env example, and a README section. Same shape as the web client refresh, but there is no registry digest to compare against when the artifact is built on the box, so it fetches each submodule and rebuilds the services whose commit moved.

## Worth a look

**Neither the service list nor the source directories are hardcoded.** Compose files, their order and the env file come off the running container's labels, the same trick and for the same reason as `refresh-web-client.sh`. Each service's build context comes out of `docker compose config --format json`, so a map of service to submodule does not exist to go stale. Cost is a `python3` dependency for the JSON, which the box has.

**It follows each submodule's `origin/main`, not the superproject gitlink.** That means a docs PR is live within ten minutes instead of waiting for `update-submodules.yml`. It also means the box's submodule checkouts move ahead of what main records, which they already do in the other direction. If you would rather they tracked the gitlink, say so and it becomes a different script rather than a flag.

**The state file.** No registry to ask what is deployed, so `/var/lib/gryt-sites-refresh/<service>.commit` records what was last built, written only after `up` succeeds. Missing counts as unknown rather than current, so installing this rebuilds all three once. That is deliberate but it is the one design choice I would most want a second opinion on.

**Both submodule shapes are handled** because both are live on the box right now: docs and site are on `main`, `ui` is detached. Branch gets `merge --ff-only`, detached gets `checkout --detach`. Both refuse rather than discard.

**The dirty check ignores untracked files.** These checkouts carry `node_modules` and `.next`, so a plain `--porcelain` would report them dirty forever and nothing would ever run. Tracked modifications still stop it.

## Behaviour it deliberately does not have

- Never a bare `up -d`. Fider and its Postgres share the compose file.
- Never brings up a container that is not already running.
- Refuses below 20GB free, up from the web client's 10, since these are real builds and it is Keycloak's disk.
- Removes no images. Superseded ones are left dangling, same as the web client script, and these are bigger.

## Verification

I could not run this end to end. Writes on the box are blocked from this session, so the build and `up` paths are untested against the real daemon. What I did check there, read only:

- the labels resolve on `internal-docs-1`: config files, working dir and env file all come back as expected
- `docker compose config --format json` gives `/home/sivert/gryt/packages/{docs,site,ui}` for the three build contexts
- all three checkouts are clean under `--untracked-files=no`, and `ui` is the detached one
- `python3` is at `/usr/bin/python3`

`shellcheck` clean, `bash -n` clean.

**Install note:** the copy of `gryt-web-client-refresh.timer` currently in `/etc/systemd/system/` predates the change that removed `Persistent=true` from it, so it is worth re-copying that one at the same time.

Once installed, the first run is the docs deploy that is currently outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)