### PR TITLE
Report a failing Windows build probe in Discord (GRYT-526)

### DIFF
--- a/.github/workflows/discord-ci-notify.yml
+++ b/.github/workflows/discord-ci-notify.yml
@@ -13,8 +13,9 @@ on:
     workflows:
       - Release Client
       - Release Server
-      - Update Submodules
       - Sync Vikunja task
+      - Update Submodules
+      - Windows build probe
     types: [completed]
 
 jobs:


### PR DESCRIPTION
Part of **GRYT-526** — a failing `CI` notifies nobody, in every repo in the org.

`discord-ci-notify.yml` lists the workflows it reports on by name, and the file explains why in a comment:

> Workflows are listed by name rather than left to a wildcard: GitHub's docs don't say whether omitting `workflows` means all of them, and an unlisted workflow notifies nobody. **Add new workflows here as you add them.**

Checked against the GitHub docs on 2026-08-22 — they still do not say. So the explicit list is a reasoned choice and not the thing that is broken. The list simply has not kept up.

``Windows build probe`` was never added. So it has been failing silently, in the sense that matters: red pull request, nothing in #ci.

That is worth caring about here because somebody clearly did — `docs` carries a whole `CI self-test` workflow whose only job is to fire the #ci alert on demand, on the reasoning that *"an alert nobody has ever seen fire is not yet an alert"*.

## The whole survey

Ten repos needed a change. Same one-line shape everywhere, opened separately because they are separate repos:

| repo | what was missing |
|---|---|
| client, server, docs, site | `CI` |
| image-worker | `Release Image Worker` (`sfu` lists `Release SFU`; this one did not list its equivalent) |
| gryt superproject | `Windows build probe` |
| voice, ui, cli, mobile | the whole file — no notifications of any kind, including release workflows |
| sfu | `CI` — added in [sfu#16](https://github.com/Gryt-chat/sfu/pull/16), which is what turned this up |
| auth | nothing; it has the file and has no `CI` workflow to list |

## Left alone on purpose

`Bump superproject gitlink` is unlisted in every repo that has it. That is consistent enough to read as deliberate — it is noisy and low-stakes — so it was not touched. Same for `Copilot cloud agent` and the GitHub-provided `Dependency Graph`. Say the word if any of those should report too; it is one line each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Note on the diff:** the existing list was not quite alphabetical (`Update Submodules` sat before `Sync Vikunja task`), so inserting kept the sort and moved one line. Cosmetic; say so if you would rather keep the original order.
