### PR TITLE
Write down the tic, since installing a skill did not fix it (GRYT-472)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,3 +218,23 @@ Match the surrounding code. Sivert's prose — docs, blog posts, comments — is
 direct, with hedges like "a bit", "probably", "honestly". Avoid aphorisms, antithesis pairs
 ("not X, but Y"), and sections that end on a punchy one-liner. If a sentence sounds like it
 belongs in a keynote, rewrite it.
+
+**Don't tell the reader a point is important.** "Worth noting", "worth a close look",
+"this is the moment the number is settled", "the one people miss" — each of those spends a
+sentence announcing the next one instead of saying anything. Cut the announcement and
+state the thing. A test that catches most of it: if a sentence could move to another
+project unchanged, it is filler, and it should be a fact, a number or a consequence
+specific to this one instead.
+
+This applies to PR bodies, commit messages and task descriptions as much as to docs. They
+are the longest prose in the repository and the least edited.
+
+Two skills are installed for this — `humanizer` for the named patterns and `no-ai-slop`
+for the principles. Run them over prose before it ships rather than trying to hold the
+list in your head; that is the failure mode. On 2026-08-21 both were installed, one was
+used on a Discord message, and the docs written an hour later still went out saying
+"Worth doing rather than skipping past".
+
+One caveat when running them over an existing page: check `git blame` before rewriting.
+"Worth knowing" and similar turn up in Sivert's own writing, where they read as his voice
+rather than as padding, and the rule above is about not adding more.


### PR DESCRIPTION
You flagged this line in `deployment/embedded`:

> Worth doing rather than skipping past, because this is the moment the number is settled.

It spends a sentence announcing the next sentence. The same shape ran through everything I wrote today — "worth a close look" as a heading in three PR bodies, "worth knowing", "the one people miss".

The `humanizer` skill was already installed and covers exactly this, under "announcing the next point". It did not help, because I ran it on one Discord message and not on the docs or the PR bodies. A skill that only works when someone remembers to invoke it is not a rule, so this puts it in `CLAUDE.md` instead.

## What the entry adds beyond "don't do that"

- **The portability test**, from `no-ai-slop`: if a sentence could move to another project unchanged, it is filler. This catches the variants a blacklist never enumerates — none of my three phrasings were literally "it's worth noting".
- **A `git blame` caveat.** Running the scan over `no-domain.mdx` flagged four lines, and all four were yours. "Worth knowing" reads as your voice there rather than as padding. The rule is about not adding more, not about editing what is already there — without that caveat, the next agent to read this reformats your prose.
- **Names both skills**, since they catch different things: `no-ai-slop` is principles, `humanizer` is the pattern list.

## Related

Prose fixes are in Gryt-chat/docs#60, which now also cleans up two more of these that shipped in docs#58 this morning.

Task: GRYT-472

🤖 Generated with [Claude Code](https://claude.com/claude-code)