### PR TITLE
Back off a build that keeps failing on the same commit (GRYT-364)

### DIFF
--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -211,7 +211,17 @@ down somewhere. A missing file counts as unknown rather than as current, which m
 first run after installing this rebuilds all three. That is the right answer anyway, since
 the running containers are of unknown vintage until something has built them.
 
-Five environment variables, none of them required:
+It also remembers what failed. A build that fails on a given commit will fail on it again,
+and retrying every ten minutes forever costs real CPU for as long as the breakage lasts. So
+the gap between attempts doubles from one interval up to a day, and a commit inside its gap
+is skipped without building. A different commit starts the count over, and a successful
+deploy clears it, so a fix is picked up on the next firing with nothing to clear by hand.
+
+Skipping still exits non-zero. The site is on old source either way, and a unit that went
+green while that was true would hide exactly what this timer exists to stop. What the
+backoff saves is the build, not the red.
+
+Seven environment variables, none of them required:
 
 | | |
 |---|---|
@@ -220,6 +230,8 @@ Five environment variables, none of them required:
 | `GRYT_SITES_BRANCH` | the branch to follow in each submodule. Default `main` |
 | `GRYT_SITES_STATE` | where the commit last built is remembered. Default `/var/lib/gryt-sites-refresh` |
 | `GRYT_MIN_FREE_GB` | refuse to build below this much free disk. Default `20` |
+| `GRYT_RETRY_BASE_SECONDS` | first gap after a failed build, doubling from there. Default `600` |
+| `GRYT_RETRY_CAP_SECONDS` | longest that gap gets. Default `86400` |
 
 It follows each submodule's own `origin/main` rather than the gitlink the superproject
 records. The gitlink lags behind `update-submodules.yml`, and none of these three sites has

--- a/ops/internal/refresh-sites.sh
+++ b/ops/internal/refresh-sites.sh
@@ -44,12 +44,41 @@ STATE_DIR="${GRYT_SITES_STATE:-/var/lib/gryt-sites-refresh}"
 # database sits on.
 MIN_FREE_GB="${GRYT_MIN_FREE_GB:-20}"
 
+# A build that fails on a given commit will fail on it again. Retrying is still
+# worth doing, because some failures are a registry timeout during install
+# rather than a broken Dockerfile, but retrying at the same rate forever is not:
+# a genuinely broken commit cost about 30 seconds of CPU every ten minutes for
+# as long as it stayed broken (GRYT-364).
+#
+# So the gap doubles from one timer interval, up to a cap. Eight failures gets
+# it to roughly a day, which is about when somebody should have noticed anyway.
+RETRY_BASE_SECONDS="${GRYT_RETRY_BASE_SECONDS:-600}"
+RETRY_CAP_SECONDS="${GRYT_RETRY_CAP_SECONDS:-86400}"
+
 # systemd's default PATH covers /usr/sbin, but this is also meant to be runnable
 # by hand from a shell where it is not on the path.
 RUNUSER=$(command -v runuser || echo /usr/sbin/runuser)
 [[ -x "$RUNUSER" ]] || RUNUSER=""
 
 log() { printf '%s  %s\n' "$(date -Is)" "$*"; }
+
+# How long to wait after this many consecutive failures. Doubling, capped.
+# Separate from everything else so it can be checked without a Docker daemon.
+retry_delay() {
+  local attempts="$1"
+  local delay="$RETRY_BASE_SECONDS"
+  local i
+
+  for (( i = 1; i < attempts; i++ )); do
+    delay=$(( delay * 2 ))
+    if (( delay >= RETRY_CAP_SECONDS )); then
+      printf '%s' "$RETRY_CAP_SECONDS"
+      return
+    fi
+  done
+
+  printf '%s' "$delay"
+}
 
 label() {
   docker inspect --format "{{index .Config.Labels \"com.docker.compose.$2\"}}" "$1" 2>/dev/null || true
@@ -118,6 +147,7 @@ refresh() {
   local -a args=()
   local config_files env_file working_dir f free_gb
   local context repo head target built state dirty
+  local failed_state failed_commit attempts first_failed next_try now
 
   # Same trick as refresh-web-client.sh: the overlay list and its order decide
   # what the merged config is, so anything other than what the stack actually
@@ -198,6 +228,23 @@ refresh() {
     return 0
   fi
 
+  # Nothing here is cheap from this point on, so the commit that failed last
+  # time gets checked before the disk, the checkout and the build.
+  failed_state="${STATE_DIR}/${service}.failed"
+  now=$(date +%s)
+  read -r failed_commit attempts first_failed next_try < <(
+    cat "$failed_state" 2>/dev/null || echo "none 0 0 0"
+  )
+
+  if [[ "$failed_commit" == "$target" ]] && (( now < next_try )); then
+    # Still non-zero, so the unit stays failed for as long as the site is stale.
+    # Skipping the build saves the CPU; pretending it succeeded would hide that
+    # a site is sitting on old source, which is the thing this timer exists to
+    # stop happening.
+    log "[$service] ${target:0:12} has failed to build ${attempts}x since $(date -Is -d "@${first_failed}"), next attempt $(date -Is -d "@${next_try}")"
+    return 1
+  fi
+
   free_gb=$(df -BG --output=avail "${working_dir:-/}" | tail -1 | tr -dc '0-9')
   if (( free_gb < MIN_FREE_GB )); then
     log "[$service] only ${free_gb}G free, want ${MIN_FREE_GB}G — refusing to build"
@@ -223,7 +270,20 @@ refresh() {
   fi
 
   if ! docker compose --progress quiet "${args[@]}" build "$service"; then
-    log "[$service] build failed — leaving the running container alone"
+    # A different commit than the one that failed before starts the count again,
+    # so a fix that does not work still gets its own full set of attempts.
+    if [[ "$failed_commit" != "$target" ]]; then
+      attempts=0
+      first_failed="$now"
+    fi
+    attempts=$(( attempts + 1 ))
+
+    mkdir -p "$STATE_DIR"
+    printf '%s %s %s %s\n' \
+      "$target" "$attempts" "$first_failed" "$(( now + $(retry_delay "$attempts") ))" \
+      > "$failed_state"
+
+    log "[$service] build failed (${attempts}x) — leaving the running container alone"
     return 1
   fi
 
@@ -238,6 +298,7 @@ refresh() {
   # did not happen, and the next run would agree with it.
   mkdir -p "$STATE_DIR"
   printf '%s\n' "$target" > "$state"
+  rm -f "$failed_state"
 
   log "[$service] deployed ${target:0:12}"
 }

--- a/ops/internal/systemd/gryt-sites-refresh.env.example
+++ b/ops/internal/systemd/gryt-sites-refresh.env.example
@@ -22,3 +22,9 @@
 # Refuse to build below this much free disk on the compose project's
 # filesystem.
 #GRYT_MIN_FREE_GB=20
+
+# How long to wait before retrying a build that failed, and the longest that
+# gap is allowed to get. The gap doubles from the base on each consecutive
+# failure of the same commit. A new commit, or a successful deploy, resets it.
+#GRYT_RETRY_BASE_SECONDS=600
+#GRYT_RETRY_CAP_SECONDS=86400


### PR DESCRIPTION
`refresh-sites.sh` recorded only what it deployed, so a commit that failed to build was rebuilt on every firing. ui.gryt.chat was in that state for the length of [GRYT-362](https://github.com/Gryt-chat/ui/pull/66): about 30 seconds of CPU every ten minutes, failing at the same `bun install` line each time. [GRYT-364](https://tasks.sivert.io/tasks/364).

The gap between attempts now doubles from one timer interval up to a day, and a commit inside its gap is skipped without building. A different commit starts the count over, and a successful deploy clears the record, so a fix is picked up on the next firing with nothing to clear by hand.

```
attempts=1  0h10m     attempts=6  5h20m
attempts=2  0h20m     attempts=7 10h40m
attempts=3  0h40m     attempts=8 21h20m
attempts=4  1h20m     attempts=9 24h00m (capped)
attempts=5  2h40m
```

## Worth a look

**Skipping still exits non-zero**, which is the part [GRYT-364](https://tasks.sivert.io/tasks/364) left open and the one real decision here. The task offered "stop the noise by not exiting non-zero when the only failures are builds that already failed". I went the other way: the site is on old source either way, and a unit that went green while that was true would hide precisely what this timer exists to stop. So the backoff saves the build, not the red. The log line carries the count and the first-failure time, which is what actually distinguishes "broken now" from "broken since Tuesday".

If you would rather have a green unit and rely on the journal, it is a one-line change.

**Retrying at all**, rather than giving up on a commit once. A registry timeout during `bun install` is exactly the failure the next firing should get past, and giving up would need a manual `systemctl start` to recover from a network blip.

**Four fields in the state file** (`<commit> <attempts> <first-failure> <next-attempt>`) rather than a commit. `first-failure` is only ever read to print it, and it is the field that makes the log line worth reading.

## Verification

`retry_delay` is a pure function specifically so it can be checked without a Docker daemon. Two levels:

- the schedule directly: 600, 1200, 2400, 4800, 9600, 19200, 38400, 76800, then 86400 from the ninth failure and staying there
- the whole state machine, against a fake `docker` on PATH and a real git repo owned by another user, covering: a first failure recording the commit; a second run inside the gap skipping the build and still exiting 1; an expired gap incrementing to 2; a new commit resetting to 1; a success deploying and clearing the record; and an already-deployed commit doing nothing at all

`shellcheck` and `bash -n` clean.

Not run against the box: writes there are blocked from this session. The paths that touch the real daemon are unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)