### PR TITLE
Add packages/mobile as a submodule (GRYT-375)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -57,6 +57,16 @@
       ],
       "port": 5001,
       "autoPort": false
+    },
+    {
+      "name": "mobile",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-lc",
+        "cd packages/mobile && npx expo start --port 8081"
+      ],
+      "port": 8081,
+      "autoPort": false
     }
   ]
 }

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -37,6 +37,7 @@ on:
           - ui
           - cli
           - voice
+          - mobile
 
 permissions:
   contents: write
@@ -90,7 +91,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice"
+          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice packages/mobile"
 
           # Clone straight from the URL rather than `git submodule update`,
           # which insists on the recorded gitlink and so fails on a broken one.
@@ -189,6 +190,10 @@ jobs:
 
           if [[ "$SELECTED" == "all" || "$SELECTED" == "voice" ]]; then
             update_submodule "packages/voice" "$DEFAULT_SUBMODULE_BRANCH"
+          fi
+
+          if [[ "$SELECTED" == "all" || "$SELECTED" == "mobile" ]]; then
+            update_submodule "packages/mobile" "$DEFAULT_SUBMODULE_BRANCH"
           fi
 
       - name: Commit changes

--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,7 @@
 	path = packages/voice
 	url = https://github.com/Gryt-chat/voice.git
 	branch = main
+[submodule "packages/mobile"]
+	path = packages/mobile
+	url = https://github.com/Gryt-chat/mobile.git
+	branch = main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Working rules for Gryt
 
 Gryt is a WebRTC voice chat platform maintained by one person. It's a superproject with
-ten git submodules under `packages/`. Read these rules before making changes.
+eleven git submodules under `packages/`. Read these rules before making changes.
 
 ## Review-required paths
 


### PR DESCRIPTION
[Gryt-chat/mobile](https://github.com/Gryt-chat/mobile) is the React Native client GRYT-334 settled on: Expo `prebuild` plus a dev client, phones only, `react-native-webrtc` through `@config-plugins/react-native-webrtc`.

It builds and runs. `expo run:ios` succeeds, `react-native-webrtc@124.0.8` and `JitsiWebRTC@124.0.2` are in `Podfile.lock`, the microphone/camera/background-audio keys are in `Info.plist`, and the app launches on an iPhone 17 Pro simulator rendering `@gryt/ui-native`.

## The part worth checking

**The gitlink sweep names its submodules by hand in three separate places**, and I had to touch all three:

1. the `workflow_dispatch` choice list
2. the `SUBMODULES=` string used to clone anything missing
3. a per-submodule `if` block calling `update_submodule`

Missing one of those is a failure this repo has had before — the pointer silently stops moving while every check stays green. Worth confirming I got all three rather than taking my word for it.

## Also here

- `CLAUDE.md` said ten submodules. Eleven now.
- `.claude/launch.json` gets a `mobile` entry running Metro on 8081, since a submodule's own `launch.json` is never read.

## Voice is deliberately not in the app yet

`@gryt/voice@0.1.1` cannot run on React Native. `VoicePlatform` and `SfuTransport` are exported types that nothing in the published `dist` consumes, while `dist` calls `navigator.mediaDevices` in six files, references `AudioWorklet` in thirteen, and constructs `RTCPeerConnection`, `AudioContext` and `Worker` directly. Installing it would typecheck and fail at runtime.

The WebRTC native module is wired anyway, because that is exactly what GRYT-335's spike needs and because a config plugin that does not build is better found now. Wiring the platform seam is the next piece of work.

Related: Gryt-chat/mobile#1 adds that repo's workflows. GRYT-376 filed for `ui` missing `bump-gitlink.yml`, spotted while doing this.