### PR TITLE
Three things that stopped the changelog timer running at all (GRYT-638)

### DIFF
--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -113,29 +113,75 @@ function compareVersions(a, b) {
   return 0
 }
 
+/* Asked for as lines rather than as JSON, and through `gh api` rather than
+   `gh release list`. Both halves of that are about the gh on the machine this
+   runs on, and both were found by installing the timer rather than by reading
+   anything:
+
+   - `--json` on `gh release list` landed in gh 2.24. dev.lan runs Debian's
+     2.23, where it is an unknown flag, so the process exited 1 before drafting
+     anything and did so every hour.
+   - `gh api --paginate` on an array endpoint concatenates one array per page
+     on that version, so the output is `[...][...]` and JSON.parse refuses it
+     with "Extra data". `--slurp`, which merges them, is gh 2.42.
+
+   A `-q` projection is applied per page and comes back as lines, which is the
+   one shape every version in between agrees on. */
+const RELEASE_FIELDS =
+  '.[] | [.tag_name, (.prerelease|tostring), (.draft|tostring), (.published_at // "")] | @tsv'
+
 function releases() {
   const raw = sh('gh', [
-    'release', 'list', '-R', 'Gryt-chat/gryt',
-    '--limit', '300',
-    '--json', 'tagName,isPrerelease,publishedAt',
+    'api', '--paginate',
+    '-q', RELEASE_FIELDS,
+    'repos/Gryt-chat/gryt/releases?per_page=100',
   ], { cwd: REPO })
 
-  return JSON.parse(raw)
-    .map((r) => {
+  return raw.split('\n')
+    .map((line) => line.split('\t'))
+    /* A draft release has no tag pointing at it and never shipped, so there is
+       nothing to diff and nobody to tell about it. `gh release list --json`
+       could not report this at all, so the old call would have drafted notes
+       for the untagged v1.6.21 a workflow left behind. */
+    .filter(([tag, , draft]) => tag && draft !== 'true')
+    .map(([tag, prerelease, , publishedAt]) => {
       /* A tag that was never published, or was published by a rewrite, has a
          date that is not the release's. The manifest records when the release
-         was actually cut, so prefer it and keep publishedAt as the fallback. */
-      const published = /^\d{4}/.test(r.publishedAt) && !r.publishedAt.startsWith('0001')
-        ? r.publishedAt.slice(0, 10)
+         was actually cut, so prefer it and keep published_at as the fallback.
+         The REST field is null rather than absent where the CLI said
+         "0001-01-01", so both shapes have to miss the test below. */
+      const published = /^\d{4}/.test(publishedAt ?? '') && !publishedAt.startsWith('0001')
+        ? publishedAt.slice(0, 10)
         : null
       return {
-        tag: r.tagName,
-        version: r.tagName.replace(/^v/, ''),
-        channel: r.isPrerelease ? 'beta' : 'latest',
+        tag,
+        version: tag.replace(/^v/, ''),
+        channel: prerelease === 'true' ? 'beta' : 'latest',
         date: published,
       }
     })
     .sort((a, b) => compareVersions(a.version, b.version))
+}
+
+/**
+ * Bring the release tags in, once, before anything asks for a manifest.
+ *
+ * The checkout this reads is kept current by `git fetch origin main`, which
+ * does not bring tags with it. So every release cut since somebody last fetched
+ * tags by hand is simply not a ref here, and `git show <tag>:.release/…` fails
+ * for it — which surfaces as "no manifest on one of the tags" for every recent
+ * release at once. That reads like a missing file and is a missing ref, and on
+ * dev.lan it was the difference between 344 tags present and the three releases
+ * that mattered absent.
+ */
+function fetchTags() {
+  try {
+    execFileSync('git', ['-C', REPO, 'fetch', '--quiet', '--tags', 'origin'], { stdio: 'ignore' })
+  } catch {
+    /* Not fatal. Whatever tags are already here still work, and the manifest
+       check says plainly which releases cannot be reached. */
+    log('! could not fetch tags — working from the ones already here')
+  }
 }
 
 function manifestAt(tag) {
@@ -586,6 +632,8 @@ async function main() {
         'or --dry-run to print the prompt without asking the model.',
     )
   }
+
+  fetchTags()
 
   const style = readFileSync(join(REPO, 'patch-notes-style.md'), 'utf8')
   const all = releases()

--- a/ops/internal/systemd/gryt-changelog-notes.service
+++ b/ops/internal/systemd/gryt-changelog-notes.service
@@ -23,15 +23,30 @@ ExecStart=/usr/bin/env node /usr/local/lib/gryt/changelog-notes.mjs
 # draft. See gryt-changelog-notes.env.example.
 EnvironmentFile=-/etc/default/gryt-changelog-notes
 
-# It reads a git checkout and talks to two hosts, one on the LAN and one on
+# It works on a git checkout and talks to two hosts, one on the LAN and one on
 # loopback. None of that wants the rest of the machine.
 #
+# `full` rather than `strict`, and no ProtectHome, because both of those were
+# wrong about what this does. It is not a reader: ExecStartPre pulls the
+# checkout, and the run itself fetches release tags and deepens a shallow
+# submodule to reach the commit an old manifest pins. Under `strict` the whole
+# hierarchy is read-only, and the checkout on dev.lan lives in a home directory,
+# so ProtectHome=read-only would have blocked it there even without that.
+#
+# What it cost to find out: the unit failed on every run with
+# "cannot open '.git/FETCH_HEAD': Read-only file system", which reads like a
+# broken checkout rather than a sandbox refusing a write.
+#
+# `full` still keeps /usr, /boot, /efi and /etc read-only, which is the part
+# worth having for something that runs as root on a timer.
+#
 # No ReadWritePaths any more. This wrote /var/lib/gryt-changelog directly until
-# GRYT-635; the reports service owns that file now, and this posts to it.
+# GRYT-635; the reports service owns that file now, and this posts to it. Naming
+# the checkout here instead is not an option — it is a different path on every
+# machine, and EnvironmentFile cannot reach this directive.
 NoNewPrivileges=true
 PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=read-only
+ProtectSystem=full
 
 # A 32b model on CPU is minutes per release, and a first run with a backlog is
 # several of them in a row. Longer than the timer interval on purpose; systemd


### PR DESCRIPTION
Installing `gryt-changelog-notes.timer` on dev.lan after [gryt#132](https://github.com/Gryt-chat/gryt/pull/132) merged found all three of these at once. Each would have been enough on its own to make the unit fail every hour and draft nothing, and none of them are visible from a machine with current tooling.

## 1. `gh release list --json` does not exist on the gh that is there

`--json` on `release list` landed in **gh 2.24**. dev.lan runs Debian's **2.23.0**, where it is an unknown flag, so node exited 1 before reaching the model:

```
unknown flag: --json
Usage:  gh release list [flags]
```

The obvious replacement has its own version problem on 2.23: `gh api --paginate` on an array endpoint concatenates one array per page, so the output is `[...][...]` and `JSON.parse` refuses it with `Extra data`. `--slurp`, which merges them, is **gh 2.42**.

A `-q` projection is applied per page and comes back as lines, which is the one shape every version in between agrees on.

The REST fields also carry `draft`, which the CLI call could not report at all — so the old code would have drafted notes for the untagged `v1.6.21` a workflow left behind, and that release is also where the `0001-01-01` oddity in the ordering comment comes from.

## 2. The checkout has no tags for recent releases

`gryt-pull-superproject` keeps it current with `git fetch origin main`, which does not bring tags. So every release cut since somebody last fetched tags by hand is not a ref at all, and `git show <tag>:.release/manifest.json` fails for it.

On the box that was **344 tags present and the three releases that mattered absent**, reported as `no manifest on one of the tags` — which reads like a missing file and is a missing ref. That distinction is the entire bug and the message gives you no way to tell.

`fetchTags()` once, before anything asks for a manifest. A failure is logged and the run continues on whatever tags are already there.

## 3. The unit sandbox was written for a script that only reads

`ProtectSystem=strict` makes the whole hierarchy read-only, and `ProtectHome=read-only` would have blocked the checkout anyway, since on dev.lan it lives in a home directory. But this is not a reader: `ExecStartPre` pulls the checkout, and the run fetches tags and deepens a shallow submodule to reach the commit an old manifest pins.

```
gryt-pull-superproject[775601]: error: cannot open '.git/FETCH_HEAD': Read-only file system
```

Which reads like a broken checkout rather than a sandbox refusing a write.

`ProtectSystem=full` and no `ProtectHome`. `/usr`, `/boot`, `/efi` and `/etc` stay read-only, which is the part worth having for something running as root on a timer. `ReadWritePaths` is not an option — the checkout is a different path on every machine, and `EnvironmentFile` cannot reach that directive.

## What to look at

**Whether `ProtectSystem=full` is the trade you want.** It is the one thing here that widens what a root timer can touch. The alternative is a per-machine drop-in naming the checkout, which works but is another manual step on every box and the kind that gets forgotten until something fails quietly.

## Checked

Ran the fixed script on dev.lan against its own gh 2.23. It enumerates the releases, fetches the 22 missing tags, and resolves the commit range for 1.6.41, 1.6.42 and 1.6.43 — where the old one reported "no manifest" for all three.

## Deploying

Needs the unit re-copied and a `daemon-reload`, because 3 changes a file under `/etc`. Everything else arrives on the ten-minute pull.

```bash
cd /home/sivert/gryt && git pull && sudo cp ops/internal/systemd/gryt-changelog-notes.service /etc/systemd/system/ && sudo systemctl daemon-reload
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)