### PR TITLE
Stop telling people to move ui's tasks by hand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,10 +115,10 @@ kanban board is the state: **To-Do → Doing → Review → Done**.
 | PR merged | Move to **Done** *and* set the task's done flag | CI |
 
 CI covers the last two through `.github/workflows/vikunja-task-done.yml`, which calls a
-reusable workflow in `Gryt-chat/.github`. Eight of the nine repos have it, so you don't
-normally need to touch a task after opening the PR. `ui` is the exception — it was added
-as a submodule later and still needs the workflow (GRYT-143), so move its tasks by hand
-until that lands.
+reusable workflow in `Gryt-chat/.github`. Every repo has it — the superproject and all ten
+submodules — so you don't normally need to touch a task after opening the PR. There is no
+longer an exception to work around: `ui` was the last one missing it and GRYT-143 landed
+that on 2026-08-11.
 
 Moving a task is not exposed by the Vikunja MCP server, so use the REST API directly:
 


### PR DESCRIPTION
CLAUDE.md's task-tracking section said:

> Eight of the nine repos have it, so you don't normally need to touch a task after opening the PR. `ui` is the exception — it was added as a submodule later and still needs the workflow (GRYT-143), so move its tasks by hand until that lands.

GRYT-143 landed on 2026-08-11. The note outlived it by nine days, and the repo count it quotes predates `voice` and `cli` being added.

Found while opening Gryt-chat/ui#73 — I was about to move GRYT-373 across the board by hand because CLAUDE.md said to, and checked first.

## Verified, not assumed

Every one of the eleven repos has the workflow:

```
gryt  client  server  sfu  auth  docs  site  ui  image-worker  voice  cli
```

(plus `.github`, which holds the reusable workflow itself). And `sync-task / sync` passed on Gryt-chat/ui#73 while this was being written, moving GRYT-373 to Review with no help from me.

The "ten git submodules" count in the intro was already corrected on main separately; this was the other place the old number survived.

## Also checked while here, and left alone

- The review-required path list and [`guide/ai.mdx`](https://github.com/Gryt-chat/docs/blob/main/content/docs/guide/ai.mdx) still agree exactly — CLAUDE.md calls those two drifting apart the failure mode that matters most, so it seemed worth confirming rather than assuming.
- `ops/start_dev.sh`, `patch-notes-style.md` and `ops/internal/docker-compose.yml` all exist as referenced.
- `packages/site` does still have both `yarn.lock` and `package-lock.json` committed, as the package-manager section says.