### PR TITLE
Default the media port to 3478 in the compose files too

### DIFF
--- a/ops/deploy/compose/.env.example
+++ b/ops/deploy/compose/.env.example
@@ -90,10 +90,22 @@ SERVER_PORT=5000
 SFU_PORT=5005
 
 # WebRTC media, UDP. Every participant's media shares this one port, and it is
-# the only port voice needs open. 443 is what restrictive networks tend to leave
-# alone; it needs a privileged bind and clashes with anything serving HTTPS.
-# The SFU itself defaults to 3478 when this is unset.
-ICE_UDP_MUX_PORT=443
+# the only port voice needs open. Publish it as UDP and forward it to this host.
+#
+# 3478 is the default everywhere: the SFU itself, the gryt CLI, and these compose
+# files. It is the STUN port, it needs no privileged bind, and networks that
+# allow UDP at all usually allow it.
+#
+# UDP 443 is the alternative, and it is worth knowing why it is even an option.
+# Ports are per-protocol: UDP 443 and TCP 443 are different sockets, so an
+# HTTPS server on TCP 443 does not collide with media on UDP 443. That surprises
+# people often enough to be worth saying outright. The reason to reach for it is
+# that restrictive networks tend to allow UDP 443, since that is where QUIC and
+# HTTP/3 live.
+#
+# The one thing that does collide is HTTP/3. A reverse proxy serving it wants
+# UDP 443 for itself, and Caddy does that by default. Check before you move.
+ICE_UDP_MUX_PORT=3478
 
 # Web client, only with: docker compose --profile web up -d
 CLIENT_PORT=3666

--- a/ops/deploy/compose/.env.example
+++ b/ops/deploy/compose/.env.example
@@ -93,18 +93,23 @@ SFU_PORT=5005
 # the only port voice needs open. Publish it as UDP and forward it to this host.
 #
 # 3478 is the default everywhere: the SFU itself, the gryt CLI, and these compose
-# files. It is the STUN port, it needs no privileged bind, and networks that
-# allow UDP at all usually allow it.
+# files. It is the IANA STUN port and needs no privileged bind.
 #
-# UDP 443 is the alternative, and it is worth knowing why it is even an option.
-# Ports are per-protocol: UDP 443 and TCP 443 are different sockets, so an
-# HTTPS server on TCP 443 does not collide with media on UDP 443. That surprises
-# people often enough to be worth saying outright. The reason to reach for it is
-# that restrictive networks tend to allow UDP 443, since that is where QUIC and
-# HTTP/3 live.
+# Why 3478 and not 443, which is the one everybody reaches for:
 #
-# The one thing that does collide is HTTP/3. A reverse proxy serving it wants
-# UDP 443 for itself, and Caddy does that by default. Check before you move.
+# Teams requires outbound UDP 3478-3481, so a corporate or school firewall has
+# most likely already opened it. UDP 443 is the opposite. Firewall vendors
+# recommend blocking it, because QUIC there cannot be TLS-inspected and blocking
+# it forces browsers back to TCP where it can be. On the networks you would pick
+# 443 to get through, it is the port most likely to be shut on purpose.
+#
+# Worth saying outright, because it catches people: ports are per-protocol. UDP
+# 443 and TCP 443 are different sockets, so an HTTPS server never collides with
+# media on UDP 443. HTTP/3 does, because that is UDP 443 as well, and Caddy
+# serves it by default.
+#
+# No UDP port is universally allowed. A network that blocks outbound UDP
+# entirely needs a TURN relay on TCP 443, which Gryt does not have yet.
 ICE_UDP_MUX_PORT=3478
 
 # Web client, only with: docker compose --profile web up -d

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -61,11 +61,11 @@ services:
     container_name: gryt-prod-sfu
     ports:
       - "${SFU_PORT:-5005}:5005"
-      - "${ICE_UDP_MUX_PORT:-443}:${ICE_UDP_MUX_PORT:-443}/udp"
+      - "${ICE_UDP_MUX_PORT:-3478}:${ICE_UDP_MUX_PORT:-3478}/udp"
     environment:
       PORT: "5005"
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
-      ICE_UDP_MUX_PORT: ${ICE_UDP_MUX_PORT:-443}
+      ICE_UDP_MUX_PORT: ${ICE_UDP_MUX_PORT:-3478}
       ICE_ADVERTISE_IP: ${ICE_ADVERTISE_IP:-}
       DISABLE_STUN: ${DISABLE_STUN:-false}
       MAX_PEERS: ${MAX_PEERS:-}


### PR DESCRIPTION
The compose files were the last place still defaulting to 443. The SFU binary,
the `gryt` CLI, `deploy/host` and `dev.yml` already used 3478, so one number now
covers every way of starting a server.

## Read this before merging

**`.env.prod` on the box does not set `ICE_UDP_MUX_PORT`.** I checked: prod is
falling through to the compose default, which this PR changes.

So merging and redeploying moves production's media port from 443 to 3478, and
whatever forwards UDP 443 to that host would need to follow. `.env.beta` *does*
set it explicitly (4443), so beta is unaffected.

Two ways to take it, and it is your call:

- **Move prod to 3478**, and update the UDP forward at the same time. Consistent
  with everything else, and by the research below it is the better port anyway.
- **Pin prod where it is** by adding `ICE_UDP_MUX_PORT=443` to `.env.prod`, and
  let the new default apply only to new deployments.

I have not touched anything on the box.

## Why 3478 is actually the better default

I argued for keeping 443 earlier and was wrong, in the direction that matters.

Enterprise firewall vendors — Zscaler, Palo Alto, Sophos, Check Point — all
**recommend blocking UDP 443**, because QUIC there cannot be TLS-inspected and
blocking it forces browsers back to TCP where it can be. On exactly the networks
you would choose 443 to get through, it is the port most likely to be shut
deliberately.

3478 is the IANA STUN port, needs no privileged bind, and is the UDP port a
locked-down network has most likely already opened, since Teams requires
outbound 3478–3481.

That inheritance is partial and the comment does not oversell it: Teams rules are
often scoped to Microsoft's IP ranges, and app-aware firewalls match `ms-teams`
rather than the port. It helps where the rule is unscoped, which is common.

## The comment was wrong twice

It said 443 "clashes with anything serving HTTPS". Ports are per-protocol — UDP
443 and TCP 443 are different sockets. Verified on the box: the SFU holds UDP 443
and nothing holds TCP 443. What does collide is HTTP/3, which Caddy serves by
default.

Both corrections are in the file now, along with the ceiling: no UDP port is
universally allowed, and a network blocking outbound UDP needs TURN on TCP 443,
which is GRYT-9.

## Checked

`docker compose config` parses `prod.yml` and `beta.yml`. beta keeps 4443, since
it shares a host with prod and they cannot both hold one UDP port.

Docs still say 443 in about ten places; that sweep follows in docs.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>