### PR TITLE
Pull the superproject, so ops/ changes reach the machine

### DIFF
--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -242,10 +242,20 @@ that is a different script rather than a flag.
 
 ```bash
 sudo ln -sfn "$PWD/ops/internal/refresh-sites.sh" /usr/local/bin/gryt-sites-refresh
+sudo ln -sfn "$PWD/ops/internal/pull-superproject.sh" /usr/local/bin/gryt-pull-superproject
 sudo cp ops/internal/systemd/gryt-sites-refresh.{service,timer} /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now gryt-sites-refresh.timer
 ```
+
+The second symlink is what keeps this checkout current. The unit runs it as an
+`ExecStartPre`, so every tick fast-forwards the superproject before rebuilding
+anything, and a change to `ops/` reaches the machine on its own.
+
+It only ever fast-forwards, and never recurses into the submodules — those
+belong to the refresher below, which moves them to commits the gitlinks here do
+not name. A checkout with local commits or tracked changes outside `packages/`
+is left alone and says so.
 
 Same shape as the web client timer, including the symlink and the root-by-default. It fires
 every ten minutes with a randomised delay offset from that one, so a build and an image pull

--- a/ops/internal/pull-superproject.sh
+++ b/ops/internal/pull-superproject.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Fast-forward the superproject checkout so ops/ changes reach the machine.
+#
+# Everything else on this box updates itself. The sites refresher fetches the
+# docs, site and ui submodules; the web client refresher asks GHCR for a newer
+# image. Nothing pulled the superproject, so ops/ was the one directory where
+# merging a pull request changed nothing here at all.
+#
+# That is not academic. On 2026-08-21 the checkout sat six merges behind while
+# three of them were compose changes, and the refresher scripts themselves are
+# symlinked out of this checkout, so a change to those could never take effect
+# either. A script that cannot deliver its own updates is a poor place to put
+# the delivery mechanism.
+#
+# Which is also why this is its own file rather than a few lines inside
+# refresh-sites.sh. Bash reads a script as it runs it, so a script that pulls
+# the checkout it lives in can have its own remaining lines replaced underneath
+# it. This one is short enough to be read in a single go, and it is run from
+# ExecStartPre so the refresher that follows is a fresh process reading whatever
+# the pull just left behind.
+#
+# Deliberately fast-forward only, and deliberately --no-recurse-submodules. The
+# submodules are the sites refresher's business and it moves them to commits the
+# gitlinks here do not name; recursing would drag them backwards to whatever the
+# superproject last recorded, which is the opposite of what everything else on
+# this box is trying to do.
+#
+# Refuses on any local commit or tracked modification rather than resolving it.
+# Nothing here should be editing this checkout, and if something is, standing on
+# it is worse than doing nothing.
+
+set -euo pipefail
+
+ROOT="${GRYT_ROOT:-/home/sivert/gryt}"
+BRANCH="${GRYT_BRANCH:-main}"
+
+log() { printf '%s  %s\n' "$(date -Is)" "$*"; }
+
+RUNUSER=$(command -v runuser || echo /usr/sbin/runuser)
+[[ -x "$RUNUSER" ]] || RUNUSER=""
+
+git_in() {
+  local owner
+  owner=$(stat -c '%U' "$ROOT" 2>/dev/null || true)
+  if [[ -z "$owner" || "$owner" == "$(id -un)" || "$(id -u)" != "0" ]]; then
+    git -C "$ROOT" "$@"
+    return
+  fi
+  if [[ -z "$RUNUSER" ]]; then
+    log "runuser is not installed, so git cannot be run as $owner"
+    return 1
+  fi
+  "$RUNUSER" -u "$owner" -- git -C "$ROOT" "$@"
+}
+
+[[ -d "$ROOT/.git" ]] || { log "$ROOT is not a git checkout — nothing to do"; exit 0; }
+
+# Tracked changes only. Submodule gitlinks read as modified here as a matter of
+# course, because the sites refresher moves the submodules without committing
+# them, so those are not a reason to refuse.
+if ! dirty=$(git_in status --porcelain --untracked-files=no -- ':!packages' 2>&1); then
+  log "cannot read the state of $ROOT: $dirty"
+  exit 1
+fi
+if [[ -n "$dirty" ]]; then
+  log "$ROOT has local changes outside packages/ — leaving it alone"
+  exit 0
+fi
+
+if ! git_in fetch --quiet origin "$BRANCH"; then
+  log "fetch failed — leaving the checkout alone"
+  exit 1
+fi
+
+before=$(git_in rev-parse HEAD)
+target=$(git_in rev-parse FETCH_HEAD)
+if [[ "$before" == "$target" ]]; then
+  exit 0
+fi
+
+if ! git_in merge --ff-only --quiet --no-recurse-submodules FETCH_HEAD 2>/dev/null \
+  && ! git_in merge --ff-only --quiet FETCH_HEAD; then
+  log "cannot fast-forward $ROOT to $target — left at $before"
+  exit 1
+fi
+
+log "superproject ${before:0:12} -> ${target:0:12}"

--- a/ops/internal/systemd/gryt-sites-refresh.service
+++ b/ops/internal/systemd/gryt-sites-refresh.service
@@ -7,6 +7,22 @@ Requires=docker.service
 [Service]
 Type=oneshot
 
+# Bring the checkout itself up to date first, so ops/ changes reach this
+# machine at all. Nothing else pulls the superproject: the refresher below
+# fetches the submodules, and the web client refresher asks GHCR, which left
+# ops/ as the one directory where merging a pull request changed nothing here.
+#
+# A separate process on purpose. The refresher is symlinked out of the checkout
+# this pull rewrites, and bash reads a script as it runs it, so pulling from
+# inside the refresher could replace its own remaining lines underneath it.
+# Running the pull first and the refresher second means the refresher is a
+# fresh read of whatever the pull just left behind.
+#
+# The leading dash so a failed pull does not stop the rebuild. Being a few
+# commits behind is worse than not rebuilding at all, but not by enough to make
+# a network blip take the sites down.
+ExecStartPre=-/usr/local/bin/gryt-pull-superproject
+
 # A symlink into the checkout rather than a copy, so `git pull` updates the
 # script and nothing has to be installed again. systemd needs a literal
 # absolute path here, so the symlink is what keeps the unit free of anybody's


### PR DESCRIPTION
Everything on the box updates itself except the thing the updaters live in.

The sites refresher fetches the `docs`, `site` and `ui` submodules. The web
client refresher asks GHCR whether a digest moved. **Nothing pulled the
superproject**, so `ops/` was the one directory where merging a pull request
changed nothing on the machine at all.

## Found the hard way, today

The checkout was sitting **six merges behind** while three of those were compose
changes. gryt#105's removal of the dead `SFU_UDP_PORT_MIN`/`MAX` had never taken
effect; I only noticed because the servers were recreated for it the moment I
pulled by hand.

Worse, the refresher scripts are symlinked out of that same checkout, so the
change in gryt#108 could not have taken effect either. The delivery mechanism
could not deliver its own updates.

## Why a separate script and an ExecStartPre

Bash reads a script as it runs it. A script that pulls the checkout it lives in
can have its own remaining lines replaced underneath it, mid-run, which is a
genuinely nasty failure to debug.

Running the pull as `ExecStartPre` makes it a separate process that finishes
before the refresher starts, so the refresher is a fresh read of whatever the
pull just left behind. The leading dash means a failed pull does not stop the
rebuild — being a few commits behind is worse than not rebuilding, but not by
enough to let a network blip take the sites down.

## What it refuses to do

**Fast-forward only, never recursing into submodules.** The submodules belong to
the sites refresher, which moves them to commits the gitlinks here do not name.
Recursing would drag them *backwards* to whatever the superproject last recorded,
which is the opposite of what everything else on this box is doing.

**Leaves a dirty checkout alone.** Local commits, or tracked changes outside
`packages/`, and it says so and exits. Submodule gitlinks read as modified as a
matter of course, so those are excluded from that test — otherwise it would never
run.

## Tested on the box

Ran from `/tmp`, not the installed path. It fast-forwarded `49604bb → 53ffd55`
(CI's submodule-update commits, which had landed since I pulled by hand earlier),
left the checkout on `main` and clean, and prod still resolves its media port to
443. Test file removed afterwards.

## Installing

`ops/internal/README.md` has the extra symlink. This needs a `daemon-reload` and
the unit re-copied on the box, since the units are copies rather than symlinks —
I have not touched `/etc/systemd/system`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>