### PR TITLE
Take back what a failed release leaves lying around (GRYT-466)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1452,3 +1452,86 @@ jobs:
 
           echo "::error::snapcraft upload failed with exit code $rc."
           exit $rc
+  # Take back what a failed release left lying around.
+  #
+  # A run that dies after "Prepare release" has already pushed the tag and
+  # created the draft, so a failure in any build leaves both behind. v1.6.21
+  # failed in Windows packaging and stranded a tag, a draft, the Linux
+  # installers and half the macOS upload. GRYT-466.
+  #
+  # Draft only, and that is the whole safety argument: a draft has been seen by
+  # nobody. `publish-release` flips it live as the last thing it does, so
+  # anything still in draft when this job runs never reached a client, never
+  # answered an update check, and is not in anybody's download history. A
+  # release that did go live is left strictly alone, whatever else failed.
+  #
+  # What deliberately survives: the release.json and package.json bumps, and the
+  # "release: vX.Y.Z" commits carrying them. Reverting commits on two mains is a
+  # much bigger hammer than this problem deserves, and leaving them costs
+  # nothing — release.json sitting at a version with no tag is exactly what a
+  # re-dispatch with bump=none wants to find.
+  cleanup-failed-release:
+    name: Clean up a failed release
+    needs: [prepare-release, build-electron, publish-release]
+
+    # Not `failure()`: publish-snap is continue-on-error and publish-release may
+    # be skipped rather than failed when a build dies, so the condition is
+    # written out. It runs when the version is known and something after it went
+    # wrong.
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      (needs.build-electron.result != 'success' ||
+      needs.publish-release.result != 'success')
+
+    runs-on: ubuntu-latest
+
+    env:
+      OWNER: Gryt-chat
+      REPO: gryt
+      VERSION: ${{ needs.prepare-release.outputs.version }}
+
+    steps:
+      - name: Delete the tag and release, if it never left draft
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          TAG="v$VERSION"
+
+          IS_DRAFT="$(
+            gh release view "$TAG" --repo "$OWNER/$REPO" --json isDraft --jq .isDraft 2>/dev/null || true
+          )"
+
+          if [[ "$IS_DRAFT" == "false" ]]; then
+            echo "$TAG is published. Leaving it, and its tag, alone."
+            exit 0
+          fi
+
+          if [[ "$IS_DRAFT" == "true" ]]; then
+            # --cleanup-tag takes the git tag with it, which is the half that
+            # blocks a re-dispatch at the same version.
+            echo "Deleting the draft release $TAG and its tag."
+            gh release delete "$TAG" --repo "$OWNER/$REPO" --yes --cleanup-tag
+            exit 0
+          fi
+
+          # No release at all. The run died between pushing the tag and creating
+          # the release, so the tag is the only thing out there.
+          if git ls-remote --exit-code --tags \
+              "https://github.com/$OWNER/$REPO.git" "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "No release for $TAG, deleting the stranded tag."
+            gh api -X DELETE "repos/$OWNER/$REPO/git/refs/tags/$TAG"
+          else
+            echo "Nothing to clean up for $TAG."
+          fi
+
+      - name: Say what to do next
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "::notice::v$VERSION has been cleared. Fix the failure and"
+          echo "::notice::dispatch again with bump=none to reuse the number."


### PR DESCRIPTION
v1.6.21 died in Windows packaging (GRYT-463). By then the run had already pushed the tag and created the draft release, so it left both behind, plus the Linux installers and half a macOS upload. Nothing picks that up.

Two costs:

- The release list grows a draft nobody will ever publish. From outside that reads as a version that both exists and does not.
- A re-dispatch at the same number cannot work. `prepare-release` refuses to move a tag that already names another commit, which is right for a release that went live and wrong for one that never left draft. So a retry costs either a manual tag deletion or a version number. We paid the number: 1.6.21 is skipped and the fix went out as 1.6.22.

## What it does

A `cleanup-failed-release` job that runs when the version is known and something after it failed, and deletes the tag and the release **only while the release is still a draft**.

That is the whole safety argument. `publish-release` flips the draft live as the last thing it does, so anything still in draft when this job runs reached no client, answered no update check, and is in nobody's download history. A release that did go live is left alone regardless of what else failed.

Three cases, in order:

| State | Action |
|---|---|
| Release exists, `isDraft: false` | Leave it, and its tag, alone |
| Release exists, `isDraft: true` | `gh release delete --cleanup-tag` |
| No release, tag on remote | Delete the tag ref (died between tagging and creating the release) |

## Worth a close look

- **The `if:` condition.** Spelled out rather than `failure()`, because `publish-release` is *skipped* rather than failed when a build dies, and `failure()` on a cancelled run behaves differently again. `publish-snap` is `continue-on-error` and is deliberately not in `needs`, so a Snap Store outage can never delete a good release. I would re-read this expression against the cases you care about — it is the part where being wrong is expensive in the wrong direction.
- **`always()` plus a `prepare-release.result == 'success'` guard.** If prepare itself fails there may be no version output, and deleting `v` would be bad. Hence the guard rather than a bare `always()`.
- **I could not run this.** Workflow changes only prove themselves on a real failed release. Verified as far as it goes: the file parses as YAML, the job registers, both `run:` blocks pass `bash -n`, and the `if:` folds to a single line.

## Not in scope

The `release.json` and `package.json` bumps and their `release: vX.Y.Z` commits survive. Reverting commits on two mains is a much bigger hammer than this deserves, and leaving them costs nothing: `release.json` sitting at a version with no tag is exactly what a re-dispatch with `bump=none` wants to find. The job's closing notice says so.

Noted on the task as a possible follow-up, not done here: relaxing the tag guard itself to allow moving a tag whose release is still a draft, so a retry works even when this job did not run.

Task: GRYT-466

🤖 Generated with [Claude Code](https://claude.com/claude-code)