### PR TITLE
No TURN is the design, not a missing feature

### DIFF
--- a/ops/deploy/compose/.env.example
+++ b/ops/deploy/compose/.env.example
@@ -108,8 +108,11 @@ SFU_PORT=5005
 # media on UDP 443. HTTP/3 does, because that is UDP 443 as well, and Caddy
 # serves it by default.
 #
-# No UDP port is universally allowed. A network that blocks outbound UDP
-# entirely needs a TURN relay on TCP 443, which Gryt does not have yet.
+# No UDP port is allowed everywhere, and Gryt does not paper over that with a
+# relay. There is no TURN server here on purpose: it would put an extra hop
+# between two people who could talk directly and charge latency and bandwidth
+# for it on every packet. Gryt gets a direct path or it does not connect, which
+# is why the port you forward is the thing that matters.
 ICE_UDP_MUX_PORT=3478
 
 # Web client, only with: docker compose --profile web up -d


### PR DESCRIPTION
Same correction as Gryt-chat/sfu#13, in `ops/deploy/compose/.env.example`.

I wrote that a network blocking outbound UDP "needs a TURN relay on TCP 443,
which Gryt does not have **yet**". The "yet" implied a plan that does not exist.

`ops/helm/gryt/values.yaml`, in this same repository, already said **"TURN is
intentionally not required"**. The comment now agrees with it instead of
contradicting it two directories away.

Comment text only. No compose values change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>