### PR TITLE
Add packages/bot as a submodule (GRYT-464)

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -38,6 +38,7 @@ on:
           - cli
           - voice
           - mobile
+          - bot
 
 permissions:
   contents: write
@@ -91,7 +92,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice packages/mobile"
+          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice packages/mobile packages/bot"
 
           # Clone straight from the URL rather than `git submodule update`,
           # which insists on the recorded gitlink and so fails on a broken one.
@@ -196,6 +197,10 @@ jobs:
             update_submodule "packages/mobile" "$DEFAULT_SUBMODULE_BRANCH"
           fi
 
+          if [[ "$SELECTED" == "all" || "$SELECTED" == "bot" ]]; then
+            update_submodule "packages/bot" "$DEFAULT_SUBMODULE_BRANCH"
+          fi
+
       - name: Commit changes
         shell: bash
         run: |
@@ -226,7 +231,10 @@ jobs:
             git fetch origin "$TARGET_BRANCH"
             git reset --hard "origin/$TARGET_BRANCH"
 
-            for path in packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice; do
+            # Every submodule, not most of them. mobile was missing, so a
+            # rejected push rebuilt the commit without it and silently dropped
+            # whatever bump had just been made.
+            for path in packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice packages/mobile packages/bot; do
               [[ -d "$path" ]] || continue
               git -C "$path" fetch origin main
               git -C "$path" checkout -B main origin/main

--- a/.gitmodules
+++ b/.gitmodules
@@ -42,3 +42,7 @@
 	path = packages/mobile
 	url = https://github.com/Gryt-chat/mobile.git
 	branch = main
+[submodule "packages/bot"]
+	path = packages/bot
+	url = https://github.com/Gryt-chat/bot.git
+	branch = main


### PR DESCRIPTION
The bot SDK has been a repository of its own since it was written and never a submodule, so `cd packages/bot` finds nothing — which is how you find out, when you go to publish it.

Registered in `update-submodules.yml` in all three places it needs to be: the initialisation list, the per-submodule dispatch choice, and the retry loop. `Gryt-chat/bot` also got the `bump-gitlink` workflow every other submodule repo has, so its pointer moves on merge rather than on the hourly sweep.

## One thing this fixes on the way past

The retry loop was already missing `packages/mobile`:

```
for path in packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice; do
```

That loop rebuilds the commit from scratch when a push is rejected, so **a rejected push silently dropped whatever mobile bump had just been made** — no error, just a gitlink that did not move. Both `mobile` and `bot` are in the list now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)