### PR TITLE
Pass the triage thinking switch through to the service

### DIFF
--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -62,8 +62,12 @@ REPORTS_REQUIRE_SIGNATURE=false
 #
 # Ollama runs on Astro, not on this box, so this is its LAN address — and it has
 # no authentication, so whatever can reach it can use that GPU.
+# qwen3:14b fits entirely on a 12GB card and leaves Frigate its room. Thinking
+# on costs about fifteen seconds a report and buys summaries that name the
+# fault rather than describing it.
 REPORTS_OLLAMA_URL=
-REPORTS_TRIAGE_MODEL=
+REPORTS_TRIAGE_MODEL=qwen3:14b
+REPORTS_TRIAGE_THINK=true
 ANTHROPIC_API_KEY=
 REPORTS_NOTIFY_ON=triage
 REPORTS_DISCORD_WEBHOOK_URL=

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -108,6 +108,10 @@ services:
       REPORTS_OLLAMA_URL: "${REPORTS_OLLAMA_URL:-}"
       REPORTS_OLLAMA_KEEP_ALIVE: "${REPORTS_OLLAMA_KEEP_ALIVE:-5m}"
       REPORTS_TRIAGE_TIMEOUT_MS: "${REPORTS_TRIAGE_TIMEOUT_MS:-120000}"
+      # Whether the model may reason before it answers. Worth the extra seconds
+      # on a model that fits on the card: it is the difference between "the app
+      # crashed" and "TypeError in ChannelList".
+      REPORTS_TRIAGE_THINK: "${REPORTS_TRIAGE_THINK:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       REPORTS_TRIAGE_MODEL: "${REPORTS_TRIAGE_MODEL:-}"
       REPORTS_DISCORD_WEBHOOK_URL: "${REPORTS_DISCORD_WEBHOOK_URL:-}"


### PR DESCRIPTION
`REPORTS_TRIAGE_THINK` exists in the service and was missing from the compose, so setting it in `ops/internal/.env` did nothing — and did it silently, which is the worst shape for a setting to have. Found by setting it.

## Why it is worth the seconds

Measured on the four reports in the inbox, same prompts, same schema, on the box's own hardware:

| | 14B | 14B + thinking | 32B |
|---|---|---|---|
| four reports | 34s | 93s | minutes each |
| on GPU | 100% | 100% | 50%, rest in RAM |
| crash summary | "TypeError" | **"TypeError in ChannelList"** | "TypeError in ChannelList" |
| voice summary | "cuts out on network change" | **"ICE disconnect on network change"** | "cuts out on network change" |

Thinking reads the stack trace and the log tail rather than the message. For a queue somebody skims, the difference is whether a line is worth opening.

`qwen3:14b` is the pick over `qwen3:32b`: it fits entirely on the 3060 so Frigate keeps its headroom, runs about ten times faster, and differs from the 32B on exactly one judgement out of four — a priority call that is arguable either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)