### PR TITLE
Pass the digest and board settings to the reports container (GRYT-537)

### DIFF
--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -100,3 +100,15 @@ GRYT_SMTP_PASS=replace-me
 
 # Fider SMTP options
 FIDER_EMAIL_SMTP_ENABLE_STARTTLS=true
+
+# Filing a report as a task on the board (GRYT-534). A write credential.
+REPORTS_VIKUNJA_URL=https://tasks.sivert.io
+REPORTS_VIKUNJA_TOKEN=
+REPORTS_VIKUNJA_PROJECT=2
+
+# The weekly digest (GRYT-537). Monday 09:00, on the service's own clock.
+# SMTP is the GRYT_SMTP_* set below, shared with the rest of Gryt. Without a
+# host the digest does not run and the service starts as normal.
+REPORTS_DIGEST_ENABLED=true
+REPORTS_DIGEST_DAY=1
+REPORTS_DIGEST_HOUR=9

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -130,6 +130,26 @@ services:
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       REPORTS_TRIAGE_MODEL: "${REPORTS_TRIAGE_MODEL:-}"
       REPORTS_DISCORD_WEBHOOK_URL: "${REPORTS_DISCORD_WEBHOOK_URL:-}"
+      # Filing a report as a task on the board (GRYT-534). A write credential,
+      # so it is empty here and set in .env; without it the button is not
+      # offered rather than offered and broken.
+      REPORTS_VIKUNJA_URL: "${REPORTS_VIKUNJA_URL:-https://tasks.sivert.io}"
+      REPORTS_VIKUNJA_TOKEN: "${REPORTS_VIKUNJA_TOKEN:-}"
+      REPORTS_VIKUNJA_PROJECT: "${REPORTS_VIKUNJA_PROJECT:-2}"
+      # The weekly digest (GRYT-537). SMTP is the GRYT_SMTP_* set the rest of
+      # Gryt already points at Postmark, rather than a second copy to rotate —
+      # which is exactly why it has to be named here: a variable that is in
+      # .env and not in this block reaches nothing, silently.
+      REPORTS_DIGEST_ENABLED: "${REPORTS_DIGEST_ENABLED:-}"
+      REPORTS_DIGEST_DAY: "${REPORTS_DIGEST_DAY:-1}"
+      REPORTS_DIGEST_HOUR: "${REPORTS_DIGEST_HOUR:-9}"
+      GRYT_SMTP_HOST: "${GRYT_SMTP_HOST:-}"
+      GRYT_SMTP_PORT: "${GRYT_SMTP_PORT:-587}"
+      GRYT_SMTP_USER: "${GRYT_SMTP_USER:-}"
+      GRYT_SMTP_PASS: "${GRYT_SMTP_PASS:-}"
+      GRYT_SMTP_FROM: "${GRYT_SMTP_FROM:-hello@gryt.chat}"
+      GRYT_SMTP_FROM_NAME: "${GRYT_SMTP_FROM_NAME:-Gryt}"
+      GRYT_SMTP_REPLY_TO: "${GRYT_SMTP_REPLY_TO:-}"
       REPORTS_NOTIFY_ON: "${REPORTS_NOTIFY_ON:-triage}"
       # Signing in with a Gryt account. Who may actually read the inbox is a
       # list inside the service, not a role in the realm.


### PR DESCRIPTION
`GRYT_SMTP_*` has been in `ops/internal/.env` all along for the rest of Gryt,
and `REPORTS_VIKUNJA_*` went in with GRYT-534 — but neither reaches the reports
container. It gets the environment this file builds, not the file `--env-file`
points at.

So without this, the digest starts, finds no SMTP host, and logs that it is
off, with the host sitting right there in `.env`. And Create task never offers
itself, because the token it looks for is not in its environment.

This is the same failure as GRYT-529, where `REPORTS_ALLOW_UNKEYED=true` in
`.env` reached nothing and the service crash-looped for a minute. Third time,
so the block now says it in words: **a variable named in `.env` and not here is
inert, and nothing tells you.**

## What's added

| | |
|---|---|
| `REPORTS_VIKUNJA_URL` / `_TOKEN` / `_PROJECT` | GRYT-534, the Create task button |
| `REPORTS_DIGEST_ENABLED` / `_DAY` / `_HOUR` | Monday 09:00 by default |
| `GRYT_SMTP_HOST` / `_PORT` / `_USER` / `_PASS` / `_FROM` / `_FROM_NAME` / `_REPLY_TO` | shared with the rest of Gryt |

The SMTP set is shared rather than copied. A second `REPORTS_SMTP_*` would be a
second thing to rotate and a second thing to get out of step.

`docker compose config` parses. Nothing needs setting on the box for this to be
safe to merge — every value already has a default, and the digest stays off
until `GRYT_SMTP_HOST` reaches the container, which is what this enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)