### PR TITLE
Pass the Ollama settings through to the reports service

### DIFF
--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -55,7 +55,13 @@ REPORTS_SESSION_SECRET=replace-me
 # client sends one.
 REPORTS_REQUIRE_SIGNATURE=false
 
-# The triage pass. Without a key reports arrive unsorted, which still works.
+# The triage pass. Without one of these reports arrive unsorted, which still
+# works. A URL picks the local model, a key picks the API.
+#
+# Ollama runs on Astro, not on this box, so this is its LAN address — and it has
+# no authentication, so whatever can reach it can use that GPU.
+REPORTS_OLLAMA_URL=
+REPORTS_TRIAGE_MODEL=
 ANTHROPIC_API_KEY=
 REPORTS_NOTIFY_ON=triage
 REPORTS_DISCORD_WEBHOOK_URL=

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -106,8 +106,15 @@ services:
       # Behind the tunnel the socket address is cloudflared, so the client
       # address has to come from cf-connecting-ip.
       REPORTS_TRUST_PROXY: "true"
+      # Triage. A URL picks the local model, a key picks the API, and naming
+      # the provider wins over both. Ollama runs on another machine, so this is
+      # its address on the network rather than localhost.
+      REPORTS_TRIAGE_PROVIDER: "${REPORTS_TRIAGE_PROVIDER:-}"
+      REPORTS_OLLAMA_URL: "${REPORTS_OLLAMA_URL:-}"
+      REPORTS_OLLAMA_KEEP_ALIVE: "${REPORTS_OLLAMA_KEEP_ALIVE:-5m}"
+      REPORTS_TRIAGE_TIMEOUT_MS: "${REPORTS_TRIAGE_TIMEOUT_MS:-120000}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
-      REPORTS_TRIAGE_MODEL: "${REPORTS_TRIAGE_MODEL:-claude-opus-5}"
+      REPORTS_TRIAGE_MODEL: "${REPORTS_TRIAGE_MODEL:-}"
       REPORTS_DISCORD_WEBHOOK_URL: "${REPORTS_DISCORD_WEBHOOK_URL:-}"
       REPORTS_NOTIFY_ON: "${REPORTS_NOTIFY_ON:-triage}"
       # Signing in with a Gryt account. Who may actually read the inbox is a


### PR DESCRIPTION
Follows [Gryt-chat/reports#5](https://github.com/Gryt-chat/reports/pull/5), which adds the provider. This just carries the settings.

Nothing is turned on: with no `REPORTS_OLLAMA_URL` and no `ANTHROPIC_API_KEY`, triage does nothing and reports arrive unsorted — which is what happens today.

Two things worth knowing when it is turned on:

- **Ollama runs on Astro, not on this box.** So `REPORTS_OLLAMA_URL` is a LAN address, and Ollama has to bind `0.0.0.0` rather than loopback or the container cannot reach it at all.
- **Ollama has no authentication.** Whatever can reach it can use that GPU, and it is the same card Frigate runs its detector on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)