### PR TITLE
Draft the changelog for a release, on the box (GRYT-634)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ ops/downloads/**
 ops/deploy/compose/local.yml
 ops/deploy/compose/pp.yml
 
+
+# Drafted release notes written by `changelog-notes.mjs --dump`, for reading
+# while the prompt is being worked on. Nothing else reads them.
+ops/internal/changelog/

--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -112,3 +112,18 @@ REPORTS_VIKUNJA_PROJECT=2
 REPORTS_DIGEST_ENABLED=true
 REPORTS_DIGEST_DAY=1
 REPORTS_DIGEST_HOUR=9
+
+# Reading a drafted release note before it is published (GRYT-635).
+#
+# gryt-changelog-notes.service drafts a note after a release and posts it to
+# reports, which holds it until somebody has read it at /admin/changelog. This
+# key is what lets it post, and has to match GRYT_CHANGELOG_KEY in
+# /etc/default/gryt-changelog-notes. Without it those routes do not exist.
+#
+# Not one of the app keys above: those ship inside a public binary, and this one
+# writes to a page.
+REPORTS_CHANGELOG_KEY=replace-me
+
+# Where changelog.json is written and served from. The reports service mounts
+# this writable and the site mounts it read-only, so there is one writer.
+GRYT_CHANGELOG_DIR=/var/lib/gryt-changelog

--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -330,3 +330,74 @@ the same reason it does above.
 
 The first run rebuilds all three and will take a few minutes. After that, most runs print
 three `already on <commit>` lines and stop.
+
+## Drafting the changelog
+
+`changelog-notes.mjs` writes the release notes for a stable release and leaves
+them where the site can fetch them. The facts are not guessed: every release
+commits `.release/manifest.json`, which pins the exact client, server, sfu and
+image worker commit it shipped, so the diff between two releases is `git log
+old..new` in four submodules. `patch-notes-style.md` at the repository root is
+the style guide, and it is handed to the model in full along with the headlines
+of the three notes written by hand.
+
+The model never writes markup. It fills a fixed shape — a headline, two to four
+sections of heading and paragraphs, and the recap list grouped by label — and
+the changelog page renders that shape with its own components. A malformed
+answer is detectable rather than merely ugly, and is dropped: the next run tries
+again rather than publishing something half-formed.
+
+Output goes to `GRYT_CHANGELOG_OUT`, which the `site` service bind-mounts at
+`/usr/share/nginx/html/release-notes`. The page fetches it at runtime, so a
+note is live as soon as the run finishes. Nothing rebuilds and nothing waits
+for a pull request.
+
+Stable releases only by default. `GRYT_CHANGELOG_CHANNELS="latest beta"` drafts
+the pre-releases as well, which the changelog page hides behind a toggle.
+
+Notes written by hand in `packages/site/content/changelog` are not touched and
+win where both exist.
+
+Releases older than **v1.2.12** have no manifest and are skipped — the format
+did not exist yet. Nothing here involves changesets; those live in the `ui`
+repository and version npm packages, which is a different job.
+
+### Installing the timer
+
+```bash
+sudo mkdir -p /var/lib/gryt-changelog
+sudo mkdir -p /usr/local/lib/gryt
+sudo ln -sfn "$PWD/ops/internal/changelog-notes.mjs" /usr/local/lib/gryt/changelog-notes.mjs
+sudo cp ops/internal/systemd/gryt-changelog-notes.env.example /etc/default/gryt-changelog-notes
+sudo cp ops/internal/systemd/gryt-changelog-notes.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now gryt-changelog-notes.timer
+```
+
+Edit `/etc/default/gryt-changelog-notes` before the first run. `OLLAMA_URL` has
+no useful default — the model does not run on this box — and the port is not
+optional.
+
+Then recreate the site container once so it picks up the new mount:
+
+```bash
+docker compose -f ops/internal/docker-compose.yml up -d --no-deps site
+```
+
+Needs Node 20 or newer on the host, and `gh` authenticated as something that
+can list releases on `Gryt-chat/gryt`.
+
+Run it by hand first, and read what it wrote before letting the timer have it:
+
+```bash
+node ops/internal/changelog-notes.mjs --dry-run   # the prompt, without the model
+node ops/internal/changelog-notes.mjs             # one run
+```
+
+`--dry-run` prints what it would ask for each release and calls nothing. Useful
+for reading the prompt after changing the style guide.
+
+A run with nothing to do costs one `gh release list`. A run with something to do
+is minutes: roughly eight per release on qwen3:32b on the machine this was
+written for, three on qwen3:14b. `sudo journalctl -u gryt-changelog-notes -n 50`
+for what it did.

--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -333,24 +333,44 @@ three `already on <commit>` lines and stop.
 
 ## Drafting the changelog
 
-`changelog-notes.mjs` writes the release notes for a stable release and leaves
-them where the site can fetch them. The facts are not guessed: every release
-commits `.release/manifest.json`, which pins the exact client, server, sfu and
-image worker commit it shipped, so the diff between two releases is `git log
-old..new` in four submodules. `patch-notes-style.md` at the repository root is
-the style guide, and it is handed to the model in full along with the headlines
-of the three notes written by hand.
+`changelog-notes.mjs` drafts the release notes for a stable release. The facts
+are not guessed: every release commits `.release/manifest.json`, which pins the
+exact client, server, sfu and image worker commit it shipped, so the diff
+between two releases is `git log old..new` in four submodules.
+`patch-notes-style.md` at the repository root is the style guide, and it is
+handed to the model in full along with the headlines of the three notes written
+by hand.
 
 The model never writes markup. It fills a fixed shape — a headline, two to four
 sections of heading and paragraphs, and the recap list grouped by label — and
 the changelog page renders that shape with its own components. A malformed
 answer is detectable rather than merely ugly, and is dropped: the next run tries
-again rather than publishing something half-formed.
+again rather than posting something half-formed.
 
-Output goes to `GRYT_CHANGELOG_OUT`, which the `site` service bind-mounts at
-`/usr/share/nginx/html/release-notes`. The page fetches it at runtime, so a
-note is live as soon as the run finishes. Nothing rebuilds and nothing waits
-for a pull request.
+### A draft is not published
+
+Each draft is posted to the reports service, which holds it until somebody has
+read it at [reports.gryt.chat/admin/changelog](https://reports.gryt.chat/admin/changelog)
+and pressed Publish or Reject. Reports is what writes `changelog.json` into the
+directory both containers mount, and the changelog page fetches it at runtime —
+so publishing takes seconds and nothing rebuilds.
+
+This script wrote that file itself until GRYT-635. Two fabricated drafts were
+caught by reading them while it was being built: one retold a different release
+wholesale, and one was a paraphrase — a section headed "Security improvements
+for identity and account tokens", about keychain encryption, in a release whose
+commit range does not contain the word keychain. It read like the rest of the
+note and it scored under the contamination guard in this script, so the guard is
+a backstop rather than a proof.
+
+`GRYT_CHANGELOG_URL` and `GRYT_CHANGELOG_KEY` are required and the script
+refuses to start without them. `GRYT_CHANGELOG_REDRAFT=1.6.43` drafts one
+version again even though reports already has a note for it; the existing draft
+is kept and marked superseded.
+
+The commit range each note was drafted from is posted with it and shown beside
+it in the inbox, so a claim can be checked against the commits. It is not in the
+file the site reads.
 
 Stable releases only by default. `GRYT_CHANGELOG_CHANNELS="latest beta"` drafts
 the pre-releases as well, which the changelog page hides behind a toggle.
@@ -378,10 +398,13 @@ Edit `/etc/default/gryt-changelog-notes` before the first run. `OLLAMA_URL` has
 no useful default — the model does not run on this box — and the port is not
 optional.
 
-Then recreate the site container once so it picks up the new mount:
+`GRYT_CHANGELOG_KEY` here has to match `REPORTS_CHANGELOG_KEY` in
+`ops/internal/.env`, which is what the reports service checks.
+
+Then recreate both containers once so they pick up the mounts:
 
 ```bash
-docker compose -f ops/internal/docker-compose.yml up -d --no-deps site
+docker compose -f ops/internal/docker-compose.yml up -d --no-deps site reports
 ```
 
 Needs Node 20 or newer on the host, and `gh` authenticated as something that
@@ -391,11 +414,15 @@ Run it by hand first, and read what it wrote before letting the timer have it:
 
 ```bash
 node ops/internal/changelog-notes.mjs --dry-run   # the prompt, without the model
+node ops/internal/changelog-notes.mjs --dump      # draft to disk, post nothing
 node ops/internal/changelog-notes.mjs             # one run
 ```
 
 `--dry-run` prints what it would ask for each release and calls nothing. Useful
-for reading the prompt after changing the style guide.
+for reading the prompt after changing the style guide. `--dump` asks the model
+and writes each draft to `GRYT_CHANGELOG_DUMP` instead of posting it, which is
+for working on the prompt without a reports instance to hand; nothing reads what
+it writes.
 
 A run with nothing to do costs one `gh release list`. A run with something to do
 is minutes: roughly eight per release on qwen3:32b on the machine this was

--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -428,3 +428,36 @@ A run with nothing to do costs one `gh release list`. A run with something to do
 is minutes: roughly eight per release on qwen3:32b on the machine this was
 written for, three on qwen3:14b. `sudo journalctl -u gryt-changelog-notes -n 50`
 for what it did.
+
+### The backfill
+
+42 stable releases have shipped and three have notes written by hand, so the
+first real run has about 35 to draft. That is four and a half hours on qwen3:32b
+and under two on qwen3:14b, and the unit's `TimeoutStartSec` is two hours — so
+run it by hand on the smaller model rather than letting the timer discover it:
+
+```bash
+# Old manifests pin commits a --depth 1 clone cannot reach, and the script
+# skips a release rather than drafting from half a range. Once, on the box.
+git -C /opt/gryt submodule foreach git fetch --unshallow
+
+sudo systemctl stop gryt-changelog-notes.timer
+set -a; . /etc/default/gryt-changelog-notes; set +a
+OLLAMA_MODEL=qwen3:14b GRYT_CHANGELOG_LIMIT=50 \
+  node ops/internal/changelog-notes.mjs
+sudo systemctl start gryt-changelog-notes.timer
+```
+
+Idempotent, so an interrupted run picks up where it stopped: the script asks
+reports which versions already have a note and skips those.
+
+Nothing is published by any of that. All 35 land in the queue at
+`/admin/changelog` waiting to be read, which is the point — and reading 35 is a
+sitting or two, not an afternoon, because the queue advances to the next one
+still waiting after each decision.
+
+Expect to reject some. qwen3:14b reads flatter than the 32b and copies more:
+in one run it produced a headline word for word from one of the hand-written
+notes it had been shown as an example, for a release about something else
+entirely. Rejecting frees the version, so the next tick draws it again — on
+whichever model is configured then.

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -198,6 +198,10 @@ const SCHEMA = {
   type: 'object',
   properties: {
     headline: { type: 'string' },
+    /* The untitled paragraph or two before the first heading. Every note
+       written by hand has one, and its absence is most of what made the first
+       drafts read like output rather than like writing. */
+    intro: { type: 'array', items: { type: 'string' } },
     sections: {
       type: 'array',
       items: {
@@ -224,7 +228,7 @@ const SCHEMA = {
       },
     },
   },
-  required: ['headline', 'sections', 'recap'],
+  required: ['headline', 'intro', 'sections', 'recap'],
 }
 
 /* The three notes written by hand, as the target. A rule can say "a sentence,
@@ -238,6 +242,26 @@ function examples(repo) {
     .filter((f) => f.endsWith('.mdx'))
     .map((f) => readFileSync(join(dir, f), 'utf8').match(/^headline:\s*(.+)$/m)?.[1]?.trim())
     .filter(Boolean)
+}
+
+/* One hand-written note in full, as the worked example.
+   The headlines alone were not enough: the drafts came back with no opening
+   paragraph at all, because nothing had shown the model that a note has one.
+   The newest is used on the assumption it is the most representative. */
+function workedExample(repo) {
+  const dir = join(repo, 'packages/site/content/changelog')
+  if (!existsSync(dir)) return null
+  const files = readdirSync(dir).filter((f) => f.endsWith('.mdx')).sort()
+  const newest = files[files.length - 1]
+  if (!newest) return null
+  const raw = readFileSync(join(dir, newest), 'utf8')
+  const body = raw.split('---').slice(2).join('---').trim()
+  /* Media and MDX components are not something the drafter can produce, and
+     showing them invites an attempt. */
+  return body
+    .replace(/^<(Image|Clip)[^>]*\/>\s*$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
 }
 
 function prompt(release, changes, style) {
@@ -254,13 +278,10 @@ function prompt(release, changes, style) {
     }
   }
   return [
-    `Gryt ${release.version} shipped on ${release.date}.`,
-    '',
-    'These are the commits it contains, grouped by component. Commit bodies are',
-    'included where the author wrote one, and they are usually the best source',
-    'for why a change was made.',
-    '',
-    lines.join('\n'),
+    'You are writing the release notes for one version of Gryt. The style guide',
+    'comes first, then an example of a finished note about a different release,',
+    'then the commits this release actually contains, then the rules for your',
+    'answer. Write about the commits. Follow the rules at the bottom.',
     '',
     '─────────────────────────────────────────────────────────────────────',
     'HOW GRYT PATCH NOTES ARE WRITTEN',
@@ -270,6 +291,30 @@ function prompt(release, changes, style) {
     '',
     style,
     '',
+    '─────────────────────────────────────────────────────────────────────',
+    'AN EXAMPLE OF THE SHAPE — ABOUT A DIFFERENT RELEASE',
+    '',
+    'This is a note somebody wrote by hand, for a version that is not the one you',
+    'are writing about. Read it for its shape and its voice: the paragraph at the',
+    'top with no heading, the length of the sections, how a sentence sounds.',
+    '',
+    'Its subject matter is not yours. It is about identity backups, password',
+    'managers and certificate authorities. Your release is almost certainly about',
+    'something else entirely. If any of its subjects appear in what you write, you',
+    'have copied the example instead of reading the commits, and the note is wrong.',
+    '',
+    '<<<EXAMPLE>>>',
+    workedExample(REPO) ?? '(none available)',
+    '<<<END EXAMPLE>>>',
+    '',
+    '─────────────────────────────────────────────────────────────────────',
+    `THE RELEASE YOU ARE WRITING ABOUT: Gryt ${release.version}, ${release.date}`,
+    '',
+    'These are the commits it contains, grouped by component, and they are the',
+    'only source for what this release changed. Commit bodies are included where',
+    'the author wrote one, and are usually the best source for why.',
+    '',
+    lines.join('\n'),
     '─────────────────────────────────────────────────────────────────────',
     'WHAT APPLIES TO THIS DRAFT',
     '',
@@ -294,6 +339,11 @@ function prompt(release, changes, style) {
     '',
     ...examples(REPO).map((h) => `              ${h}`),
     '',
+    '  intro     One or two paragraphs, no heading, before everything else.',
+    '            What this release is about: what was wrong, or what changed',
+    '            direction, or what somebody notices first. Not a summary of',
+    '            the sections below. If the release is small, one sentence',
+    '            saying so is the right answer.',
     '  sections  The article. Two to four, each about one thing that changed,',
     '            in the order the guide gives: what you notice, then what a',
     '            host notices, then what a careful person asks about. Each has',
@@ -337,7 +387,9 @@ function prompt(release, changes, style) {
     'date, a feature or a reason.',
     '',
     'If nothing in this release is visible to a user, return an empty sections',
-    'array, an empty recap, and a headline saying it is a maintenance release.',
+    'array, an empty recap, a one-sentence intro saying so, and a headline',
+    'saying it is a maintenance release.',
+    '',
   ].join('\n')
 }
 
@@ -392,10 +444,55 @@ async function ask(text) {
   }
 }
 
+/* Words that belong to the example and to nothing in this release.
+   The example is there to show the shape, and a model that has just read a
+   finished note is very willing to write that note again — the 1.6.43 draft
+   came back describing 24-word backups and certificate authorities, none of
+   which appear anywhere in its commit range. Telling it not to is not enough,
+   so this checks. */
+function contamination(entry, exampleText, commitText) {
+  if (!exampleText) return null
+  const words = (t) => new Set((t.toLowerCase().match(/[a-z][a-z-]{4,}/g) ?? []))
+  const inCommits = words(commitText)
+  const distinctive = [...words(exampleText)].filter(
+    (w) => !inCommits.has(w) && !COMMON.has(w),
+  )
+  const draft = words(JSON.stringify(entry))
+  const borrowed = distinctive.filter((w) => draft.has(w))
+  /* A handful is coincidence. A pile of it is the example being retold. The
+     contaminated 1.6.43 draft scored 59 against a correct one's 8, so there is
+     a lot of room between them; the ordinary English filtered out by COMMON is
+     what keeps a short commit range from making that gap look narrower than it
+     is. */
+  return borrowed.length > 20
+    ? `looks copied from the example (${borrowed.length} of its words, none in the commits: ${borrowed.slice(0, 6).join(', ')})`
+    : null
+}
+
+/* Ordinary English long enough to pass the length filter. A four-commit range
+   is small, so plenty of unremarkable words are "not in the commits" without
+   meaning anything at all. */
+const COMMON = new Set(`about after again against along already also although always
+  another anything around because become been before being below better between both
+  cannot could different does doing done during each either enough even every
+  everything first from further given gives going great group hardly have having
+  here however into itself just keep kept know large last later least less like
+  little long made make many might more most much must never next nothing
+  often once only other others over own part particular perhaps place point
+  quite rather really right same seem seems several should since small some
+  something sometimes still such take taken than that their them then there
+  these they thing things think this those though three through thus time
+  together
+  under until upon used uses using usually very want well were what when where
+  whether which while with within without would your yours` .split(/\s+/).filter(Boolean))
+
 /* Anything the model got wrong in a way that would reach the page. A bad entry
    is not written at all; the next run tries again. */
 function validate(entry) {
   if (typeof entry?.headline !== 'string' || !entry.headline.trim()) return 'no headline'
+  if (!Array.isArray(entry.intro) || entry.intro.some((p) => typeof p !== 'string')) {
+    return 'intro is missing or is not all strings'
+  }
   if (!Array.isArray(entry.sections)) return 'sections is not an array'
   for (const s of entry.sections) {
     if (typeof s?.heading !== 'string' || !s.heading.trim()) return 'a section has no heading'
@@ -474,13 +571,30 @@ async function main() {
         continue
       }
       const bad = validate(entry)
-      if (bad) { log(`  ! rejected: ${bad}`); continue }
+        ?? contamination(entry, workedExample(REPO), JSON.stringify(changes.parts))
+      if (bad) {
+        log(`  ! rejected: ${bad}`)
+        /* Kept, because a refusal nobody can read is a refusal nobody can
+           judge. This is how the first contaminated draft was diagnosed at
+           all, and a false positive is only findable this way. */
+        try {
+          const dir = join(dirname(OUT), 'rejected')
+          mkdirSync(dir, { recursive: true })
+          writeFileSync(
+            join(dir, `${release.version}.json`),
+            `${JSON.stringify({ version: release.version, reason: bad, entry }, null, 2)}\n`,
+          )
+          log(`    kept for inspection: ${join(dir, `${release.version}.json`)}`)
+        } catch { /* the draft is lost, which is the status quo */ }
+        continue
+      }
 
       doc.entries.push({
         version: release.version,
         date,
         channel: release.channel,
         headline: entry.headline.trim(),
+        intro: entry.intro,
         sections: entry.sections,
         recap: entry.recap,
         source: { since: prev.version, commits: count, model: OLLAMA_MODEL },

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -61,31 +61,52 @@ function sh(cmd, args, opts = {}) {
 
 /* ── Releases ──────────────────────────────────────────────────────────
    The tag is the source of truth for what shipped, and `isPrerelease` is
-   what separates a beta from a stable one. The manifest inside the tag
-   says which channel it called itself, but a tag that exists is a release
-   that happened, which a file in a working tree is not. */
+   what separates a beta from a stable one. */
+
+/* Ordered by version, not by date. Two reasons, both real here: the February
+   history rewrite re-pushed every old tag, so v1.0.137 carries a March 2026
+   publish date and sorts *after* releases that shipped long before it; and
+   v1.6.21 carries `0001-01-01`, which sorts before everything. "The previous
+   release" means the previous version, and only the version says so. */
+function compareVersions(a, b) {
+  const parse = (v) => v.replace(/^v/, '').split(/[.-]/).map((p) => (/^\d+$/.test(p) ? Number(p) : p))
+  const pa = parse(a)
+  const pb = parse(b)
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i]
+    const y = pb[i]
+    if (x === undefined) return -1
+    if (y === undefined) return 1
+    if (x === y) continue
+    if (typeof x === 'number' && typeof y === 'number') return x - y
+    return String(x).localeCompare(String(y))
+  }
+  return 0
+}
+
 function releases() {
-  /* A fixed, generous fetch. Scaling this off GRYT_CHANGELOG_LIMIT was wrong:
-     betas outnumber stable releases by roughly ten to one, so asking for four
-     releases to draft four stable notes returned four pre-releases and no
-     stable ones at all. The limit belongs on what gets drafted, not on what
-     gets looked at. */
   const raw = sh('gh', [
     'release', 'list', '-R', 'Gryt-chat/gryt',
     '--limit', '300',
     '--json', 'tagName,isPrerelease,publishedAt',
   ], { cwd: REPO })
-  /* Sort before mapping. Mapping first drops publishedAt, which left the
-     comparator reading undefined on both sides, the order untouched, and every
-     diff running from the newer release to the older one. */
+
   return JSON.parse(raw)
-    .sort((a, b) => (a.publishedAt < b.publishedAt ? -1 : 1))
-    .map((r) => ({
-      tag: r.tagName,
-      version: r.tagName.replace(/^v/, ''),
-      channel: r.isPrerelease ? 'beta' : 'latest',
-      date: r.publishedAt.slice(0, 10),
-    }))
+    .map((r) => {
+      /* A tag that was never published, or was published by a rewrite, has a
+         date that is not the release's. The manifest records when the release
+         was actually cut, so prefer it and keep publishedAt as the fallback. */
+      const published = /^\d{4}/.test(r.publishedAt) && !r.publishedAt.startsWith('0001')
+        ? r.publishedAt.slice(0, 10)
+        : null
+      return {
+        tag: r.tagName,
+        version: r.tagName.replace(/^v/, ''),
+        channel: r.isPrerelease ? 'beta' : 'latest',
+        date: published,
+      }
+    })
+    .sort((a, b) => compareVersions(a.version, b.version))
 }
 
 function manifestAt(tag) {
@@ -429,6 +450,11 @@ async function main() {
       const prev = inChannel[inChannel.indexOf(release) - 1]
       if (!prev) { log(`${release.version}: no previous ${channel} release, skipping`); continue }
 
+      /* The manifest is the only honest record of when this release happened
+         for a tag whose publish date was rewritten. */
+      const date = release.date ?? manifestAt(release.tag)?.createdAt?.slice(0, 10) ?? null
+      if (!date) { log(`${release.version}: no usable date, skipping`); continue }
+
       const changes = changesBetween(prev.tag, release.tag)
       if (!changes) { log(`${release.version}: no manifest on one of the tags, skipping`); continue }
       if (changes.incomplete) { log(`${release.version}: incomplete history, skipping`); continue }
@@ -452,7 +478,7 @@ async function main() {
 
       doc.entries.push({
         version: release.version,
-        date: release.date,
+        date,
         channel: release.channel,
         headline: entry.headline.trim(),
         sections: entry.sections,

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -244,10 +244,16 @@ function examples(repo) {
     .filter(Boolean)
 }
 
-/* One hand-written note in full, as the worked example.
-   The headlines alone were not enough: the drafts came back with no opening
-   paragraph at all, because nothing had shown the model that a note has one.
-   The newest is used on the assumption it is the most representative. */
+/* One hand-written note in full.
+   Not in the prompt any more, and the reason is worth keeping. It was added
+   because the drafts had no opening paragraph, and it did fix that — and it
+   also produced a note for 1.6.43 about 24-word backups and certificate
+   authorities, which belong to the release the example described. Reordering
+   the prompt fixed the wholesale case and left a paraphrased one: a fabricated
+   security section about keychain encryption, in a release whose commit range
+   does not contain the word "keychain".
+   Still used by the contamination check below, which needs to know what the
+   example says in order to notice a draft repeating it. */
 function workedExample(repo) {
   const dir = join(repo, 'packages/site/content/changelog')
   if (!existsSync(dir)) return null
@@ -279,9 +285,8 @@ function prompt(release, changes, style) {
   }
   return [
     'You are writing the release notes for one version of Gryt. The style guide',
-    'comes first, then an example of a finished note about a different release,',
-    'then the commits this release actually contains, then the rules for your',
-    'answer. Write about the commits. Follow the rules at the bottom.',
+    'comes first, then the commits this release actually contains, then the',
+    'rules for your answer. Write about the commits. Follow the rules.',
     '',
     '─────────────────────────────────────────────────────────────────────',
     'HOW GRYT PATCH NOTES ARE WRITTEN',
@@ -290,22 +295,6 @@ function prompt(release, changes, style) {
     'the bullet rules matter most.',
     '',
     style,
-    '',
-    '─────────────────────────────────────────────────────────────────────',
-    'AN EXAMPLE OF THE SHAPE — ABOUT A DIFFERENT RELEASE',
-    '',
-    'This is a note somebody wrote by hand, for a version that is not the one you',
-    'are writing about. Read it for its shape and its voice: the paragraph at the',
-    'top with no heading, the length of the sections, how a sentence sounds.',
-    '',
-    'Its subject matter is not yours. It is about identity backups, password',
-    'managers and certificate authorities. Your release is almost certainly about',
-    'something else entirely. If any of its subjects appear in what you write, you',
-    'have copied the example instead of reading the commits, and the note is wrong.',
-    '',
-    '<<<EXAMPLE>>>',
-    workedExample(REPO) ?? '(none available)',
-    '<<<END EXAMPLE>>>',
     '',
     '─────────────────────────────────────────────────────────────────────',
     `THE RELEASE YOU ARE WRITING ABOUT: Gryt ${release.version}, ${release.date}`,

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -8,9 +8,19 @@
 // submodules. patch-notes-style.md says how the result should read. This puts
 // the two together and asks the Ollama instance on this machine for the prose.
 //
-// What it writes is `changelog.json`, which nginx serves beside the site at
-// /release-notes/changelog.json and the site fetches at runtime. So a new entry is live as soon as this finishes;
-// there is no rebuild and no pull request in the path.
+// What it produces is not published. Each draft is posted to the reports
+// service, which holds it until somebody reads it at /admin/changelog and
+// presses Publish or Reject; reports is what writes the changelog.json nginx
+// serves beside the site.
+//
+// This used to write that file itself, so a note nobody had read was public the
+// moment the model finished writing it. Two fabricated drafts were caught by
+// reading them while this was being built. One retold a different release
+// wholesale. The other was a paraphrase: a section headed "Security
+// improvements for identity and account tokens", about keychain encryption, in
+// a release whose commit range does not contain the word keychain. It read like
+// the rest of the note and it scored under the contamination guard below, which
+// is why that guard is a backstop rather than a proof.
 //
 // The model never writes markup. It fills a fixed JSON shape — headline, then
 // sections of heading + paragraphs + bullets — and the site renders that with
@@ -22,32 +32,51 @@
 // `--dry-run` prints what it would ask the model without asking it.
 //
 // Environment:
-//   GRYT_CHANGELOG_OUT     changelog.json to write.
-//                          Default ./changelog/changelog.json beside this file.
+//   GRYT_CHANGELOG_URL     the reports service to post drafts to, e.g.
+//                          http://127.0.0.1:9476. Required unless --dump.
+//   GRYT_CHANGELOG_KEY     what it sends as X-Gryt-Changelog-Key. Required
+//                          unless --dump. Matches REPORTS_CHANGELOG_KEY there.
+//   GRYT_CHANGELOG_REDRAFT a version to draft again even though reports
+//                          already has one for it. Replaces the existing draft;
+//                          the old one is kept and marked superseded.
 //   GRYT_CHANGELOG_REPO    the superproject checkout to read releases from.
 //                          Default the checkout this script lives in.
 //   GRYT_CHANGELOG_CHANNELS  which channels to draft. Default "latest".
 //                          "latest beta" also drafts the pre-releases, which
 //                          the site hides behind a toggle.
 //   GRYT_CHANGELOG_LIMIT   how many releases back to consider. Default 12.
+//   GRYT_CHANGELOG_DUMP    with --dump, where to write drafts for inspection.
+//                          Default ./changelog/drafts beside this file. Nothing
+//                          reads what is written there.
 //   OLLAMA_URL             Default http://127.0.0.1:11434
 //   OLLAMA_MODEL           Default llama3.1:8b
 //   OLLAMA_TIMEOUT_MS      Default 180000
 
 import { execFileSync } from 'node:child_process'
-import { readFileSync, readdirSync, writeFileSync, renameSync, mkdirSync, existsSync } from 'node:fs'
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO = resolve(process.env.GRYT_CHANGELOG_REPO ?? join(HERE, '..', '..'))
-const OUT = resolve(process.env.GRYT_CHANGELOG_OUT ?? join(HERE, 'changelog', 'changelog.json'))
 const CHANNELS = (process.env.GRYT_CHANGELOG_CHANNELS ?? 'latest').split(/\s+/).filter(Boolean)
 const LIMIT = Number(process.env.GRYT_CHANGELOG_LIMIT ?? 12)
 const OLLAMA_URL = process.env.OLLAMA_URL ?? 'http://127.0.0.1:11434'
 const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? 'llama3.1:8b'
 const OLLAMA_TIMEOUT_MS = Number(process.env.OLLAMA_TIMEOUT_MS ?? 180_000)
 const DRY_RUN = process.argv.includes('--dry-run')
+
+/* Where a draft goes. */
+const REPORTS_URL = (process.env.GRYT_CHANGELOG_URL ?? '').replace(/\/$/, '')
+const REPORTS_KEY = process.env.GRYT_CHANGELOG_KEY ?? ''
+const REDRAFT = process.env.GRYT_CHANGELOG_REDRAFT?.trim().replace(/^v/, '') || null
+
+/* Writing drafts to disk instead of posting them, for working on the prompt
+   without a reports instance to hand. Nothing reads what this writes — the
+   flag is spelled out rather than inferred from a path, because the previous
+   arrangement was a path and a path is what made an unread note public. */
+const DUMP = process.argv.includes('--dump')
+const DUMP_DIR = resolve(process.env.GRYT_CHANGELOG_DUMP ?? join(HERE, 'changelog', 'drafts'))
 
 const log = (...a) => console.log('[changelog]', ...a)
 
@@ -498,31 +527,73 @@ function validate(entry) {
   return null
 }
 
-function readOut() {
-  if (!existsSync(OUT)) return { generatedAt: null, entries: [] }
-  try {
-    const parsed = JSON.parse(readFileSync(OUT, 'utf8'))
-    return { generatedAt: parsed.generatedAt ?? null, entries: parsed.entries ?? [] }
-  } catch {
-    log('! existing changelog.json is not valid JSON, starting a new one')
-    return { generatedAt: null, entries: [] }
+/* ── Reports ───────────────────────────────────────────────────────────
+   Drafts go to the reports service and wait there. It owns changelog.json —
+   one writer per file — and nothing reaches the changelog page until somebody
+   has read the note at /admin/changelog. */
+
+async function reports(path, init = {}) {
+  const res = await fetch(`${REPORTS_URL}${path}`, {
+    ...init,
+    headers: {
+      'x-gryt-changelog-key': REPORTS_KEY,
+      ...(init.headers ?? {}),
+    },
+  })
+  if (!res.ok) {
+    throw new Error(`reports ${res.status} ${(await res.text().catch(() => '')).slice(0, 300)}`.trim())
   }
+  return res.json()
 }
 
-/* Written to a sibling and renamed, because nginx is serving this file and a
-   half-written one is a broken changelog page rather than an old one. */
-function writeOut(doc) {
-  mkdirSync(dirname(OUT), { recursive: true })
-  const tmp = `${OUT}.tmp`
-  writeFileSync(tmp, `${JSON.stringify(doc, null, 2)}\n`)
-  renameSync(tmp, OUT)
+/* Versions reports has already been given a draft for, in any state. A
+   rejected one is not in this list, so a note somebody refused is drafted
+   again on the next tick — which is what rejecting it is for. */
+async function alreadyDrafted() {
+  const { versions } = await reports('/v1/changelog/versions')
+  return new Set(Array.isArray(versions) ? versions : [])
+}
+
+async function postDraft(entry) {
+  const query = REDRAFT === entry.version ? '?force=1' : ''
+  return reports(`/v1/changelog${query}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(entry),
+  })
+}
+
+/* --dump. A draft on disk, for reading while the prompt is being worked on.
+   One file per release rather than one document, so a run is a set of things
+   to read rather than a file to diff against the last one. */
+function dumpDraft(entry) {
+  mkdirSync(DUMP_DIR, { recursive: true })
+  const path = join(DUMP_DIR, `${entry.version}.json`)
+  writeFileSync(path, `${JSON.stringify(entry, null, 2)}\n`)
+  return path
 }
 
 async function main() {
+  if (!DRY_RUN && !DUMP && (!REPORTS_URL || !REPORTS_KEY)) {
+    /* Refused rather than defaulted. There is no safe default here: the whole
+       point of this script no longer writing the file itself is that a note
+       goes somewhere a person reads it first, and a fallback would be a way
+       back to the arrangement that published two fabricated drafts. */
+    throw new Error(
+      'GRYT_CHANGELOG_URL and GRYT_CHANGELOG_KEY are required. Drafts are ' +
+        'posted to the reports service, which holds them until somebody reads ' +
+        'them at /admin/changelog. Use --dump to write drafts to disk instead, ' +
+        'or --dry-run to print the prompt without asking the model.',
+    )
+  }
+
   const style = readFileSync(join(REPO, 'patch-notes-style.md'), 'utf8')
   const all = releases()
-  const doc = readOut()
-  const have = new Set(doc.entries.map((e) => e.version))
+  const have = DRY_RUN || DUMP ? new Set() : await alreadyDrafted()
+  if (REDRAFT) {
+    have.delete(REDRAFT)
+    log(`drafting ${REDRAFT} again, replacing the draft reports already has`)
+  }
 
   let wrote = 0
   for (const channel of CHANNELS) {
@@ -567,7 +638,7 @@ async function main() {
            judge. This is how the first contaminated draft was diagnosed at
            all, and a false positive is only findable this way. */
         try {
-          const dir = join(dirname(OUT), 'rejected')
+          const dir = join(DUMP_DIR, 'rejected')
           mkdirSync(dir, { recursive: true })
           writeFileSync(
             join(dir, `${release.version}.json`),
@@ -578,7 +649,7 @@ async function main() {
         continue
       }
 
-      doc.entries.push({
+      const drafted = {
         version: release.version,
         date,
         channel: release.channel,
@@ -587,18 +658,40 @@ async function main() {
         sections: entry.sections,
         recap: entry.recap,
         source: { since: prev.version, commits: count, model: OLLAMA_MODEL },
-      })
+        /* The range this was written from, so whoever reads the note can check
+           a claim against the commits rather than agree with prose that reads
+           well. Checking is what caught the paraphrased security section; the
+           guard above scored that draft as clean. */
+        commits: changes.parts,
+      }
+
+      if (DUMP) {
+        log(`  ✓ ${entry.headline}`)
+        log(`    ${dumpDraft(drafted)}`)
+      } else {
+        try {
+          const result = await postDraft(drafted)
+          log(`  ✓ ${entry.headline}`)
+          log(`    ${result.created ? 'waiting to be read' : `reports already had ${result.version}`}`)
+        } catch (err) {
+          /* Not fatal. The release is still without a draft, so the next tick
+             tries again, and the ones already posted are safe where they are. */
+          log(`  ! could not post ${release.version}: ${err.message}`)
+          continue
+        }
+      }
+
       have.add(release.version)
       wrote++
-      log(`  ✓ ${entry.headline}`)
     }
   }
 
   if (!wrote) { log('nothing new'); return }
-  doc.generatedAt = new Date().toISOString()
-  doc.entries.sort((a, b) => (a.version < b.version ? 1 : -1))
-  writeOut(doc)
-  log(`wrote ${wrote} entr${wrote === 1 ? 'y' : 'ies'} to ${OUT}`)
+  log(
+    DUMP
+      ? `wrote ${wrote} draft${wrote === 1 ? '' : 's'} to ${DUMP_DIR}`
+      : `posted ${wrote} draft${wrote === 1 ? '' : 's'}, waiting to be read at ${REPORTS_URL}/admin/changelog`,
+  )
 }
 
 main().catch((err) => {

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -1,0 +1,478 @@
+#!/usr/bin/env node
+//
+// Draft the user-facing changelog for a release, from the release itself.
+//
+// The facts are already pinned. `.release/manifest.json` is committed on every
+// release and names the exact commit each component shipped at, so the diff
+// between two releases is not a guess — it is `git log old..new` in four
+// submodules. patch-notes-style.md says how the result should read. This puts
+// the two together and asks the Ollama instance on this machine for the prose.
+//
+// What it writes is `changelog.json`, which nginx serves beside the site at
+// /release-notes/changelog.json and the site fetches at runtime. So a new entry is live as soon as this finishes;
+// there is no rebuild and no pull request in the path.
+//
+// The model never writes markup. It fills a fixed JSON shape — headline, then
+// sections of heading + paragraphs + bullets — and the site renders that with
+// its own components. A model cannot inject markup into a page it is not
+// allowed to write markup for, and the shape is also what keeps every entry
+// reading like the three that were written by hand.
+//
+// Run from the systemd timer beside this script. Safe to run by hand, and
+// `--dry-run` prints what it would ask the model without asking it.
+//
+// Environment:
+//   GRYT_CHANGELOG_OUT     changelog.json to write.
+//                          Default ./changelog/changelog.json beside this file.
+//   GRYT_CHANGELOG_REPO    the superproject checkout to read releases from.
+//                          Default the checkout this script lives in.
+//   GRYT_CHANGELOG_CHANNELS  which channels to draft. Default "latest".
+//                          "latest beta" also drafts the pre-releases, which
+//                          the site hides behind a toggle.
+//   GRYT_CHANGELOG_LIMIT   how many releases back to consider. Default 12.
+//   OLLAMA_URL             Default http://127.0.0.1:11434
+//   OLLAMA_MODEL           Default llama3.1:8b
+//   OLLAMA_TIMEOUT_MS      Default 180000
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, readdirSync, writeFileSync, renameSync, mkdirSync, existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO = resolve(process.env.GRYT_CHANGELOG_REPO ?? join(HERE, '..', '..'))
+const OUT = resolve(process.env.GRYT_CHANGELOG_OUT ?? join(HERE, 'changelog', 'changelog.json'))
+const CHANNELS = (process.env.GRYT_CHANGELOG_CHANNELS ?? 'latest').split(/\s+/).filter(Boolean)
+const LIMIT = Number(process.env.GRYT_CHANGELOG_LIMIT ?? 12)
+const OLLAMA_URL = process.env.OLLAMA_URL ?? 'http://127.0.0.1:11434'
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? 'llama3.1:8b'
+const OLLAMA_TIMEOUT_MS = Number(process.env.OLLAMA_TIMEOUT_MS ?? 180_000)
+const DRY_RUN = process.argv.includes('--dry-run')
+
+const log = (...a) => console.log('[changelog]', ...a)
+
+function sh(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    ...opts,
+  }).trim()
+}
+
+/* ── Releases ──────────────────────────────────────────────────────────
+   The tag is the source of truth for what shipped, and `isPrerelease` is
+   what separates a beta from a stable one. The manifest inside the tag
+   says which channel it called itself, but a tag that exists is a release
+   that happened, which a file in a working tree is not. */
+function releases() {
+  /* A fixed, generous fetch. Scaling this off GRYT_CHANGELOG_LIMIT was wrong:
+     betas outnumber stable releases by roughly ten to one, so asking for four
+     releases to draft four stable notes returned four pre-releases and no
+     stable ones at all. The limit belongs on what gets drafted, not on what
+     gets looked at. */
+  const raw = sh('gh', [
+    'release', 'list', '-R', 'Gryt-chat/gryt',
+    '--limit', '300',
+    '--json', 'tagName,isPrerelease,publishedAt',
+  ], { cwd: REPO })
+  /* Sort before mapping. Mapping first drops publishedAt, which left the
+     comparator reading undefined on both sides, the order untouched, and every
+     diff running from the newer release to the older one. */
+  return JSON.parse(raw)
+    .sort((a, b) => (a.publishedAt < b.publishedAt ? -1 : 1))
+    .map((r) => ({
+      tag: r.tagName,
+      version: r.tagName.replace(/^v/, ''),
+      channel: r.isPrerelease ? 'beta' : 'latest',
+      date: r.publishedAt.slice(0, 10),
+    }))
+}
+
+function manifestAt(tag) {
+  try {
+    return JSON.parse(sh('git', ['show', `${tag}:.release/manifest.json`], { cwd: REPO }))
+  } catch {
+    return null
+  }
+}
+
+/* Commits that describe the release rather than anything in it. A reader does
+   not want "Build 19, because 18 is uploaded" in their patch notes. */
+const NOISE = /^(release:|chore:|ci:|build:|Version Packages|Merge (pull request|branch)|Bump |Build \d+, because)/i
+
+/* A submodule cloned with --depth does not have the commit a months-old
+   release pinned. Try to deepen once; a checkout that cannot reach it is a
+   checkout that must not draft notes off half the changes. */
+function have(dir, sha) {
+  try {
+    execFileSync('git', ['-C', dir, 'cat-file', '-e', `${sha}^{commit}`], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function reach(dir, sha) {
+  if (have(dir, sha)) return true
+  for (const args of [['fetch', '--quiet', 'origin', sha], ['fetch', '--quiet', '--unshallow', 'origin']]) {
+    try {
+      execFileSync('git', ['-C', dir, ...args], { stdio: 'ignore' })
+      if (have(dir, sha)) return true
+    } catch { /* try the next one */ }
+  }
+  return false
+}
+
+function commitsFor(component, from, to) {
+  const dir = join(REPO, component.path)
+  if (!existsSync(dir)) return []
+  for (const sha of [from, to]) {
+    if (!reach(dir, sha)) {
+      log(`  ! ${component.name}: ${sha.slice(0, 8)} is not in this checkout`)
+      return null
+    }
+  }
+  try {
+    /* %x1f between fields and %x1e between records: a commit body contains
+       newlines, and splitting on those loses half of every message. */
+    const raw = sh('git', [
+      '-C', dir, 'log', '--no-merges', `--format=%s%x1f%b%x1e`, `${from}..${to}`,
+    ])
+    if (!raw) return []
+    return raw.split('\x1e')
+      .map((rec) => {
+        const [subject = '', body = ''] = rec.split('\x1f')
+        return { subject: subject.trim(), body: body.trim() }
+      })
+      .filter((c) => c.subject && !NOISE.test(c.subject))
+  } catch (err) {
+    log(`  ! ${component.name}: ${String(err.message).split('\n')[0]}`)
+    return null
+  }
+}
+
+function changesBetween(prevTag, tag) {
+  const a = manifestAt(prevTag)
+  const b = manifestAt(tag)
+  if (!a || !b) return null
+
+  const out = []
+  let incomplete = false
+  for (const [name, comp] of Object.entries(b.components)) {
+    const before = a.components[name]
+    if (!before || before.commit === comp.commit) continue
+    const commits = commitsFor({ ...comp, name }, before.commit, comp.commit)
+    if (commits === null) { incomplete = true; continue }
+    if (commits.length) out.push({ component: name, commits })
+  }
+  return { parts: out, incomplete }
+}
+
+/* ── The model ─────────────────────────────────────────────────────────
+   A fixed shape rather than prose, for three reasons: the site renders it
+   with its own components so no markup crosses the boundary, a malformed
+   answer is detectable instead of merely ugly, and the shape is most of
+   what makes an entry read like the hand-written ones. */
+const SCHEMA = {
+  type: 'object',
+  properties: {
+    headline: { type: 'string' },
+    sections: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          heading: { type: 'string' },
+          body: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['heading', 'body'],
+      },
+    },
+    /* "The short version" from the style guide: one-line bullets grouped under
+       a label, after the article. Someone who read the prose stops before it;
+       someone who wants only the list starts here. */
+    recap: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          group: { type: 'string' },
+          items: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['group', 'items'],
+      },
+    },
+  },
+  required: ['headline', 'sections', 'recap'],
+}
+
+/* The three notes written by hand, as the target. A rule can say "a sentence,
+   not a label"; an example of one shows what that means, and these are the
+   only three examples that exist. Read at run time so a fourth hand-written
+   note joins them without anybody editing this file. */
+function examples(repo) {
+  const dir = join(repo, 'packages/site/content/changelog')
+  if (!existsSync(dir)) return []
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.mdx'))
+    .map((f) => readFileSync(join(dir, f), 'utf8').match(/^headline:\s*(.+)$/m)?.[1]?.trim())
+    .filter(Boolean)
+}
+
+function prompt(release, changes, style) {
+  const lines = []
+  for (const part of changes.parts) {
+    lines.push(`## ${part.component}`)
+    for (const c of part.commits) {
+      lines.push(`- ${c.subject}`)
+      if (c.body) {
+        for (const l of c.body.split('\n').map((s) => s.trim()).filter(Boolean).slice(0, 8)) {
+          lines.push(`    ${l}`)
+        }
+      }
+    }
+  }
+  return [
+    `Gryt ${release.version} shipped on ${release.date}.`,
+    '',
+    'These are the commits it contains, grouped by component. Commit bodies are',
+    'included where the author wrote one, and they are usually the best source',
+    'for why a change was made.',
+    '',
+    lines.join('\n'),
+    '',
+    '─────────────────────────────────────────────────────────────────────',
+    'HOW GRYT PATCH NOTES ARE WRITTEN',
+    '',
+    'This is the house style guide, in full. Follow it. The voice section and',
+    'the bullet rules matter most.',
+    '',
+    style,
+    '',
+    '─────────────────────────────────────────────────────────────────────',
+    'WHAT APPLIES TO THIS DRAFT',
+    '',
+    'You are drafting from the commit range alone, so parts of the guide above',
+    'are not yours to do:',
+    '',
+    '- Pictures and clips. You cannot take a screenshot. Never refer to one,',
+    '  and never write the sentence that would introduce one.',
+    '- Sponsors. You cannot see the sponsors list. Write nothing about them.',
+    '- Vikunja. You cannot read the tasks. Where the guide says to use them for',
+    '  the "why", use the commit body instead, and if it does not say why, do',
+    '  not guess.',
+    '',
+    'Return JSON in this shape, and nothing else:',
+    '',
+    '  headline  One sentence naming the thing that actually matters, written',
+    '            for somebody deciding whether to read on. Do not name the',
+    '            version number in it; the page already shows that. Do not list',
+    '            three things to sound complete — pick what matters and say it.',
+    '            These are the headlines written by hand, and they are the',
+    '            target:',
+    '',
+    ...examples(REPO).map((h) => `              ${h}`),
+    '',
+    '  sections  The article. Two to four, each about one thing that changed,',
+    '            in the order the guide gives: what you notice, then what a',
+    '            host notices, then what a careful person asks about. Each has',
+    '            a heading that is a sentence rather than a label, and a body',
+    '            of one to three paragraphs. Security is always its own',
+    '            section and is never softened.',
+    '  recap     The short version. Groups from the guide\'s list: Voice,',
+    '            Avatars and images, Emoji, Updates, Hosting, Security,',
+    '            Accessibility, Under the hood. Skip a group with nothing in',
+    '            it. One line per item, past tense, from the reader\'s side.',
+    '',
+    'Plain sentences only. No markdown, no bold, no links, no headings inside a',
+    'paragraph. The site renders the shape itself.',
+    '',
+    'Never mention a task number, a pull request, a file or a function outside',
+    'the "Under the hood" recap group. The same goes for:',
+    '',
+    '- package names such as @gryt/owl, and version numbers of anything that is',
+    '  not Gryt itself',
+    '- measurements: pixel values, corner radii, percentages, sample sizes. A',
+    '  reader does not need "46.1% of avatars over 20,000 seeds" to understand',
+    '  that avatars changed. Say that they changed.',
+    '- acronyms and internal names: SFU, CDN, socket, module, dependency. If a',
+    '  sentence needs one to make sense, the sentence is aimed at the wrong',
+    '  reader. Write "the media server" or leave it out.',
+    '',
+    'Use the word "Previously" at most once in the whole note. It is the obvious',
+    'way to write a contrast and it reads as a template when every paragraph has',
+    'it. "used to", "before this", or simply putting the old behaviour in the',
+    'second half of the sentence all work.',
+    '',
+    'A section belongs in "Under the hood" only if a user cannot see it. A',
+    'redesigned hover card is something they can see, so it is not under the',
+    'hood.',
+    '',
+    'Do not start more than one section with the same word. "Previously" in',
+    'front of every contrast reads as a form someone filled in. Vary it, or',
+    'put the old behaviour second in the sentence.',
+    '',
+    'Every fact must come from the commits above. Do not invent a number, a',
+    'date, a feature or a reason.',
+    '',
+    'If nothing in this release is visible to a user, return an empty sections',
+    'array, an empty recap, and a headline saying it is a maintenance release.',
+  ].join('\n')
+}
+
+async function ask(text) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), OLLAMA_TIMEOUT_MS)
+  try {
+    /* Streamed, and not for the progress. With stream:false the server sends
+       nothing at all until the whole answer is generated, and Node's fetch
+       gives up waiting for response headers after five minutes — a 13 kB
+       prompt into a 32b model is comfortably past that, and it surfaces as a
+       bare "fetch failed" that looks like the box is unreachable. Streaming
+       puts bytes on the wire immediately, so the only timeout that applies is
+       the one above. */
+    const res = await fetch(`${OLLAMA_URL}/api/chat`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({
+        model: OLLAMA_MODEL,
+        stream: true,
+        format: SCHEMA,
+        /* qwen3 reasons out loud by default, and the reasoning is not the
+           answer. Without this the content comes back with a think block
+           wrapped round the JSON and the parse fails. */
+        think: false,
+        options: { temperature: 0.4 },
+        messages: [{ role: 'user', content: text }],
+      }),
+    })
+    if (!res.ok) throw new Error(`ollama ${res.status} ${await res.text().catch(() => '')}`.trim())
+
+    let out = ''
+    let buf = ''
+    for await (const chunk of res.body) {
+      buf += Buffer.from(chunk).toString('utf8')
+      /* One JSON object per line, and the last line of a chunk is usually a
+         partial one — keep it for the next chunk rather than parsing it. */
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const line of lines) {
+        if (!line.trim()) continue
+        let obj
+        try { obj = JSON.parse(line) } catch { continue }
+        if (obj.error) throw new Error(`ollama: ${obj.error}`)
+        if (obj.message?.content) out += obj.message.content
+      }
+    }
+    return JSON.parse(out)
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/* Anything the model got wrong in a way that would reach the page. A bad entry
+   is not written at all; the next run tries again. */
+function validate(entry) {
+  if (typeof entry?.headline !== 'string' || !entry.headline.trim()) return 'no headline'
+  if (!Array.isArray(entry.sections)) return 'sections is not an array'
+  for (const s of entry.sections) {
+    if (typeof s?.heading !== 'string' || !s.heading.trim()) return 'a section has no heading'
+    if (!Array.isArray(s.body)) return 'a section body is not an array'
+    if (s.body.some((p) => typeof p !== 'string')) return 'a section body is not all strings'
+  }
+  if (!Array.isArray(entry.recap)) return 'recap is not an array'
+  for (const g of entry.recap) {
+    if (typeof g?.group !== 'string' || !g.group.trim()) return 'a recap group has no label'
+    if (!Array.isArray(g.items) || g.items.some((p) => typeof p !== 'string')) {
+      return 'a recap group is not all strings'
+    }
+  }
+  return null
+}
+
+function readOut() {
+  if (!existsSync(OUT)) return { generatedAt: null, entries: [] }
+  try {
+    const parsed = JSON.parse(readFileSync(OUT, 'utf8'))
+    return { generatedAt: parsed.generatedAt ?? null, entries: parsed.entries ?? [] }
+  } catch {
+    log('! existing changelog.json is not valid JSON, starting a new one')
+    return { generatedAt: null, entries: [] }
+  }
+}
+
+/* Written to a sibling and renamed, because nginx is serving this file and a
+   half-written one is a broken changelog page rather than an old one. */
+function writeOut(doc) {
+  mkdirSync(dirname(OUT), { recursive: true })
+  const tmp = `${OUT}.tmp`
+  writeFileSync(tmp, `${JSON.stringify(doc, null, 2)}\n`)
+  renameSync(tmp, OUT)
+}
+
+async function main() {
+  const style = readFileSync(join(REPO, 'patch-notes-style.md'), 'utf8')
+  const all = releases()
+  const doc = readOut()
+  const have = new Set(doc.entries.map((e) => e.version))
+
+  let wrote = 0
+  for (const channel of CHANNELS) {
+    const inChannel = all.filter((r) => r.channel === channel)
+    /* Only the tail: this is a timer, not a backfill. */
+    const recent = inChannel.slice(-LIMIT)
+    for (let i = 0; i < recent.length; i++) {
+      const release = recent[i]
+      if (have.has(release.version)) continue
+
+      const prev = inChannel[inChannel.indexOf(release) - 1]
+      if (!prev) { log(`${release.version}: no previous ${channel} release, skipping`); continue }
+
+      const changes = changesBetween(prev.tag, release.tag)
+      if (!changes) { log(`${release.version}: no manifest on one of the tags, skipping`); continue }
+      if (changes.incomplete) { log(`${release.version}: incomplete history, skipping`); continue }
+
+      const count = changes.parts.reduce((n, p) => n + p.commits.length, 0)
+      if (!count) { log(`${release.version}: nothing user-visible since ${prev.version}, skipping`); continue }
+
+      log(`${release.version}: ${count} commits since ${prev.version}`)
+      const text = prompt(release, changes, style)
+      if (DRY_RUN) { console.log(`\n───── prompt for ${release.version} ─────\n${text}\n`); continue }
+
+      let entry
+      try {
+        entry = await ask(text)
+      } catch (err) {
+        log(`  ! model failed: ${err.message}`)
+        continue
+      }
+      const bad = validate(entry)
+      if (bad) { log(`  ! rejected: ${bad}`); continue }
+
+      doc.entries.push({
+        version: release.version,
+        date: release.date,
+        channel: release.channel,
+        headline: entry.headline.trim(),
+        sections: entry.sections,
+        recap: entry.recap,
+        source: { since: prev.version, commits: count, model: OLLAMA_MODEL },
+      })
+      have.add(release.version)
+      wrote++
+      log(`  ✓ ${entry.headline}`)
+    }
+  }
+
+  if (!wrote) { log('nothing new'); return }
+  doc.generatedAt = new Date().toISOString()
+  doc.entries.sort((a, b) => (a.version < b.version ? 1 : -1))
+  writeOut(doc)
+  log(`wrote ${wrote} entr${wrote === 1 ? 'y' : 'ies'} to ${OUT}`)
+}
+
+main().catch((err) => {
+  console.error('[changelog] failed:', err)
+  process.exit(1)
+})

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -16,6 +16,18 @@ services:
       - "${INTERNAL_SITE_HTTP_PORT:-9472}:80"
     volumes:
       - ./downloads:/usr/share/nginx/html/downloads:ro
+      # Release notes drafted after a release by gryt-changelog-notes.service,
+      # which the changelog page fetches at runtime. Mounted rather than built
+      # in so a new note is live without rebuilding the site.
+      #
+      # Its own path, not /changelog.json at the root: the site router owns
+      # /changelog, and a real file under a path the router also claims is a
+      # collision waiting to be discovered by somebody else.
+      #
+      # A missing source directory makes Docker create one, which is harmless
+      # here — the page treats an absent file the same as an empty one and
+      # renders the hand-written notes on their own.
+      - ${GRYT_CHANGELOG_DIR:-/var/lib/gryt-changelog}:/usr/share/nginx/html/release-notes:ro
     restart: unless-stopped
 
   # Component library docs (ui.gryt.chat). Built from packages/ui, which is a

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -16,9 +16,13 @@ services:
       - "${INTERNAL_SITE_HTTP_PORT:-9472}:80"
     volumes:
       - ./downloads:/usr/share/nginx/html/downloads:ro
-      # Release notes drafted after a release by gryt-changelog-notes.service,
-      # which the changelog page fetches at runtime. Mounted rather than built
-      # in so a new note is live without rebuilding the site.
+      # Release notes, which the changelog page fetches at runtime. Mounted
+      # rather than built in so a note is live without rebuilding the site.
+      #
+      # Read-only here and writable in the reports service below, which is the
+      # only thing that writes this file. gryt-changelog-notes.service drafts
+      # the notes and posts them to reports; reports holds each one until
+      # somebody has read it at /admin/changelog, and writes the file.
       #
       # Its own path, not /changelog.json at the root: the site router owns
       # /changelog, and a real file under a path the router also claims is a
@@ -171,8 +175,20 @@ services:
       REPORTS_OIDC_REDIRECT_URI: "${REPORTS_OIDC_REDIRECT_URI:-}"
       REPORTS_BOOTSTRAP_ADMIN: "${REPORTS_BOOTSTRAP_ADMIN:-}"
       REPORTS_SESSION_SECRET: "${REPORTS_SESSION_SECRET:-}"
+      # Reading a drafted release note before it is published (GRYT-635).
+      #
+      # gryt-changelog-notes.service on this box drafts a note after a release
+      # and posts it here rather than writing the file the site reads, so
+      # nothing a model wrote is public until somebody has read it. The key is
+      # what lets it post, and it is not one of the app keys above: those ship
+      # inside a public binary and this one writes to a page. Empty here and set
+      # in .env; without it those routes do not exist.
+      REPORTS_CHANGELOG_KEY: "${REPORTS_CHANGELOG_KEY:-}"
+      REPORTS_CHANGELOG_FILE: /release-notes/changelog.json
     volumes:
       - gryt-reports-data:/data
+      # The same directory the site mounts read-only above. One writer.
+      - ${GRYT_CHANGELOG_DIR:-/var/lib/gryt-changelog}:/release-notes
     restart: unless-stopped
 
 volumes:

--- a/ops/internal/systemd/gryt-changelog-notes.env.example
+++ b/ops/internal/systemd/gryt-changelog-notes.env.example
@@ -17,9 +17,21 @@ OLLAMA_MODEL=qwen3:32b
 # a half-written note is not written at all.
 #OLLAMA_TIMEOUT_MS=1800000
 
-# Where the file the site reads is written. This has to be the directory the
-# site service bind-mounts at /usr/share/nginx/html/release-notes.
-#GRYT_CHANGELOG_OUT=/var/lib/gryt-changelog/changelog.json
+# Where drafts are posted. Required — this script does not publish anything
+# itself. The reports service holds each note until somebody has read it at
+# reports.gryt.chat/admin/changelog, and it is what writes the file the site
+# reads. Port from INTERNAL_REPORTS_HTTP_PORT in ops/internal/.env.
+GRYT_CHANGELOG_URL=http://127.0.0.1:9476
+
+# The key it posts with. Has to match REPORTS_CHANGELOG_KEY in the reports
+# service. Not one of the app keys: those ship inside a public binary and this
+# one writes to a page.
+GRYT_CHANGELOG_KEY=
+
+# Draft one version again even though reports already has a note for it. For a
+# draft that was rejected and then refused again, or one you want another go at
+# with a different model. The existing draft is kept and marked superseded.
+#GRYT_CHANGELOG_REDRAFT=1.6.43
 
 # The superproject checkout to read releases and submodule history from.
 #GRYT_CHANGELOG_REPO=/opt/gryt

--- a/ops/internal/systemd/gryt-changelog-notes.env.example
+++ b/ops/internal/systemd/gryt-changelog-notes.env.example
@@ -1,0 +1,35 @@
+# Per-machine settings for gryt-changelog-notes.service.
+# Install to /etc/default/gryt-changelog-notes.
+#
+# Unlike the other two units here, this one needs at least OLLAMA_URL: the
+# default is a local Ollama and the model does not run on this box.
+
+# The Ollama instance that writes the prose. No trailing slash, and the port is
+# not optional — Ollama's default is 11434 and nothing is listening on 80.
+OLLAMA_URL=http://192.168.50.168:11434
+
+# qwen3:32b writes the better note and takes roughly eight minutes per release
+# on the machine this was written for. qwen3:14b is around three and reads
+# noticeably flatter. Neither is fast, and neither needs to be.
+OLLAMA_MODEL=qwen3:32b
+
+# Aborts a single draft. Generous, because the timer has nothing else to do and
+# a half-written note is not written at all.
+#OLLAMA_TIMEOUT_MS=1800000
+
+# Where the file the site reads is written. This has to be the directory the
+# site service bind-mounts at /usr/share/nginx/html/release-notes.
+#GRYT_CHANGELOG_OUT=/var/lib/gryt-changelog/changelog.json
+
+# The superproject checkout to read releases and submodule history from.
+#GRYT_CHANGELOG_REPO=/opt/gryt
+
+# Which channels get notes. "latest" is the stable releases only, which is what
+# a reader wants. Add beta to draft the pre-releases too; the changelog page
+# hides those behind a toggle rather than showing them by default.
+#GRYT_CHANGELOG_CHANNELS=latest
+#GRYT_CHANGELOG_CHANNELS=latest beta
+
+# How many releases back to consider on each run. Only affects a first run with
+# a backlog; after that there is at most one new release to draft.
+#GRYT_CHANGELOG_LIMIT=12

--- a/ops/internal/systemd/gryt-changelog-notes.service
+++ b/ops/internal/systemd/gryt-changelog-notes.service
@@ -17,18 +17,21 @@ ExecStartPre=-/usr/local/bin/gryt-pull-superproject
 # to be installed again.
 ExecStart=/usr/bin/env node /usr/local/lib/gryt/changelog-notes.mjs
 
-# Where OLLAMA_URL, OLLAMA_MODEL and the output path live. Required in
-# practice: the defaults point at a local Ollama, and there is not one on this
-# box. See gryt-changelog-notes.env.example.
+# Where OLLAMA_URL, OLLAMA_MODEL and the reports address and key live.
+# Required: the Ollama defaults point at a local instance and there is not one
+# on this box, and the script refuses to start without somewhere to post a
+# draft. See gryt-changelog-notes.env.example.
 EnvironmentFile=-/etc/default/gryt-changelog-notes
 
-# It writes one file, reads a git checkout and talks to one host on the LAN.
-# None of that wants the rest of the machine.
+# It reads a git checkout and talks to two hosts, one on the LAN and one on
+# loopback. None of that wants the rest of the machine.
+#
+# No ReadWritePaths any more. This wrote /var/lib/gryt-changelog directly until
+# GRYT-635; the reports service owns that file now, and this posts to it.
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/var/lib/gryt-changelog
 
 # A 32b model on CPU is minutes per release, and a first run with a backlog is
 # several of them in a row. Longer than the timer interval on purpose; systemd

--- a/ops/internal/systemd/gryt-changelog-notes.service
+++ b/ops/internal/systemd/gryt-changelog-notes.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Draft the changelog for any Gryt release that does not have one yet
+Documentation=https://github.com/Gryt-chat/gryt/blob/main/ops/internal/README.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+
+# Same reason as gryt-sites-refresh: nothing else pulls the superproject, and
+# this script reads release tags and submodule history out of that checkout.
+# The leading dash so a failed pull does not stop a draft that could still be
+# written from what is already here.
+ExecStartPre=-/usr/local/bin/gryt-pull-superproject
+
+# A symlink into the checkout, so `git pull` updates the script and nothing has
+# to be installed again.
+ExecStart=/usr/bin/env node /usr/local/lib/gryt/changelog-notes.mjs
+
+# Where OLLAMA_URL, OLLAMA_MODEL and the output path live. Required in
+# practice: the defaults point at a local Ollama, and there is not one on this
+# box. See gryt-changelog-notes.env.example.
+EnvironmentFile=-/etc/default/gryt-changelog-notes
+
+# It writes one file, reads a git checkout and talks to one host on the LAN.
+# None of that wants the rest of the machine.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/lib/gryt-changelog
+
+# A 32b model on CPU is minutes per release, and a first run with a backlog is
+# several of them in a row. Longer than the timer interval on purpose; systemd
+# leaves a running oneshot alone when the timer next fires.
+TimeoutStartSec=7200

--- a/ops/internal/systemd/gryt-changelog-notes.timer
+++ b/ops/internal/systemd/gryt-changelog-notes.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Look for Gryt releases without changelog notes, hourly
+
+[Timer]
+# Hourly is far more often than releases happen, and a run with nothing to do
+# costs one `gh release list`. The point is that a release cut at any hour has
+# notes within the hour rather than whenever somebody remembers.
+OnBootSec=15min
+OnUnitActiveSec=1h
+
+# The model is the expensive part and it is shared with whatever else uses that
+# box. No reason for this to start on the hour, every hour.
+RandomizedDelaySec=10min
+
+[Install]
+WantedBy=timers.target

--- a/patch-notes-style.md
+++ b/patch-notes-style.md
@@ -29,6 +29,25 @@ two things that actually matter.
 
 Then **the note itself, written as prose**, and **a recap list at the end**.
 
+### The opening
+
+Before the first heading, a paragraph or two with no heading of its own, saying
+what this release is about. Every note so far has one and it is the part that
+makes the rest read like writing rather than output.
+
+It is not a summary of the sections below. It is the frame the sections hang on
+— what was wrong, or what changed direction, or what somebody will notice first:
+
+> Using Gryt without an account has always had one sharp edge: whatever you were
+> on a server lived in one browser on one machine. Clear your site data and it
+> was gone, along with any roles you had and any server you owned. This release
+> takes that apart.
+
+> Two things changed in this release and they point the same way.
+
+If the release is small, say so in a sentence and move on. A release with one
+fix in it does not need a paragraph pretending otherwise.
+
 ### The article
 
 A few sections with real headings, each about one thing that changed, in the order
@@ -151,6 +170,42 @@ there were no sponsors.
 Not every beta deserves notes. If a release contains nothing above **Under the
 hood**, skip it — a note saying "we deleted a dead script" is worse than silence.
 Accumulate and publish when there is something to say.
+
+## Things that make it read like a machine wrote it
+
+Worth its own section because they are the failures that actually turn up, and
+because every one of them survives a read-through unless you are looking for it.
+
+**Groups of three.** "Voice presence is now reliable, avatars are consistent,
+and macOS icons look right" is three things in a row because three sounds
+finished, not because three things matter equally. Pick the one that matters and
+say that.
+
+**The same word starting every paragraph.** "Previously" in front of every
+contrast reads as a form somebody filled in. Once per note is plenty. Put the
+old behaviour in the second half of the sentence instead, or leave it out where
+the fix speaks for itself.
+
+**"Not X, but Y."** State Y. "This is not a redesign, it is a rewrite" is one
+sentence pretending to be two.
+
+**A noun phrase, a colon, then a reveal.** "The detail that makes it work: a
+separate process." Write it as a sentence.
+
+**Importance claims.** "marks a significant step", "underscores our commitment",
+"a major improvement to". Say what changed and let the reader decide what it was
+worth. If it needs to be called significant, it probably was not.
+
+**Trailing -ing clauses that pretend to explain.** "…, ensuring a smoother
+experience", "…, reflecting our focus on reliability". They add length and no
+information. Cut at the comma.
+
+**Every sentence the same length.** Real writing varies. A run of medium
+sentences with no short one anywhere is the most reliable tell there is, and the
+hardest to notice.
+
+**A closing paragraph that restates the note.** The reader was just there. Stop
+on the last real thing.
 
 ## Voice
 


### PR DESCRIPTION
Gryt cuts a stable release every day or two and the changelog has three entries
in it, all written by hand. This drafts the rest, on dev.lan, using the Ollama
instance there.

**Updated 2026-08-27: it no longer publishes.** Drafts are posted to the reports
service and wait there until somebody reads one. Two more PRs go with this:

- [Gryt-chat/reports#22](https://github.com/Gryt-chat/reports/pull/22) — the gate: the store, the endpoint, and the screen at `/admin/changelog`. **Merge and release this first**; the endpoint has to exist before the timer starts posting at it.
- [Gryt-chat/site#49](https://github.com/Gryt-chat/site/pull/49) — the site half: runtime fetch, `?drafts=1`, published-only by default. Safe on its own.

## What to look at

**It no longer publishes, and that is the change since you last read this.**
The first version of this PR wrote `changelog.json` directly, and I flagged that
`docs/guide/ai.mdx` and the "Nothing Security-Relevant Ships Unread" post both
promise a human reads AI-written output before it ships. You picked the gate, and
an interface rather than a CLI flag. So: `GRYT_CHANGELOG_URL` and
`GRYT_CHANGELOG_KEY` are required, the script refuses to start without them, and
there is no file-writing fallback — a fallback is a way back to the arrangement
that published two fabricated drafts. The policy needs no line while the gate is
there. If it ever comes off, it does.

**`--dump`.** The one way to get a draft onto disk from this script, for working
on the prompt without a reports instance. Nothing reads what it writes, and it is
a flag rather than a path, because a path is what made an unread note public.

**The commit range is posted with the draft.** Reports shows it beside the note
so a claim can be checked against the commits. The paraphrased security section
scored clean against the guard in this file; reading it and going to look for
"keychain" is what caught it.

**The prompt.** It is the part that decides quality, and it is worth reading:
`patch-notes-style.md` in full, then a short adapter naming what the model cannot
do (pictures, sponsors, Vikunja) and the shape to fill.

## Where the facts come from

Every release commits `.release/manifest.json`, pinning the exact client, server,
sfu and image worker commit. So the diff between two releases is `git log
old..new` in four submodules, not a guess. GitHub's pre-release flag is what
separates a beta from a stable release, so "the previous stable release" is a
lookup.

The three hand-written headlines are read at run time and given to the model as
the target, so a fourth written note joins them without editing the script.

## The model never writes markup

It fills a fixed shape and the site renders it. No markup crosses the boundary, a
malformed answer is detectable rather than merely ugly, and a note that fails
validation is not written at all — the next run tries again.

## Four bugs that only showed up by running it

- `--limit` scaled the GitHub fetch as well as the draft count. Betas outnumber
  stable releases ten to one, so it fetched four pre-releases and found no stable
  ones at all.
- Releases were sorted *after* mapping, and the map drops `publishedAt`. The
  comparator read `undefined` on both sides and every diff ran backwards.
- `stream: false` means no bytes until the answer is complete, and Node's fetch
  gives up on response headers after five minutes. A 13 kB prompt into a 32b
  model is past that; it surfaced as a bare `fetch failed`.
- qwen3 reasons out loud by default, wrapping the JSON in a think block.

## What it actually wrote

Verified against your instance on `qwen3:32b`, drafting 1.6.43 from its four
commits. About eight minutes a release.

First draft leaked `@gryt/owl`, "31.9% of avatars over 20,000 seeds" and "SFU
(Selective Forwarding Unit)", and opened three of four sections with
"Previously". After tightening the prompt: none of those, "Previously" once, and
"the media server" where it had written SFU.

Facts came from the commits. "Apple's shape since Big Sur" reads like the model's
own knowledge and is verbatim in the GRYT-616 commit body.

**Still wrong:** the headline lists three things when told not to —
*"Voice presence is now reliable, avatars are consistent, and macOS icons look
right"* against a house style of one sentence naming what matters.

## Installing

`ops/internal/README.md` has the steps. Needs Node 20+ on the host, `gh`
authenticated, `OLLAMA_URL` set in `/etc/default/gryt-changelog-notes` — the
default is a local Ollama and there is not one on that box — and the site
container recreated once for the new mount.

`node ops/internal/changelog-notes.mjs --dry-run` prints the prompt and calls
nothing.

## Scope

Releases before v1.2.12 have no manifest and are skipped. Nothing here involves
changesets — those live in the `ui` repository and version npm packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
