### PR TITLE
List the pull requests in a release instead of pointing at the manifest

### DIFF
--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -1,0 +1,217 @@
+/* eslint-env node */
+
+/**
+ * What changed between two releases, as the body of a GitHub release.
+ *
+ * Every other repository in the org gets this for free from
+ * `generate_release_notes: true`, which lists the pull requests merged since the
+ * previous tag. That does nothing useful here. The superproject's own commits
+ * between two releases are `chore: update all submodules on main [skip ci]` and
+ * a version bump — the work is in four other repositories, and GitHub cannot
+ * see across them.
+ *
+ * So this builds the same thing by hand. Both manifests name the exact commit
+ * each component was built from, so the range per component is a subtraction,
+ * and every merged pull request in that range is one line of `git log`.
+ *
+ * The alternative it replaces was a release body that said "see manifest.json
+ * for the exact commits". True, and nobody has ever done it.
+ *
+ *   node .github/scripts/release-notes.mjs \
+ *     --previous <manifest.json> --current <manifest.json> [--repo-root .]
+ *
+ * Writes markdown to stdout. Missing a previous manifest is not an error — the
+ * first release of a line has nothing to diff against and says so.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+/* --- arguments ----------------------------------------------------------- */
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 2) {
+  args.set(process.argv[i].replace(/^--/, ""), process.argv[i + 1]);
+}
+const repoRoot = args.get("repo-root") ?? process.cwd();
+const currentPath = args.get("current");
+const previousPath = args.get("previous");
+
+if (!currentPath) {
+  console.error("usage: release-notes.mjs --current <manifest.json> [--previous <manifest.json>]");
+  process.exit(1);
+}
+
+const current = JSON.parse(readFileSync(currentPath, "utf8"));
+const previous =
+  previousPath && existsSync(previousPath)
+    ? JSON.parse(readFileSync(previousPath, "utf8"))
+    : null;
+
+/** The order they are listed in, and what to call each one. */
+const COMPONENTS = [
+  ["client", "Client"],
+  ["server", "Server"],
+  ["sfu", "SFU"],
+  ["imageWorker", "Image worker"],
+];
+
+/* --- reading a component's history --------------------------------------- */
+
+function git(cwd, cmdArgs) {
+  return execFileSync("git", cmdArgs, { cwd, encoding: "utf8", maxBuffer: 32 * 1024 * 1024 });
+}
+
+/** Does this repository have that commit? A shallow clone often does not. */
+function has(cwd, commit) {
+  try {
+    git(cwd, ["cat-file", "-e", `${commit}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Commits between two points, first parent only.
+ *
+ * `--first-parent` is what turns a branch's worth of commits into one line per
+ * pull request. Without it a squash-merge repository reads correctly and a
+ * merge-commit one lists every intermediate commit somebody pushed while
+ * working, which is not what a release note is.
+ */
+function commits(cwd, from, to) {
+  const out = git(cwd, [
+    "log",
+    "--first-parent",
+    "--no-merges",
+    "--format=%H%x1f%s%x1f%b%x1e",
+    `${from}..${to}`,
+  ]);
+  return out
+    .split("\x1e")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [sha, subject, body] = entry.split("\x1f");
+      return { sha, subject: subject ?? "", body: body ?? "" };
+    });
+}
+
+/**
+ * The pull request a commit came from, if it names one.
+ *
+ * Two shapes appear in these repositories. A squash merge — which is how
+ * everything lands now — puts the number on the end of the subject:
+ * `Say when a join failed (GRYT-559) (#234)`. Older commits came through merge
+ * commits, `Merge pull request #68 from Gryt-chat/…`, whose real title is the
+ * first line of the body.
+ *
+ * Anything with no number at all is still listed. A commit pushed straight to
+ * main is exactly the kind of thing worth seeing in a release note, and
+ * dropping it because it skipped review would be the wrong way round.
+ */
+function describe(commit) {
+  const squashed = /^(.*)\s+\(#(\d+)\)\s*$/.exec(commit.subject);
+  if (squashed) return { title: squashed[1].trim(), pr: Number(squashed[2]) };
+
+  const merged = /^Merge pull request #(\d+) from /.exec(commit.subject);
+  if (merged) {
+    const title = commit.body.split("\n").map((l) => l.trim()).find(Boolean);
+    return { title: title || commit.subject, pr: Number(merged[1]) };
+  }
+
+  return { title: commit.subject.trim(), pr: null };
+}
+
+/**
+ * Commits that are about cutting a release rather than about the product.
+ *
+ * The version bump each component makes on its own release is noise in a note
+ * about what changed, and it is always there.
+ */
+function isRelease(title) {
+  return /^(release|chore\(release\)):/i.test(title) || /^v?\d+\.\d+\.\d+/.test(title);
+}
+
+/* --- building the note --------------------------------------------------- */
+
+const sections = [];
+const compareLinks = [];
+const problems = [];
+
+for (const [key, label] of COMPONENTS) {
+  const now = current.components?.[key];
+  if (!now) continue;
+
+  const before = previous?.components?.[key];
+  const cwd = path.join(repoRoot, now.path);
+
+  if (!existsSync(path.join(cwd, ".git"))) {
+    problems.push(`${label}: ${now.path} is not checked out, so its changes are not listed.`);
+    continue;
+  }
+  if (!before) {
+    sections.push(`### ${label}\n\nFirst release including this component.`);
+    continue;
+  }
+  if (before.commit === now.commit) continue;
+  if (!has(cwd, before.commit) || !has(cwd, now.commit)) {
+    problems.push(
+      `${label}: ${before.commit.slice(0, 7)}..${now.commit.slice(0, 7)} is not in the ` +
+        "local clone, so its changes are not listed.",
+    );
+    continue;
+  }
+
+  const entries = commits(cwd, before.commit, now.commit)
+    .map(describe)
+    .filter((entry) => entry.title && !isRelease(entry.title));
+
+  compareLinks.push(
+    `* ${label}: https://github.com/${now.repo}/compare/${before.commit}...${now.commit}`,
+  );
+
+  if (entries.length === 0) continue;
+
+  const lines = entries.map((entry) =>
+    entry.pr
+      ? `* ${entry.title} in https://github.com/${now.repo}/pull/${entry.pr}`
+      : `* ${entry.title}`,
+  );
+  sections.push(`### ${label}\n\n${lines.join("\n")}`);
+}
+
+/* --- output -------------------------------------------------------------- */
+
+const out = [];
+out.push(`Gryt v${current.version}`, "", `Channel: ${current.channel}`, "");
+
+if (!previous) {
+  out.push(
+    "No previous release to compare against, so there is no list of changes.",
+    "",
+  );
+} else if (sections.length === 0) {
+  out.push(
+    `No component moved since v${previous.version}. This release rebuilds the same code.`,
+    "",
+  );
+} else {
+  out.push(`## What changed since v${previous.version}`, "", sections.join("\n\n"), "");
+}
+
+if (compareLinks.length > 0) {
+  out.push("**Full changelogs**", "", compareLinks.join("\n"), "");
+}
+if (problems.length > 0) {
+  out.push("<!-- " + problems.join(" ") + " -->", "");
+}
+
+out.push(
+  "Built from the monorepo with pinned submodule commits. `manifest.json` below " +
+    "names the exact commit each component was built from.",
+);
+
+process.stdout.write(out.join("\n").replace(/\n{3,}/g, "\n\n") + "\n");

--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -18,7 +18,15 @@
  * for the exact commits". True, and nobody has ever done it.
  *
  *   node .github/scripts/release-notes.mjs \
- *     --previous <manifest.json> --current <manifest.json> [--repo-root .]
+ *     --previous <manifest.json> --current <manifest.json> [--repo-root .] \
+ *     [--title "Gryt Server"] [--details <file>]
+ *
+ * `--title` names the product in the first line, because two workflows use
+ * this and one of them is releasing the server rather than Gryt itself.
+ * `--details` is a file of markdown dropped in under the channel line, which
+ * is where the server release puts its image tag and its bundle names —
+ * before the list of changes, since somebody opening that page came for the
+ * download.
  *
  * Writes markdown to stdout. Missing a previous manifest is not an error — the
  * first release of a line has nothing to diff against and says so.
@@ -37,6 +45,8 @@ for (let i = 2; i < process.argv.length; i += 2) {
 const repoRoot = args.get("repo-root") ?? process.cwd();
 const currentPath = args.get("current");
 const previousPath = args.get("previous");
+const title = args.get("title") ?? "Gryt";
+const detailsPath = args.get("details");
 
 if (!currentPath) {
   console.error("usage: release-notes.mjs --current <manifest.json> [--previous <manifest.json>]");
@@ -186,7 +196,11 @@ for (const [key, label] of COMPONENTS) {
 /* --- output -------------------------------------------------------------- */
 
 const out = [];
-out.push(`Gryt v${current.version}`, "", `Channel: ${current.channel}`, "");
+out.push(`${title} v${current.version}`, "", `Channel: ${current.channel}`, "");
+
+if (detailsPath && existsSync(detailsPath)) {
+  out.push(readFileSync(detailsPath, "utf8").trim(), "");
+}
 
 if (!previous) {
   out.push(

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -498,6 +498,47 @@ jobs:
 
           cat .release/manifest.json
 
+      # Every other repository in the org gets its release notes from
+      # `generate_release_notes: true`, which lists the pull requests merged
+      # since the previous tag. That is useless here: the superproject's own
+      # commits between two releases are submodule bumps and a version bump, and
+      # the work is in four repositories GitHub cannot see across.
+      #
+      # Runs before the tag is pushed, so the newest stable tag is still the
+      # previous release rather than this one.
+      - name: Build release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ steps.version.outputs.version }}"
+          PREVIOUS_MANIFEST="${RUNNER_TEMP}/previous-manifest.json"
+
+          # The previous stable release, whichever channel this one is. A beta
+          # then lists everything since the last thing most people are running,
+          # which is what patch-notes-style.md asks of the written note too — a
+          # note covering only beta.4..beta.5 describes a build nobody is on.
+          PREVIOUS_TAG="$(git tag --list 'v*' --sort=-v:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -vx "v${VERSION}" \
+            | head -n1 || true)"
+
+          ARGS=(--current .release/manifest.json --repo-root .)
+          if [[ -n "$PREVIOUS_TAG" ]] \
+            && git show "${PREVIOUS_TAG}:.release/manifest.json" > "$PREVIOUS_MANIFEST" 2>/dev/null; then
+            echo "Comparing against $PREVIOUS_TAG"
+            ARGS+=(--previous "$PREVIOUS_MANIFEST")
+          else
+            # Only reachable for a release line older than the manifest itself.
+            # Worth degrading rather than failing: a release with no list of
+            # changes still installs.
+            echo "No previous manifest found — the notes will say so."
+            rm -f "$PREVIOUS_MANIFEST"
+          fi
+
+          node .github/scripts/release-notes.mjs "${ARGS[@]}" > "${RUNNER_TEMP}/release-notes.md"
+          cat "${RUNNER_TEMP}/release-notes.md"
+
       - name: Commit release metadata and tag
         shell: bash
         env:
@@ -634,15 +675,7 @@ jobs:
           prerelease: ${{ steps.channel.outputs.channel == 'beta' }}
           draft: true
           files: .release/manifest.json
-          body: |
-            Gryt v${{ steps.version.outputs.version }}
-
-            Channel: ${{ steps.channel.outputs.channel }}
-
-            This release was built from the monorepo with pinned submodule commits.
-
-            See `manifest.json` for the exact client, server, SFU and image
-            worker commits.
+          body_path: ${{ runner.temp }}/release-notes.md
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -622,6 +622,87 @@ jobs:
 
           cat .release/server/manifest.json
 
+      # Same reasoning as release-client.yml: `generate_release_notes: true`
+      # lists the pull requests merged in *this* repository since the previous
+      # tag, and this repository's commits between two server releases are
+      # gitlink bumps. The work is in three others GitHub cannot see across.
+      #
+      # The previous manifest comes out of the release asset rather than out of
+      # a tag, which is the one way this differs from the client. That workflow
+      # commits its manifest, so it can read the old one back with `git show`.
+      # This one never has — the only copy of the last release's component
+      # commits is the file attached to that release.
+      - name: Build release notes
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          BUILD_WINDOWS: ${{ github.event.inputs.build_windows }}
+          BUILD_LINUX: ${{ github.event.inputs.build_linux }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          PREVIOUS_MANIFEST="${RUNNER_TEMP}/previous-manifest.json"
+          DETAILS="${RUNNER_TEMP}/release-details.md"
+
+          # What somebody came to this page for, so it goes above the changes.
+          # Only the bundles that were actually built: both were listed
+          # unconditionally before, and the two build inputs can be turned off
+          # one at a time, so the note promised a zip nobody uploaded.
+          {
+            printf '%s\n' "Docker image:" "ghcr.io/gryt-chat/server:${VERSION}" ""
+            if [[ "$BUILD_WINDOWS" == "true" || "$BUILD_LINUX" == "true" ]]; then
+              printf '%s\n' "Self-hosted bundles:"
+              if [[ "$BUILD_WINDOWS" == "true" ]]; then
+                printf '%s\n' "* Windows x64: gryt-server-windows-x64-v${VERSION}.zip"
+              fi
+              if [[ "$BUILD_LINUX" == "true" ]]; then
+                printf '%s\n' "* Linux x64: gryt-server-linux-x64-v${VERSION}.zip"
+              fi
+              printf '%s\n' "" "Each bundle carries the server, SFU and image-worker commits named in manifest.json."
+            fi
+          } > "$DETAILS"
+
+          # The newest stable tag whichever channel this is, so a beta lists
+          # everything since the last thing most people are running. The same
+          # choice release-client.yml makes, and what patch-notes-style.md asks
+          # of the written note: one covering only beta.4..beta.5 describes a
+          # build nobody is on.
+          #
+          # `Fetch server tags` ran long before this and the new tag is not
+          # created until two steps below, so this cannot pick itself. The
+          # grep is there for a rerun that arrives with the tag already local.
+          PREVIOUS_TAG="$(git -C packages/server tag --list 'v*' --sort=-v:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -vx "$TAG" \
+            | head -n1 || true)"
+
+          ARGS=(
+            --current .release/server/manifest.json
+            --repo-root .
+            --title "Gryt Server"
+            --details "$DETAILS"
+          )
+
+          if [[ -n "$PREVIOUS_TAG" ]] && gh release download "$PREVIOUS_TAG" \
+              --repo "${{ env.RELEASE_OWNER }}/${{ env.RELEASE_REPO }}" \
+              --pattern manifest.json \
+              --output "$PREVIOUS_MANIFEST" \
+              --clobber; then
+            echo "Comparing against $PREVIOUS_TAG"
+            ARGS+=(--previous "$PREVIOUS_MANIFEST")
+          else
+            # Reachable for a release line older than the manifest asset itself,
+            # and for one whose release was deleted. Worth degrading rather than
+            # failing: a release with no list of changes still installs.
+            echo "No manifest to compare against — the notes will say so."
+            rm -f "$PREVIOUS_MANIFEST"
+          fi
+
+          node .github/scripts/release-notes.mjs "${ARGS[@]}" > "${RUNNER_TEMP}/release-notes.md"
+          cat "${RUNNER_TEMP}/release-notes.md"
+
       - name: Commit monorepo release state
         shell: bash
         env:
@@ -756,27 +837,10 @@ jobs:
             FLAGS+=(--latest)
           fi
 
-          mkdir -p .release/server
-
-          printf '%s\n' \
-            "Gryt Server ${TAG}" \
-            "" \
-            "Channel: ${CHANNEL}" \
-            "" \
-            "Docker image:" \
-            "ghcr.io/gryt-chat/server:${VERSION}" \
-            "" \
-            "Self-hosted bundles:" \
-            "- Windows x64: gryt-server-windows-x64-v${VERSION}.zip" \
-            "- Linux x64: gryt-server-linux-x64-v${VERSION}.zip" \
-            "" \
-            "The self-hosted bundles include the server, SFU, and image-worker commits listed in manifest.json." \
-            > .release/server/release-notes.md
-
           gh release create "$TAG" \
             --repo "${{ env.RELEASE_OWNER }}/${{ env.RELEASE_REPO }}" \
             --title "Gryt Server ${TAG}" \
-            --notes-file .release/server/release-notes.md \
+            --notes-file "${RUNNER_TEMP}/release-notes.md" \
             "${FLAGS[@]}" \
             "${ASSETS[@]}"
 


### PR DESCRIPTION
The GitHub release body said "see `manifest.json` for the exact commits". True, and nobody has ever done it.

`generate_release_notes: true` does nothing useful in this repository: the commits here between two releases are submodule bumps and a version bump, and the work is in four repositories GitHub cannot see across. So `.github/scripts/release-notes.mjs` diffs the two manifests, turns each component's commit range into one line per merged pull request, and links them.

Wired into both `release-client.yml` and `release-server.yml`.

## Please look at

- **The server workflow never commits its manifest**, so the previous one comes out of the release asset through `gh release download` rather than out of a tag. That is the one way it differs from the client, and **that path has never run.** It cannot without a real release. If the previous release is gone, or predates the asset, the note degrades to saying there is nothing to compare against rather than failing the release.
- **The server note now lists only the bundles that were built.** Both were named unconditionally before, and `build_windows` and `build_linux` can each be turned off, so the note could promise a zip nobody uploaded.
- **`--first-parent`** in the log is what turns a branch into one line per pull request. Without it a merge-commit repository lists every intermediate commit somebody pushed while working, which is not what a release note is.
- **The previous tag is the newest stable one whichever channel this is**, so a beta lists everything since the last thing most people are running. A note covering only beta.4..beta.5 describes a build nobody is on.

## Two options on the shared script

`--title`, because one of the two workflows is releasing the server rather than Gryt itself, and `--details`, a block of markdown placed under the channel line. The image tag and the bundle names go there, above the list of changes, because somebody opening that page came for the download.

## Checks

Both workflows parse, both new steps pass `bash -n`, and the script produces the expected note for v1.6.30..v1.6.35 — 8 client PRs, 1 server, 2 SFU, each linked — with and without `--title`, `--details` and `--previous`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
