### PR TITLE
Move every deployment onto the one UDP port (GRYT-424)

### DIFF
--- a/ops/deploy/compose/.env.example
+++ b/ops/deploy/compose/.env.example
@@ -89,8 +89,10 @@ GRYT_SERVER_ENABLED=true
 SERVER_PORT=5000
 SFU_PORT=5005
 
-# WebRTC media, UDP. One port for everybody rather than a range, and a port
-# restrictive networks tend to leave alone. Open this as UDP.
+# WebRTC media, UDP. Every participant's media shares this one port, and it is
+# the only port voice needs open. 443 is what restrictive networks tend to leave
+# alone; it needs a privileged bind and clashes with anything serving HTTPS.
+# The SFU itself defaults to 3478 when this is unset.
 ICE_UDP_MUX_PORT=443
 
 # Web client, only with: docker compose --profile web up -d
@@ -126,16 +128,15 @@ GRYT_TRUSTED_PROXY_HOPS=0
 # How many joins one invite code may be used for per hour.
 GRYT_INVITE_MAX_JOINS_PER_HOUR=
 
-# How many people may be in voice at once. Leave empty for no cap.
+# The SFU's own guardrail on connected peers. Empty takes the SFU's default
+# of 200. Not a property of the port — one muxed port carries far more than a
+# machine has CPU and upload for. If you need more, run a second SFU.
 MAX_PEERS=
 
-# ── WebRTC UDP range ────────────────────────────────────────────────────────
-# Only if you are NOT using ICE_UDP_MUX_PORT above. When the mux port is set
-# these are ignored entirely, and the compose file does not publish them.
-# The range also decides the voice seat limit, so leaving it unset avoids an
-# accidental cap.
-#SFU_UDP_MIN=10000
-#SFU_UDP_MAX=10019
+# ── Voice seats ─────────────────────────────────────────────────────────────
+# How many people may sit in voice at once, on the server side. Empty is no
+# limit. This used to be derived from a UDP port range, which is gone.
+VOICE_MAX_USERS=
 
 # ── STUN ────────────────────────────────────────────────────────────────────
 # Lets the SFU discover its own public address. Only disable it when the SFU

--- a/ops/deploy/compose/beta.local.yml
+++ b/ops/deploy/compose/beta.local.yml
@@ -50,8 +50,7 @@ services:
       SFU_WS_HOST: ws://sfu:5005
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5015}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
-      SFU_UDP_PORT_MIN: ${SFU_UDP_MIN:-10020}
-      SFU_UDP_PORT_MAX: ${SFU_UDP_MAX:-10039}
+      VOICE_MAX_USERS: ${VOICE_MAX_USERS:-20}
       GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}

--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -125,8 +125,7 @@ services:
       SFU_WS_HOST: ws://sfu:${SFU_PORT:-5015}
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5015}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
-      SFU_UDP_PORT_MIN: ${SFU_UDP_MIN:-10020}
-      SFU_UDP_PORT_MAX: ${SFU_UDP_MAX:-10039}
+      VOICE_MAX_USERS: ${VOICE_MAX_USERS:-20}
       GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}

--- a/ops/deploy/compose/dev.yml
+++ b/ops/deploy/compose/dev.yml
@@ -8,14 +8,13 @@ services:
     container_name: gryt-sfu
     ports:
       - "${SFU_WS_PORT:-5006}:5005"
-      # Optional: publish a fixed UDP port range for WebRTC media (recommended in production)
-      # - "${SFU_UDP_MIN:-10000}-${SFU_UDP_MAX:-10019}:${SFU_UDP_MIN:-10000}-${SFU_UDP_MAX:-10019}/udp"
+      - "${ICE_UDP_MUX_PORT:-3478}:${ICE_UDP_MUX_PORT:-3478}/udp"
     environment:
       - PORT=5005
       - STUN_SERVERS=stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
-      # Optional: pin ICE UDP ports + capacity and control what IP is advertised in ICE candidates
-      # - ICE_UDP_PORT_MIN=${SFU_UDP_MIN:-10000}
-      # - ICE_UDP_PORT_MAX=${SFU_UDP_MAX:-10019}
+      # All media flows over this one UDP port. It has to be published above.
+      - ICE_UDP_MUX_PORT=${ICE_UDP_MUX_PORT:-3478}
+      # Optional: control what IP is advertised in ICE candidates
       # - ICE_ADVERTISE_IP=${ICE_ADVERTISE_IP:-}
       # - DISABLE_STUN=${DISABLE_STUN:-false}
     volumes:
@@ -57,9 +56,7 @@ services:
       - S3_BUCKET=${S3_BUCKET:-gryt}
       - S3_FORCE_PATH_STYLE=true
       - JWT_SECRET=${JWT_SECRET:-dev-secret-do-not-use-in-production}
-      # Optional: voice seat limit (derived if SFU_UDP_* set)
-      # - SFU_UDP_PORT_MIN=${SFU_UDP_MIN:-10000}
-      # - SFU_UDP_PORT_MAX=${SFU_UDP_MAX:-10019}
+      # Optional: voice seat limit. Unset means no limit.
       # - VOICE_MAX_USERS=${VOICE_MAX_USERS:-}
     volumes:
       - ../../../packages/server/.env:/app/.env:ro
@@ -104,9 +101,7 @@ services:
       - S3_BUCKET=${S3_BUCKET:-gryt}
       - S3_FORCE_PATH_STYLE=true
       - JWT_SECRET=${JWT_SECRET:-dev-secret-do-not-use-in-production}
-      # Optional: voice seat limit (derived if SFU_UDP_* set)
-      # - SFU_UDP_PORT_MIN=${SFU_UDP_MIN:-10000}
-      # - SFU_UDP_PORT_MAX=${SFU_UDP_MAX:-10019}
+      # Optional: voice seat limit. Unset means no limit.
       # - VOICE_MAX_USERS=${VOICE_MAX_USERS:-}
     volumes:
       - ../../../packages/server/.env:/app/.env:ro

--- a/ops/deploy/compose/prod.local.yml
+++ b/ops/deploy/compose/prod.local.yml
@@ -41,8 +41,7 @@ services:
       SFU_WS_HOST: ws://sfu:5005
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
-      SFU_UDP_PORT_MIN: ${SFU_UDP_MIN:-}
-      SFU_UDP_PORT_MAX: ${SFU_UDP_MAX:-}
+      VOICE_MAX_USERS: ${VOICE_MAX_USERS:-}
       GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -113,8 +113,7 @@ services:
       SFU_WS_HOST: ws://sfu:${SFU_PORT:-5005}
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
-      SFU_UDP_PORT_MIN: ${SFU_UDP_MIN:-}
-      SFU_UDP_PORT_MAX: ${SFU_UDP_MAX:-}
+      VOICE_MAX_USERS: ${VOICE_MAX_USERS:-}
       GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
       GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}

--- a/ops/deploy/host/.env.example
+++ b/ops/deploy/host/.env.example
@@ -15,9 +15,9 @@ BIND_ADDR=127.0.0.1
 SERVER_HTTP_PORT=5000
 SFU_WS_PORT=5005
 
-# SFU UDP media port range (MUST be reachable from the internet)
-SFU_UDP_MIN=10000
-SFU_UDP_MAX=10019
+# The one UDP port WebRTC media flows over (MUST be reachable from the
+# internet — Cloudflare Tunnel does not carry UDP).
+ICE_UDP_MUX_PORT=3478
 
 # Optional: if the SFU host is behind NAT / has multiple NICs, set the public IP it should advertise.
 # ICE_ADVERTISE_IP=203.0.113.10

--- a/ops/deploy/host/README.md
+++ b/ops/deploy/host/README.md
@@ -40,9 +40,9 @@ Users connect via the [Gryt desktop app](https://github.com/Gryt-chat/gryt/relea
 
 ### Firewall / networking (critical)
 
-Cloudflare Tunnel does **not** proxy WebRTC media (UDP). You must expose the SFU UDP range directly.
+Cloudflare Tunnel does **not** proxy WebRTC media (UDP). You must expose the SFU's UDP port directly.
 
-- **Open/forward UDP** `SFU_UDP_MIN..SFU_UDP_MAX` (default `10000-10019/udp`) to the host running the `sfu` container.
+- **Open/forward UDP** `ICE_UDP_MUX_PORT` (default `3478/udp`) to the host running the `sfu` container. Every participant's media shares that one port.
 - If the host is behind NAT or has multiple interfaces, set `ICE_ADVERTISE_IP` to its public IP.
 
 ### Health endpoints

--- a/ops/deploy/host/compose.yml
+++ b/ops/deploy/host/compose.yml
@@ -74,16 +74,16 @@ services:
     environment:
       PORT: "5005"
       STUN_SERVERS: "${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
-      ICE_UDP_PORT_MIN: "${SFU_UDP_MIN:-10000}"
-      ICE_UDP_PORT_MAX: "${SFU_UDP_MAX:-10019}"
+      ICE_UDP_MUX_PORT: "${ICE_UDP_MUX_PORT:-3478}"
       ICE_ADVERTISE_IP: "${ICE_ADVERTISE_IP:-}"
       DISABLE_STUN: "${DISABLE_STUN:-false}"
       MAX_PEERS: "${MAX_PEERS:-}"
     ports:
       # SFU websocket (HTTP) for signaling (Cloudflare Tunnel will proxy this as HTTPS/WSS)
       - "${BIND_ADDR:-127.0.0.1}:${SFU_WS_PORT:-5005}:5005"
-      # WebRTC media (UDP). Must be reachable from the public internet (not via Cloudflare).
-      - "${SFU_UDP_MIN:-10000}-${SFU_UDP_MAX:-10019}:${SFU_UDP_MIN:-10000}-${SFU_UDP_MAX:-10019}/udp"
+      # WebRTC media (UDP). One port, and it must be reachable from the public
+      # internet directly — Cloudflare Tunnel does not carry it.
+      - "${ICE_UDP_MUX_PORT:-3478}:${ICE_UDP_MUX_PORT:-3478}/udp"
     restart: unless-stopped
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:5005/health" ]


### PR DESCRIPTION
The ops half of GRYT-424. Goes with:

- Gryt-chat/sfu#10 — drops `ICE_UDP_PORT_MIN`/`MAX` from the SFU, gives the mux port a default of 3478
- Gryt-chat/server#62 — drops the `SFU_UDP_PORT_MIN`/`MAX` voice-seat derivation

## What to look at

**`deploy/host` is the one that would have broken.** It configured
`ICE_UDP_PORT_MIN`/`MAX` and published `10000-10019/udp`, with no mux port at
all. After the SFU change it would have bound 3478, published a range nothing
listens on, and failed every call with nothing in the logs worth reading. It now
publishes and configures `ICE_UDP_MUX_PORT`, default 3478.

**Beta had a real seat cap hidden in the port pair.** `SFU_UDP_PORT_MIN=10020`,
`MAX=10039` — twenty seats, through the derivation the server PR removes. That
comes back as `VOICE_MAX_USERS=20` rather than quietly disappearing. Prod's pair
defaulted to empty, so prod gets `VOICE_MAX_USERS=` and keeps having no cap.
Worth confirming that matches what the prod `.env` on the box actually sets —
I can't read it from here, and if it sets `SFU_UDP_MIN`/`MAX` today then prod
does have a cap that this would drop.

**dev published nothing for media.** The range lines were commented out and
there was no mux port, so pion picked ephemeral ports that Docker never
published. Voice worked over the host network and not much else. It publishes
3478 now.

**`MAX_PEERS`'s description in `.env.example` was wrong.** It said "how many
people may be in voice at once", which is `VOICE_MAX_USERS` on the server. It is
the SFU's own peer guardrail.

## Checked

`docker compose config` parses all six files, including `prod.yml + prod.local.yml`
and `beta.yml + beta.local.yml` as the overlay pairs they are meant to be used as.

## Deploying

Nothing here deploys itself. prod and beta pull images on their own timer, so
the compose changes only take effect when you bring those services up by name.
`deploy/host` needs its UDP forward changed from the range to the single port at
the same time, or media stops.

Part of GRYT-424

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>