### PR TITLE
Tell the report service which proxy to believe

### DIFF
--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -36,6 +36,12 @@ REPORTS_APP_KEYS=mobile:replace-me,desktop:replace-me,web:replace-me
 REPORTS_ADMIN_TOKEN=replace-me
 REPORTS_PUBLIC_URL=https://reports.gryt.chat
 
+# Whose forwarding headers to believe. The tunnel runs on another machine, so
+# this is its LAN address. Empty believes any peer, and the ingest port is
+# reachable from the whole network — so empty means anything on the LAN can name
+# its own address and skip every rate limit and every ban.
+REPORTS_TRUSTED_PROXIES=192.168.50.182
+
 # Signing in to the inbox with a Gryt account. Create a confidential client in
 # the gryt realm (see ops/internal/README.md) and put its secret here.
 REPORTS_OIDC_ISSUER=https://auth.gryt.chat/realms/gryt

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -103,9 +103,13 @@ services:
       REPORTS_PUBLIC_URL: "${REPORTS_PUBLIC_URL:-https://reports.gryt.chat}"
       REPORTS_CORS_ORIGINS: "${REPORTS_CORS_ORIGINS:-https://app.gryt.chat,https://beta.gryt.chat}"
       REPORTS_REQUIRE_SIGNATURE: "${REPORTS_REQUIRE_SIGNATURE:-false}"
-      # Behind the tunnel the socket address is cloudflared, so the client
-      # address has to come from cf-connecting-ip.
+      # Behind the tunnel the socket address is the proxy, so the client
+      # address has to come from cf-connecting-ip — and only when the proxy is
+      # the one connecting. The ingest port is on the machine's network
+      # address, so without this list anything on the LAN can claim any address
+      # and skip every per-address rate limit and ban.
       REPORTS_TRUST_PROXY: "true"
+      REPORTS_TRUSTED_PROXIES: "${REPORTS_TRUSTED_PROXIES:-}"
       # Triage. A URL picks the local model, a key picks the API, and naming
       # the provider wins over both. Ollama runs on another machine, so this is
       # its address on the network rather than localhost.


### PR DESCRIPTION
Follows [Gryt-chat/reports#6](https://github.com/Gryt-chat/reports/pull/6), which stops the service believing a forwarding header from just anyone. This passes the setting through.

The ingest port is published on the box's network address, so the tunnel is not the only thing that can reach it. Until `REPORTS_TRUSTED_PROXIES` is set, anything on the LAN can send `cf-connecting-ip: 1.2.3.4` and opt itself out of every per-address rate limit and every ban.

The example names `192.168.50.182`, the machine the tunnel runs on.

**Check it rather than trusting it.** After setting it, file a report through `reports.gryt.chat` and look at the stored address. If it comes out as the tunnel's address rather than yours, the list is wrong and every report from now on looks like it came from one machine — which would quietly make per-address limits useless in the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)