### PR TITLE
Add the report service as a submodule and wire it into ops/internal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,7 @@
 	path = packages/bot
 	url = https://github.com/Gryt-chat/bot.git
 	branch = main
+[submodule "reports"]
+	path = packages/reports
+	url = https://github.com/Gryt-chat/reports.git
+	branch = main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Working rules for Gryt
 
 Gryt is a WebRTC voice chat platform maintained by one person. It's a superproject with
-eleven git submodules under `packages/`. Read these rules before making changes.
+twelve git submodules under `packages/`. Read these rules before making changes.
 
 ## Review-required paths
 
@@ -12,6 +12,7 @@ these paths, but they never merge without Sivert reading the whole diff:
 packages/sfu/**                                    # WebRTC media plane, RTP, ICE, SVC
 packages/auth/**                                   # identity certificate authority
 packages/image-worker/**                           # decodes untrusted uploads
+packages/reports/**                                # public POST endpoint, stranger-written input
 packages/server/src/auth/**                        # challenge-response, JWT validation
 packages/server/src/middleware/**                  # request auth
 packages/server/src/db/**                          # persistence
@@ -37,13 +38,16 @@ Rules for these paths:
   CI tweak. The other half of the same fix is not unrelated — that belongs with it, or in
   its own PR opened at the same time and cross-linked. Don't drop it.
 
-Two of these look like exceptions but aren't:
+Three of these look like exceptions but aren't:
 
 - **`packages/image-worker`** compresses avatars and makes thumbnails, which sounds like a
   utility. It also hands stranger-uploaded files to an image decoder. Untrusted input
   parsing belongs here, however mundane the job looks.
 - **`packages/client/src/packages/common/src/auth/`** sits inside the client, where UI code
   gets normal review. These specific files hold the user's private key.
+- **`packages/reports`** takes bug reports and feedback from inside the apps, which sounds
+  like a form handler. It is also the only Gryt service with an endpoint anyone on the
+  internet can POST to, it parses whatever they send, and it stores IP addresses.
 
 Everything else — docs, the site, client UI, `ops/`, build scripts, CI config, tests — gets
 normal review.

--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -1,6 +1,6 @@
 ##
 ## ops/internal/.env  — internal hosted services (gryt.chat / docs.gryt.chat /
-## ui.gryt.chat / feedback.gryt.chat)
+## ui.gryt.chat / feedback.gryt.chat / reports.gryt.chat)
 ##
 ## Copy this file to ops/internal/.env and fill in values.
 ##
@@ -11,6 +11,7 @@ INTERNAL_DOCS_HTTP_PORT=9471
 INTERNAL_UI_HTTP_PORT=9475
 
 FIDER_HTTP_PORT=9473
+INTERNAL_REPORTS_HTTP_PORT=9476
 
 # ── Fider ────────────────────────────────────────────────────────────────
 FIDER_BASE_URL=https://feedback.gryt.chat
@@ -21,6 +22,23 @@ FIDER_DB_NAME=fider
 
 # Generate with: openssl rand -base64 64
 FIDER_JWT_SECRET=replace-me
+
+# ── Reports (bug reports and feedback from inside the apps) ──────────────
+# One key per app, sent as X-Gryt-App-Key. Generate with: openssl rand -hex 32
+REPORTS_APP_KEYS=mobile:replace-me,desktop:replace-me,web:replace-me
+
+# The inbox at reports.gryt.chat/admin. No token, no inbox.
+REPORTS_ADMIN_TOKEN=replace-me
+REPORTS_PUBLIC_URL=https://reports.gryt.chat
+
+# Refuse anything not signed with a Gryt identity key. Turn on once every
+# client sends one.
+REPORTS_REQUIRE_SIGNATURE=false
+
+# The triage pass. Without a key reports arrive unsorted, which still works.
+ANTHROPIC_API_KEY=
+REPORTS_NOTIFY_ON=triage
+REPORTS_DISCORD_WEBHOOK_URL=
 
 # ── SMTP (shared with Gryt Auth / Keycloak) ──────────────────────────────
 # Postmark server token goes in USER+PASS.

--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -6,6 +6,7 @@ This folder contains **internal** infrastructure used to run:
 - `docs.gryt.chat` (documentation)
 - `ui.gryt.chat` (the `@gryt/ui` component library docs)
 - `feedback.gryt.chat` (Fider feature requests board)
+- `reports.gryt.chat` (bug reports and feedback sent from inside the apps)
 
 It’s **not** intended for self-hosters. Self-hosting docs live under `ops/deploy/*` (Docker Compose) and `ops/helm/*` (Kubernetes).
 
@@ -26,6 +27,7 @@ You must use unique host ports. Configure them in `ops/internal/.env`:
 - `INTERNAL_DOCS_HTTP_PORT` (default `9471`)
 - `INTERNAL_UI_HTTP_PORT` (default `9475`)
 - `FIDER_HTTP_PORT` (default `9473`)
+- `INTERNAL_REPORTS_HTTP_PORT` (default `9476`)
 
 ## Fider auth: use Gryt Auth (Keycloak OIDC)
 
@@ -66,8 +68,13 @@ Use Fider’s **Test** button before enabling the provider.
 - `docs.gryt.chat` → `http://127.0.0.1:<INTERNAL_DOCS_HTTP_PORT>`
 - `ui.gryt.chat` → `http://127.0.0.1:<INTERNAL_UI_HTTP_PORT>`
 - `feedback.gryt.chat` → `http://127.0.0.1:<FIDER_HTTP_PORT>`
+- `reports.gryt.chat` → `http://127.0.0.1:<INTERNAL_REPORTS_HTTP_PORT>`
 
-All four should be **proxied** and routed through the same Cloudflare Tunnel.
+All five should be **proxied** and routed through the same Cloudflare Tunnel.
+
+`reports.gryt.chat` is the only one of these that takes POSTs from strangers, so it is
+also the only one where a Cloudflare rate limit in front earns its keep. The service rate
+limits and bans on its own; that is not a reason to leave the edge wide open.
 
 ## Downloads folder
 
@@ -161,6 +168,9 @@ lives on.
 
 The rest of the `gryt-prod` stack — server, SFU, image worker — is deliberately **not** in
 scope. Those carry data, and rolling them forward is a decision rather than a cron job.
+
+`reports` is a GHCR image too, and also not in scope: the script targets `gryt-<stack>-client`
+by name. Moving it forward is a `pull` and an `up -d --no-deps reports` by hand for now.
 
 ## Keeping the sites built from source current
 

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -76,5 +76,34 @@ services:
       timeout: 10s
       retries: 10
 
+  # Bug reports and feedback sent from inside the apps (reports.gryt.chat).
+  # Fider above is the public half people vote on; this is the one nobody else
+  # reads. Pulled from GHCR rather than built here — Release Reports pushes it.
+  reports:
+    image: ghcr.io/gryt-chat/reports:${REPORTS_IMAGE_TAG:-latest}
+    container_name: gryt-reports
+    ports:
+      - "${INTERNAL_REPORTS_HTTP_PORT:-9476}:8080"
+    environment:
+      # One key per app. Without at least one the service refuses to start,
+      # because what it exposes is a public POST endpoint.
+      REPORTS_APP_KEYS: "${REPORTS_APP_KEYS:-}"
+      REPORTS_ADMIN_TOKEN: "${REPORTS_ADMIN_TOKEN:-}"
+      REPORTS_PUBLIC_URL: "${REPORTS_PUBLIC_URL:-https://reports.gryt.chat}"
+      REPORTS_CORS_ORIGINS: "${REPORTS_CORS_ORIGINS:-https://app.gryt.chat,https://beta.gryt.chat}"
+      REPORTS_REQUIRE_SIGNATURE: "${REPORTS_REQUIRE_SIGNATURE:-false}"
+      # Behind the tunnel the socket address is cloudflared, so the client
+      # address has to come from cf-connecting-ip.
+      REPORTS_TRUST_PROXY: "true"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+      REPORTS_TRIAGE_MODEL: "${REPORTS_TRIAGE_MODEL:-claude-opus-5}"
+      REPORTS_DISCORD_WEBHOOK_URL: "${REPORTS_DISCORD_WEBHOOK_URL:-}"
+      REPORTS_NOTIFY_ON: "${REPORTS_NOTIFY_ON:-triage}"
+    volumes:
+      - gryt-reports-data:/data
+    restart: unless-stopped
+
 volumes:
   gryt-fider-pg-data:
+  # Every report anyone has ever sent. There are no off-box backups of this.
+  gryt-reports-data:


### PR DESCRIPTION
Part of GRYT-489. Merge after Gryt-chat/reports, since the gitlink points at it.

- **`packages/reports`** is the twelfth submodule.
- **`ops/internal`** gets a `reports` service on port 9476, running the GHCR
  image rather than a `build:` context, with a named volume for the database and
  every secret coming from `ops/internal/.env`. `.env.example` and the README
  gain the settings, the port and the cloudflared hostname.
- **`CLAUDE.md`** lists `packages/reports/**` as review-required. The matching
  row in the public policy is the docs PR, opened at the same time.

## Worth knowing before deploying

- `reports.gryt.chat` needs a cloudflared hostname pointing at
  `127.0.0.1:9476`. It is the only one of these that takes POSTs from strangers,
  so a Cloudflare rate limit in front of it is worth having even though the
  service limits and bans on its own.
- Nothing on the box pulls this image. `refresh-web-client.sh` matches
  `gryt-<stack>-client` by name and `refresh-sites.sh` only handles the three
  services built from source, so moving it forward is `pull` plus
  `up -d --no-deps reports` by hand. GRYT-509 is about closing that before it
  costs a release, the way GRYT-291 did.
- The service refuses to start without `REPORTS_APP_KEYS`, so a half-filled
  `.env` fails loudly rather than opening the endpoint.

The `packages/docs` gitlink is deliberately not moved here — that follows once
the docs PR merges.

Cross-linked:

- [Gryt-chat/reports](https://github.com/Gryt-chat/reports/pull/1) — the service
- [Gryt-chat/docs](https://github.com/Gryt-chat/docs/pull/64) — the public AI policy row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
