### PR TITLE
Run git as the owner of the checkout, not as root (GRYT-361)

### DIFF
--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -200,6 +200,11 @@ compose files, their order and the env file come off the running container's lab
 each service's build context comes out of the merged compose config, so moving a submodule
 is not also an edit here.
 
+The unit runs as root, which is what it needs to reach the Docker socket, but the git calls
+drop to whoever owns each checkout. Git refuses to work inside a repository owned by
+somebody else, and running it as root anyway would leave root-owned objects in that person's
+repository the first time it fetched. Only git changes user; docker stays as root.
+
 The one thing it does keep on the machine is what it last built, one file per service under
 `/var/lib/gryt-sites-refresh`. There is no registry to ask, so the answer has to be written
 down somewhere. A missing file counts as unknown rather than as current, which means the

--- a/ops/internal/refresh-sites.sh
+++ b/ops/internal/refresh-sites.sh
@@ -44,10 +44,57 @@ STATE_DIR="${GRYT_SITES_STATE:-/var/lib/gryt-sites-refresh}"
 # database sits on.
 MIN_FREE_GB="${GRYT_MIN_FREE_GB:-20}"
 
+# systemd's default PATH covers /usr/sbin, but this is also meant to be runnable
+# by hand from a shell where it is not on the path.
+RUNUSER=$(command -v runuser || echo /usr/sbin/runuser)
+[[ -x "$RUNUSER" ]] || RUNUSER=""
+
 log() { printf '%s  %s\n' "$(date -Is)" "$*"; }
 
 label() {
   docker inspect --format "{{index .Config.Labels \"com.docker.compose.$2\"}}" "$1" 2>/dev/null || true
+}
+
+# git, as whoever owns the checkout.
+#
+# The unit runs as root and these repositories belong to the person who cloned
+# them. Since 2.35.2 git refuses to work inside a repository owned by somebody
+# else, and that default is right: it stops root running hooks and config it
+# does not control. Every git call here failed on the first install because of
+# it, and nothing was ever deployed.
+#
+# Dropping to the owner is the way round it that does not give anything up.
+# Marking the paths safe.directory for root would also work, and would leave
+# root-owned objects behind in somebody else's repository the first time it
+# fetched. Only git needs this; docker stays as root, which is what it needs to
+# reach the socket.
+git_in() {
+  local dir="$1"
+  shift
+  local owner
+
+  owner=$(stat -c '%U' "$dir" 2>/dev/null || true)
+
+  # Already the right user, or nothing to go on. Either way, let git speak for
+  # itself rather than guessing.
+  if [[ -z "$owner" || "$owner" == "$(id -un)" ]]; then
+    git -C "$dir" "$@"
+    return
+  fi
+
+  # Not the owner and not able to become anybody. git will refuse, and its own
+  # message about it is better than one made up here.
+  if [[ "$(id -u)" != "0" ]]; then
+    git -C "$dir" "$@"
+    return
+  fi
+
+  if [[ -z "$RUNUSER" ]]; then
+    log "runuser is not installed, so git cannot be run as $owner"
+    return 1
+  fi
+
+  "$RUNUSER" -u "$owner" -- git -C "$dir" "$@"
 }
 
 # The source directory for a service, taken from the merged compose config
@@ -70,7 +117,7 @@ refresh() {
   local container="${PROJECT}-${service}-1"
   local -a args=()
   local config_files env_file working_dir f free_gb
-  local context repo head target built state
+  local context repo head target built state dirty
 
   # Same trick as refresh-web-client.sh: the overlay list and its order decide
   # what the merged config is, so anything other than what the stack actually
@@ -101,26 +148,43 @@ refresh() {
     return 1
   fi
 
-  if ! repo=$(git -C "$context" rev-parse --show-toplevel 2>/dev/null); then
-    log "[$service] $context is not in a git repository — skipped"
+  # Both streams into the variable, so a refusal is reported as what git
+  # actually said. Hiding stderr here turned "dubious ownership" into "not in a
+  # git repository", which pointed at the path when the problem was the user.
+  if ! repo=$(git_in "$context" rev-parse --show-toplevel 2>&1); then
+    log "[$service] cannot read a git repository at $context: $repo"
     return 1
   fi
 
   # Tracked changes only. These checkouts collect .next, node_modules and build
   # output, so a plain porcelain would report every one of them as dirty
   # forever and this would never run.
-  if [[ -n "$(git -C "$repo" status --porcelain --untracked-files=no)" ]]; then
+  #
+  # Checked separately from the emptiness test, because a git that failed also
+  # prints nothing, and "clean" is the one answer a failure must not produce.
+  if ! dirty=$(git_in "$repo" status --porcelain --untracked-files=no 2>&1); then
+    log "[$service] cannot read the state of $repo: $dirty"
+    return 1
+  fi
+
+  if [[ -n "$dirty" ]]; then
     log "[$service] $repo has local modifications — leaving it alone"
     return 1
   fi
 
-  if ! git -C "$repo" fetch --quiet origin "$BRANCH"; then
+  if ! git_in "$repo" fetch --quiet origin "$BRANCH"; then
     log "[$service] fetch failed — leaving the running container alone"
     return 1
   fi
 
-  head=$(git -C "$repo" rev-parse HEAD)
-  target=$(git -C "$repo" rev-parse FETCH_HEAD)
+  # These are called in a `|| status=1` context, where set -e does not apply, so
+  # a failure would otherwise carry on with an empty commit and compare it
+  # against the state file.
+  if ! head=$(git_in "$repo" rev-parse HEAD 2>&1) ||
+     ! target=$(git_in "$repo" rev-parse FETCH_HEAD 2>&1); then
+    log "[$service] cannot resolve commits in $repo — skipped"
+    return 1
+  fi
 
   # No registry to ask what is deployed, so the answer is written down. Missing
   # is treated as unknown rather than as up to date, which means the first run
@@ -144,12 +208,12 @@ refresh() {
     # Both shapes exist on the box: some submodules sit on a tracking branch and
     # some are detached. Both of these refuse rather than discard anything, so a
     # checkout that has been moved somewhere on purpose stays where it is.
-    if git -C "$repo" symbolic-ref --quiet HEAD >/dev/null; then
-      if ! git -C "$repo" merge --ff-only --quiet FETCH_HEAD; then
+    if git_in "$repo" symbolic-ref --quiet HEAD >/dev/null; then
+      if ! git_in "$repo" merge --ff-only --quiet FETCH_HEAD; then
         log "[$service] cannot fast-forward to ${target:0:12} — skipped"
         return 1
       fi
-    elif ! git -C "$repo" checkout --detach --quiet FETCH_HEAD; then
+    elif ! git_in "$repo" checkout --detach --quiet FETCH_HEAD; then
       log "[$service] cannot check out ${target:0:12} — skipped"
       return 1
     fi


### PR DESCRIPTION
`gryt-sites-refresh` has never deployed anything. It failed on its first run and every ten minutes since. [GRYT-361](https://tasks.sivert.io/tasks/361), fixing [#100](https://github.com/Gryt-chat/gryt/pull/100).

```
[docs] /home/sivert/gryt/packages/docs is not in a git repository — skipped
[site] /home/sivert/gryt/packages/site is not in a git repository — skipped
[ui]   /home/sivert/gryt/packages/ui is not in a git repository — skipped
```

That message is wrong, which is the second bug. The service runs as root, the checkouts belong to `sivert`, and git has refused to work inside another user's repository since 2.35.2. `rev-parse --show-toplevel` had its stderr sent to `/dev/null`, so "detected dubious ownership" came out as "not in a git repository" and pointed at the path instead of at the user.

## The fix

Git calls drop to the owner of the checkout through `runuser`. Only the git calls: docker stays as root, which is what it needs for the socket.

`safe.directory` for root was the alternative. It is worse, because root would then also write objects into `sivert`'s repository on the first fetch and leave them owned by root.

Both streams now go into the reported message, so the next failure of this kind reads as itself.

## Also fixed while in here

Two reads that failed quietly:

- The dirty check treated a git failure as a clean tree. Both produce no output, and "clean" is the one answer a failure must not give.
- The `rev-parse` pair is called from a `|| status=1` context, where `set -e` does not apply, so a failure carried on with an empty commit and compared that against the state file.

## Verification

This is the part I got wrong last time, so it is done properly here. Reproduced in a Debian 12 container with a repo owned by another user:

- plain git as root fails with exactly the message the box produced
- `git_in` as root returns the right toplevel
- a commit written through `git_in` leaves `.git` owned by the owner, not root, which is the thing `safe.directory` would not have given
- the already-the-owner path works, for running the script by hand
- the neither-root-nor-owner path surfaces git's own refusal rather than inventing one

`shellcheck` and `bash -n` clean.

Still not run against the real daemon: writes to the box are blocked from this session, so the build and `up` paths remain untested there. Those are the same two compose calls the web client script has been making since GRYT-291.

**After merging, the box needs `git merge --ff-only origin/main` in `~/gryt` before the timer picks this up.** `ExecStart` is a symlink into the checkout, so the script updates with the repo, but nothing updates the repo on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)