### PR TITLE
Pass the report service's new settings through compose (GRYT-529)

### DIFF
--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -25,7 +25,25 @@ FIDER_JWT_SECRET=replace-me
 
 # ── Reports (bug reports and feedback from inside the apps) ──────────────
 # One key per app, sent as X-Gryt-App-Key. Generate with: openssl rand -hex 32
-REPORTS_APP_KEYS=mobile:replace-me,desktop:replace-me,web:replace-me
+# Empty (GRYT-529). A key that ships inside a public app is not a secret, and
+# the day it needs rotating is the day everybody who has not updated stops
+# being able to report a bug. What holds the line instead is below.
+#
+# Not additive with ALLOW_UNKEYED: with keys set, an app id that is not among
+# them is refused whatever that says. Unkeyed means leaving both as they are.
+REPORTS_APP_KEYS=
+REPORTS_ALLOW_UNKEYED=true
+
+# Shortest gap between one client's reports, in seconds. 0 turns it off.
+REPORTS_MIN_INTERVAL_SEC=10
+
+# Triage bans whoever keeps sending junk: this many "noise" verdicts inside the
+# window earns a ban lasting this many days, on the identity thumbprint where
+# there is one and the address otherwise. Only "noise" counts — "not_a_bug" is
+# a feature request or a support question. 0 turns it off.
+REPORTS_AUTO_BAN_NOISE=3
+REPORTS_AUTO_BAN_WINDOW_H=24
+REPORTS_AUTO_BAN_DAYS=7
 
 # The token for scripts and anything reading the inbox as JSON. People sign in
 # with their Gryt account instead — see below.

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -87,9 +87,24 @@ services:
       # hostname, behind Keycloak sign-in.
       - "${INTERNAL_REPORTS_HTTP_PORT:-9476}:8080"
     environment:
-      # One key per app. Without at least one the service refuses to start,
-      # because what it exposes is a public POST endpoint.
+      # One key per app, and empty here (GRYT-529). A key that ships inside a
+      # public app is not a secret, and the day it needs rotating is the day
+      # everybody who has not updated stops being able to report a bug.
+      #
+      # Not additive with ALLOW_UNKEYED below: with keys set, an app id that is
+      # not among them is refused whatever that says. Unkeyed means both.
       REPORTS_APP_KEYS: "${REPORTS_APP_KEYS:-}"
+      REPORTS_ALLOW_UNKEYED: "${REPORTS_ALLOW_UNKEYED:-false}"
+      # The shortest gap between one client's reports. A script posting in a
+      # loop is stopped by its second request, before any hourly counter has
+      # noticed — the cheapest check here and the one that does the most.
+      REPORTS_MIN_INTERVAL_SEC: "${REPORTS_MIN_INTERVAL_SEC:-10}"
+      # Triage bans whoever keeps sending junk. Only the noise verdict counts;
+      # not_a_bug is a feature request or a support question, and banning that
+      # person is the opposite of what this inbox is for.
+      REPORTS_AUTO_BAN_NOISE: "${REPORTS_AUTO_BAN_NOISE:-3}"
+      REPORTS_AUTO_BAN_WINDOW_H: "${REPORTS_AUTO_BAN_WINDOW_H:-24}"
+      REPORTS_AUTO_BAN_DAYS: "${REPORTS_AUTO_BAN_DAYS:-7}"
       REPORTS_ADMIN_TOKEN: "${REPORTS_ADMIN_TOKEN:-}"
       REPORTS_PUBLIC_URL: "${REPORTS_PUBLIC_URL:-https://reports.gryt.chat}"
       REPORTS_CORS_ORIGINS: "${REPORTS_CORS_ORIGINS:-https://app.gryt.chat,https://beta.gryt.chat}"


### PR DESCRIPTION
[Gryt-chat/reports#13](https://github.com/Gryt-chat/reports/pull/13) added four
settings and `ops/internal/docker-compose.yml` named none of them, so
`REPORTS_ALLOW_UNKEYED=true` in `.env` reached nothing and the service refused
to start with no keys configured — which is the state GRYT-529 wants it in.

It crash-looped on the box for about a minute on the way to finding that out.
Already fixed there; this is the same change committed so the checkout and
`main` do not drift.

## The thing to remember

Every variable the service reads has to be listed in the `environment:` block.
The container gets the environment compose builds, not the file `--env-file`
points at, so a new setting in `.env` alone is silently inert — and when the
setting is one the service refuses to start without, the symptom is a boot loop
rather than a default.

## Also worth knowing

`REPORTS_APP_KEYS` and `REPORTS_ALLOW_UNKEYED` are **not additive**. With keys
set, an app id that is not among them is refused whatever the flag says. Taking
unkeyed reports means leaving the keys empty as well as setting the flag. Now
written down in both files, because it is the part most likely to bite whoever
configures this next.

## Verified on reports.gryt.chat

Running v0.1.9, healthy, `0 app key(s), signature optional`:

- An unkeyed report is accepted — `202`.
- A second one inside ten seconds — `429`, `Retry-After: 10`.
- A request claiming `Origin: https://evil.example` — `403`.

The three app keys that used to be in `ops/internal/.env` are gone. They had
leaked into a chat log, and emptying the list is the rotation — they authorise
nothing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)