### PR TITLE
git blame cannot tell an agent's prose from Sivert's (GRYT-472)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,12 @@ list in your head; that is the failure mode. On 2026-08-21 both were installed, 
 used on a Discord message, and the docs written an hour later still went out saying
 "Worth doing rather than skipping past".
 
-One caveat when running them over an existing page: check `git blame` before rewriting.
-"Worth knowing" and similar turn up in Sivert's own writing, where they read as his voice
-rather than as padding, and the rule above is about not adding more.
+One caveat when running them over an existing page. `git blame` will not tell you who
+wrote a line: every commit in these repositories is authored `Sivert`, including the ones
+an agent makes, so blame says "Sivert" for all of it. The `Co-authored-by: Claude` trailer
+on the commit is the only marker, and `git log --format=%b -- <file>` is how to read it.
+
+It matters less than it looks, because the answer is usually "leave it either way". A
+phrase like "worth knowing" reads as Sivert's voice in the pages that already had it, and
+the rule above is about not adding more rather than about editing what is there. Rewrite a
+line when it is genuinely announcing the next one, not because a scan matched it.


### PR DESCRIPTION
Fixes advice I added in #112 and you merged an hour ago.

That entry says to check `git blame` before rewriting a line, because "worth knowing" appears in your own docs. Blame cannot answer that question here: every commit in these repositories is authored `Sivert`, including the ones I make, so it says "Sivert" for everything.

I used the method myself earlier today — blamed four flagged lines in `no-domain.mdx`, saw your name, and reported them as your prose. Two of the four were yours, by the accident of predating the edit I was making. The method was wrong either way.

The `Co-authored-by: Claude` trailer is the real marker. The entry now says that, with `git log --format=%b -- <file>` as the way to read it.

It also says the distinction matters less than it first looks. Running the scan across all 49 doc pages, the answer was "leave it" almost every time regardless of author. What got cut was seven sentences that announced the next sentence, and those deserved cutting whoever typed them. Prose fixes are in Gryt-chat/docs#61.

Task: GRYT-472

🤖 Generated with [Claude Code](https://claude.com/claude-code)