### PR TITLE
Stop defaulting the OIDC client id, and correct where the tunnel runs

### DIFF
--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -86,11 +86,11 @@ Give the inbox its own hostname through the tunnel — `inbox.gryt.chat` →
 `http://<box>:9477` — and set `REPORTS_OIDC_REDIRECT_URI` to match. Everyone signs in with
 a Gryt account and still has to be on the list.
 
-It is published on all interfaces so cloudflared can reach it: cloudflared runs in its own
-container, and a port bound to the host's loopback is not reachable from there. So the bind
-address is not what protects the inbox — **sign-in is**, and a deploy with
-`REPORTS_OIDC_ISSUER` unset leaves a shared token as the only thing in front of every
-report anyone has sent.
+It is published on all interfaces because the tunnel does not run on this box — it runs on
+another machine and reaches these services over the LAN, which is why every port here is
+published the same way. So the bind address is not what protects the inbox — **sign-in
+is**, and a deploy with `REPORTS_OIDC_ISSUER` unset leaves a shared token as the only thing
+in front of every report anyone has sent.
 
 For SSH-tunnel-only instead, set `INTERNAL_REPORTS_ADMIN_BIND=127.0.0.1` and reach it with:
 

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -86,13 +86,14 @@ services:
       # Ingest. The apps post here from wherever they are, so this is the one
       # cloudflared routes.
       - "${INTERNAL_REPORTS_HTTP_PORT:-9476}:8080"
-      # The inbox. On all interfaces by default, because cloudflared runs in a
-      # container and cannot reach the host's loopback — a hostname in front of
-      # this is the whole point of publishing it.
+      # The inbox. On all interfaces by default, because the tunnel does not run
+      # on this box — it runs on another machine and reaches these services over
+      # the LAN, which is why every port here is published the same way. A
+      # loopback bind would be unreachable from it entirely.
       #
-      # That also means anything routed to this box reaches it, so what guards
-      # the inbox here is Keycloak sign-in rather than the bind address. Set
-      # INTERNAL_REPORTS_ADMIN_BIND=127.0.0.1 to go back to SSH-tunnel-only.
+      # That also means anything on the network reaches it, so what guards the
+      # inbox here is Keycloak sign-in rather than the bind address. Set
+      # INTERNAL_REPORTS_ADMIN_BIND=127.0.0.1 for SSH-tunnel-only instead.
       - "${INTERNAL_REPORTS_ADMIN_BIND:-0.0.0.0}:${INTERNAL_REPORTS_ADMIN_PORT:-9477}:8081"
     environment:
       # One key per app. Without at least one the service refuses to start,
@@ -112,7 +113,7 @@ services:
       # Signing in with a Gryt account. Who may actually read the inbox is a
       # list inside the service, not a role in the realm.
       REPORTS_OIDC_ISSUER: "${REPORTS_OIDC_ISSUER:-}"
-      REPORTS_OIDC_CLIENT_ID: "${REPORTS_OIDC_CLIENT_ID:-reports}"
+      REPORTS_OIDC_CLIENT_ID: "${REPORTS_OIDC_CLIENT_ID:-}"
       REPORTS_OIDC_CLIENT_SECRET: "${REPORTS_OIDC_CLIENT_SECRET:-}"
       REPORTS_OIDC_REDIRECT_URI: "${REPORTS_OIDC_REDIRECT_URI:-}"
       REPORTS_BOOTSTRAP_ADMIN: "${REPORTS_BOOTSTRAP_ADMIN:-}"


### PR DESCRIPTION
Pairs with [Gryt-chat/reports#3](https://github.com/Gryt-chat/reports/pull/3). Either change alone prevents the failure; both are in because they are two different mistakes.

**The compose default.** `REPORTS_OIDC_CLIENT_ID` defaulted to `reports` while the issuer and secret were empty, and the service refused to boot on "OIDC is half configured". A service with sign-in switched off should not fail on a default belonging to sign-in. Nothing here carries a default now.

**The comment.** It said the inbox binds `0.0.0.0` because cloudflared runs in its own container and cannot reach the host's loopback. That was a guess and it is wrong — there is no cloudflared on that box at all. The tunnel runs on another machine and reaches these services over the LAN, which is why every port in this file is published the same way. Same conclusion, right reason.

Found by deploying it: the container was created, refused to start, and said exactly why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)