### PR TITLE
Catch the client and the mobile app on different @gryt/owl versions (GRYT-585)

### DIFF
--- a/.github/scripts/check-avatar-parity.sh
+++ b/.github/scripts/check-avatar-parity.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# Fails when the desktop client and the mobile app would draw avatars from
+# different copies of @gryt/owl.
+#
+# Neither repository can answer this on its own. The client's tests run against
+# the client's node_modules and mobile's run against mobile's, so both stay
+# green while the two resolve different versions — which is the failure the
+# package exists to prevent, one person drawn as two different people. It has
+# happened once already, quietly, while a test holding copied hashes passed.
+#
+# Usage: check-avatar-parity.sh [package ...]      (default: @gryt/owl)
+#
+# Reads the two yarn.lock files in place. The caller is responsible for having
+# packages/client and packages/mobile checked out at whatever refs it wants
+# compared; this script has no opinion about that.
+
+set -euo pipefail
+
+ROOT="${GRYT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# Keep the labels and the paths together — a mismatch report that names the
+# wrong app sends somebody to the wrong repository.
+APPS=(
+  "desktop client:$ROOT/packages/client/yarn.lock"
+  "mobile app:$ROOT/packages/mobile/yarn.lock"
+)
+
+PACKAGES=("$@")
+if [[ ${#PACKAGES[@]} -eq 0 ]]; then
+  PACKAGES=("@gryt/owl")
+fi
+
+# Pulls every top-level entry for one package out of a yarn v1 lockfile, as
+# "version<TAB>integrity" lines — one per entry, because more than one is
+# itself a finding (see below).
+#
+# Matching is anchored to column 0 on purpose. The same name also appears
+# indented under `dependencies:` of whatever depends on it, and those lines
+# carry a range rather than a resolved version.
+extract() {
+  local lockfile="$1" pkg="$2"
+
+  awk -v pkg="$pkg" '
+    # A block header is any unindented line. Entering one clears the state from
+    # the previous block, so a version or integrity belonging to some other
+    # package can never leak into this one.
+    /^[^[:space:]]/ {
+      # Yarn folds compatible ranges into one header:
+      #   "@gryt/owl@^0.1.0", "@gryt/owl@0.1.2":
+      # so look for the name followed by @, anywhere on the line.
+      want = index($0, "\"" pkg "@") > 0
+      version = ""
+      integrity = ""
+      next
+    }
+
+    !want { next }
+
+    $1 == "version" {
+      version = $2
+      gsub(/"/, "", version)
+    }
+
+    $1 == "integrity" {
+      integrity = $2
+    }
+
+    # Emit once both halves are in hand. Yarn writes version before integrity,
+    # and integrity is the last of the two, so this fires exactly once per
+    # block. A registry that omits integrity would simply never print, which
+    # the caller reports as "not found" rather than as a silent pass.
+    version != "" && integrity != "" {
+      print version "\t" integrity
+      version = ""
+      integrity = ""
+    }
+  ' "$lockfile"
+}
+
+failed=0
+
+for entry in "${APPS[@]}"; do
+  lockfile="${entry#*:}"
+
+  if [[ ! -f "$lockfile" ]]; then
+    echo "::error::No lockfile at $lockfile — is the submodule checked out?" >&2
+    exit 1
+  fi
+
+  # If yarn ever moves to berry the format changes completely and every lookup
+  # below starts returning nothing. That reads as "package not found", which is
+  # a confusing way to be told the parser is obsolete.
+  if ! head -5 "$lockfile" | grep -q "yarn lockfile v1"; then
+    echo "::error::$lockfile is not a yarn v1 lockfile — this parser needs rewriting." >&2
+    exit 1
+  fi
+done
+
+for pkg in "${PACKAGES[@]}"; do
+  echo "== $pkg"
+
+  declare -a versions=()
+  declare -a integrities=()
+
+  for entry in "${APPS[@]}"; do
+    label="${entry%%:*}"
+    lockfile="${entry#*:}"
+
+    # Not mapfile: this has to run on the bash 3.2 that ships with macOS as
+    # well as on the bash 5 in CI, and mapfile is bash 4.
+    found=()
+    while IFS= read -r line; do
+      found+=("$line")
+    done < <(extract "$lockfile" "$pkg")
+
+    if [[ ${#found[@]} -eq 0 ]]; then
+      echo "   $label: not in the lockfile"
+      echo "::error::$pkg is not resolved in $lockfile"
+      failed=1
+      versions+=("")
+      integrities+=("")
+      continue
+    fi
+
+    # More than one entry means this app resolved the package twice and ships
+    # both — the same person drawn two ways inside a single app, before the two
+    # apps are even compared. Yarn does this when the app's range and a
+    # dependency's range don't overlap.
+    if [[ ${#found[@]} -gt 1 ]]; then
+      echo "   $label: ${#found[@]} separate resolutions"
+      printf '     %s\n' "${found[@]}"
+      echo "::error::$pkg resolves to ${#found[@]} versions inside $lockfile — dedupe it first"
+      failed=1
+    fi
+
+    version="${found[0]%%$'\t'*}"
+    integrity="${found[0]#*$'\t'}"
+
+    # Already printed above in the multi-resolution case, and printing one of
+    # them a second time as if it were the answer only muddies the report.
+    if [[ ${#found[@]} -eq 1 ]]; then
+      echo "   $label: $version"
+    fi
+
+    versions+=("$version")
+    integrities+=("$integrity")
+  done
+
+  if [[ -n "${versions[0]}" && -n "${versions[1]}" ]]; then
+    if [[ "${versions[0]}" != "${versions[1]}" ]]; then
+      echo "::error::$pkg differs — desktop client ${versions[0]}, mobile app ${versions[1]}"
+      failed=1
+    elif [[ "${integrities[0]}" != "${integrities[1]}" ]]; then
+      # Same version number, different tarball. npm does not allow republishing
+      # a version, so this is either a proxy serving something else or one of
+      # the two locks being stale in a way the version alone cannot show.
+      echo "::error::$pkg is ${versions[0]} in both, but the integrity hashes differ:"
+      echo "::error::  desktop client ${integrities[0]}"
+      echo "::error::  mobile app     ${integrities[1]}"
+      failed=1
+    fi
+  fi
+
+  unset versions integrities
+done
+
+if [[ $failed -ne 0 ]]; then
+  echo
+  echo "The two apps would not draw the same avatars. Put both on one version" >&2
+  echo "and commit the lockfiles." >&2
+  exit 1
+fi
+
+echo
+echo "Both apps resolve the same avatar package."

--- a/.github/workflows/avatar-parity.yml
+++ b/.github/workflows/avatar-parity.yml
@@ -1,0 +1,76 @@
+name: Avatar parity
+
+# Checks that the desktop client and the mobile app resolve the same
+# @gryt/owl, so one person is drawn the same way in both.
+#
+# This lives in the superproject because nowhere else can see both apps. Each
+# repository tests against its own node_modules, so a skew leaves every test in
+# both suites green — which is how a copied set of hashes went on passing while
+# the two had already drifted apart once.
+
+on:
+  # The primary trigger, and it has to be time-based. The commit that changes
+  # which two versions ship together is the gitlink bump from Update
+  # Submodules, and that commit carries [skip ci] — so anything hung off
+  # `push` would be skipped on exactly the commits worth checking.
+  schedule:
+    - cron: "23 6 * * *"
+
+  workflow_dispatch:
+
+  # So a change to the check is exercised by the PR that makes it, rather than
+  # first running at 06:23 the morning after it merges.
+  pull_request:
+    paths:
+      - .github/scripts/check-avatar-parity.sh
+      - .github/workflows/avatar-parity.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: avatar-parity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Compare resolved avatar package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout monorepo
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Clone the two apps
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Cloned from the URL at main rather than resolved from the recorded
+          # gitlink, and the difference matters here. What ships is each
+          # repository's own main: the desktop client is built from client:main
+          # by Release Client, and the mobile app from mobile:main. The gitlink
+          # is a snapshot of that, usually current but sometimes an hour
+          # behind, so checking it would answer a slightly different question
+          # than the one being asked — and a pointer left at a commit that is
+          # not on the remote would fail the checkout outright.
+          #
+          # Blobless rather than shallow: --depth 1 would do, but a partial
+          # clone leaves the lockfile a normal file to read while skipping the
+          # rest of the history's contents.
+          for app in client mobile; do
+            # actions/checkout leaves an empty directory for each gitlink, and
+            # clone refuses a directory that has anything in it.
+            rm -rf "packages/${app}"
+
+            git clone --quiet --filter=blob:none --no-checkout \
+              "https://github.com/Gryt-chat/${app}.git" "packages/${app}"
+            git -C "packages/${app}" checkout --quiet origin/main -- yarn.lock
+            echo "${app}: $(git -C "packages/${app}" rev-parse --short origin/main)"
+          done
+
+      - name: Compare
+        shell: bash
+        run: .github/scripts/check-avatar-parity.sh

--- a/.github/workflows/discord-ci-notify.yml
+++ b/.github/workflows/discord-ci-notify.yml
@@ -11,6 +11,7 @@ name: Discord CI notification
 on:
   workflow_run:
     workflows:
+      - Avatar parity
       - Release Client
       - Release Server
       - Sync Vikunja task


### PR DESCRIPTION
Closes GRYT-585.

Both apps draw avatars by calling `@gryt/owl`, and neither can see the other's copy. The client's tests run against the client's `node_modules` and mobile's run against mobile's, so the two can resolve different versions with every test in both suites green. That is the failure the package was created to prevent — one person drawn as two different people — and it happened once already, quietly, while a mobile test holding copied hashes went on passing.

The superproject is the only place that sees both apps, so the check lives here.

## What it does

`.github/scripts/check-avatar-parity.sh` reads the resolved `@gryt/owl` out of `packages/client/yarn.lock` and `packages/mobile/yarn.lock` and fails when they disagree. It takes package names as arguments and defaults to `@gryt/owl`.

Beyond a plain version mismatch it also fails on:

- **Same version, different integrity.** npm does not allow republishing a version, so this means something other than npm answered, or one lockfile is stale in a way the version alone cannot show.
- **A package resolved twice inside one lockfile.** yarn does this when the app's range and a dependency's range don't overlap. That app already draws one person two ways on its own, before the two apps are compared.
- **A move off yarn v1.** The parser would otherwise report "not found" for everything, which is a confusing way to be told it is obsolete.

`.github/workflows/avatar-parity.yml` clones both repos at their own `main` and runs it.

## The parts worth looking at

**Why it is scheduled and not on push.** The commit that changes which two versions ship together is the gitlink bump from Update Submodules, and that commit carries `[skip ci]`. Anything hung off `push` would be skipped on exactly the commits worth checking. It also runs on PRs touching the check itself, so a change to it is exercised before merging.

**Why it clones at `main` rather than resolving the gitlink.** What ships is each repository's own main — the desktop client is built from `client:main` by Release Client, mobile from `mobile:main`. The gitlink is a snapshot of that, usually current but sometimes an hour behind, so checking it answers a slightly different question. A pointer left at a commit not on the remote would also fail the checkout outright, which is the failure `update-submodules.yml` already carries a comment about.

**The awk parser.** Matching is anchored to column 0 because the same package name also appears indented under `dependencies:` of whatever depends on it, carrying a range rather than a resolved version. `@gryt/owl` appears both ways in the client's lock today.

**It reports, it does not block a release.** Deliberately not wired into Release Client: mobile releases separately and lags, and blocking a client release on mobile's state trades one silent failure for a loud one at the wrong moment. It fails on a schedule and Discord picks it up.

## Verified

Ran end-to-end locally against `client:main` (648508f) and `mobile:main` (97843bd) — both resolve `@gryt/owl@0.1.0` with matching integrity, exit 0.

Each failure mode was exercised against tampered copies of the real lockfiles: version mismatch, package missing from one lock, two resolutions in one lock, matching version with a tampered integrity, a berry-format lockfile, and a missing lockfile. All six exit 1 with the intended message.

Run against `@gryt/voice` today and the client is on 0.4.1 while mobile is on 0.3.2. Real drift, but visible drift, and not what this is guarding — it is not in the default list.

## Not in this PR

`Windows build probe` is listed in `discord-ci-notify.yml` and there is no workflow by that name in this repository. Left alone as an unrelated edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)