### PR TITLE
Sweep the reports submodule too, and point it at its main

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -39,6 +39,7 @@ on:
           - voice
           - mobile
           - bot
+          - reports
 
 permissions:
   contents: write
@@ -92,7 +93,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice packages/mobile packages/bot"
+          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice packages/mobile packages/bot packages/reports"
 
           # Clone straight from the URL rather than `git submodule update`,
           # which insists on the recorded gitlink and so fails on a broken one.
@@ -199,6 +200,14 @@ jobs:
 
           if [[ "$SELECTED" == "all" || "$SELECTED" == "bot" ]]; then
             update_submodule "packages/bot" "$DEFAULT_SUBMODULE_BRANCH"
+          fi
+
+          # Added with the submodule itself rather than after the first stale
+          # pointer, which is how docs, site and auth ended up in the comment
+          # above. A submodule missing from this list is one whose gitlink only
+          # ever moves by hand, and nothing reports that it has stopped.
+          if [[ "$SELECTED" == "all" || "$SELECTED" == "reports" ]]; then
+            update_submodule "packages/reports" "$DEFAULT_SUBMODULE_BRANCH"
           fi
 
       - name: Commit changes


### PR DESCRIPTION
Follow-up to [gryt#114](https://github.com/Gryt-chat/gryt/pull/114), found while checking that the merge had landed everywhere.

`packages/reports` was missing from `update-submodules.yml` in all three places a submodule has to be named: the clone list, the `workflow_dispatch` choices, and the update block. Its gitlink would only ever have moved by hand — the same gap the comment already in that file records for docs, site and auth, and the reason those had to be bumped during the llms.txt work.

The pointer is also one commit behind, which is a second symptom of the same thing. `bump-gitlink.yml` in the new repository cannot see `GITLINK_DISPATCH_TOKEN`, so nothing pinged the superproject when reports#1 merged, and the hourly backstop had no entry for it to sweep. This PR moves it to the merge commit on `reports` main.

The org secret is still worth granting — `VIKUNJA_API_TOKEN`, `GITLINK_DISPATCH_TOKEN`, `DISCORD_CI_WEBHOOK_URL` and `DISCORD_RELEASE_WEBHOOK_URL` all need `Gryt-chat/reports` added to their selected-repositories list, or the board will not move on merge either. This makes the backstop work in the meantime, which is what it is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)