### PR TITLE
Take one machine's address and home directory out of the repository

### DIFF
--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -54,7 +54,7 @@ REPORTS_PUBLIC_URL=https://reports.gryt.chat
 # this is its LAN address. Empty believes any peer, and the ingest port is
 # reachable from the whole network — so empty means anything on the LAN can name
 # its own address and skip every rate limit and every ban.
-REPORTS_TRUSTED_PROXIES=192.168.50.182
+REPORTS_TRUSTED_PROXIES=<tunnel-host-address>
 
 # Signing in to the inbox with a Gryt account. Create a confidential client in
 # the gryt realm (see ops/internal/README.md) and put its secret here.

--- a/ops/internal/pull-superproject.sh
+++ b/ops/internal/pull-superproject.sh
@@ -32,7 +32,18 @@
 
 set -euo pipefail
 
-ROOT="${GRYT_ROOT:-/home/sivert/gryt}"
+# Where the checkout is.
+#
+# Worked out from this script's own path rather than named, because it is
+# symlinked into /usr/local/bin from inside the checkout it maintains — so it
+# already knows, and every install that follows the README is that shape.
+#
+# It used to default to one machine's home directory, which is wrong for anybody
+# else and is not something a public repository should be carrying at all.
+#
+# GRYT_ROOT still wins, for an install that copies the script instead.
+SELF=$(readlink -f "${BASH_SOURCE[0]}")
+ROOT="${GRYT_ROOT:-$(cd "$(dirname "$SELF")/../.." && pwd)}"
 BRANCH="${GRYT_BRANCH:-main}"
 
 log() { printf '%s  %s\n' "$(date -Is)" "$*"; }

--- a/ops/internal/systemd/gryt-changelog-notes.env.example
+++ b/ops/internal/systemd/gryt-changelog-notes.env.example
@@ -6,10 +6,13 @@
 
 # The Ollama instance that writes the prose. No trailing slash, and the port is
 # not optional — Ollama's default is 11434 and nothing is listening on 80.
-OLLAMA_URL=http://192.168.50.168:11434
+#
+# There is no useful default. This file is where one machine's address goes;
+# the repository is not.
+OLLAMA_URL=http://<ollama-host>:11434
 
-# The largest model that fits on the card, which is qwen3:32b on the machine
-# this was written for. Roughly eight minutes per release.
+# The largest model that fits on the card. qwen3:32b where this was written.
+# Roughly eight minutes per release on that one.
 #
 # Not a knob to turn down. qwen3:14b is around three minutes and reads flatter
 # for it — in one run it copied a headline word for word from a hand-written
@@ -38,10 +41,10 @@ GRYT_CHANGELOG_KEY=
 #GRYT_CHANGELOG_REDRAFT=1.6.43
 
 # The superproject checkout to read releases and submodule history from.
-# Derived from where the script actually is when this is unset, which is
-# correct as long as it is the symlink into the checkout. On the machine this
-# was written for that resolves to /home/sivert/gryt.
-#GRYT_CHANGELOG_REPO=/home/sivert/gryt
+# Worked out from where the script actually is when this is unset, which is
+# right as long as it is the symlink into the checkout that the README installs.
+# Only needed for an install that copies the script instead.
+#GRYT_CHANGELOG_REPO=/path/to/gryt
 
 # Which channels get notes. "latest" is the stable releases only, which is what
 # a reader wants. Add beta to draft the pre-releases too; the changelog page


### PR DESCRIPTION
Three values in `ops/internal` describe the box Gryt happens to run on, in a public repository. Sivert flagged the one I had just added in [#134](https://github.com/Gryt-chat/gryt/pull/134); the other two were already there and are the same mistake.

| | |
|---|---|
| `pull-superproject.sh` | `ROOT="${GRYT_ROOT:-/home/sivert/gryt}"` |
| `gryt-changelog-notes.env.example` | `OLLAMA_URL=http://192.168.50.168:11434` |
| `ops/internal/.env.example` | `REPORTS_TRUSTED_PROXIES=192.168.50.182` |

None of them is a secret. They are somebody's home directory and somebody's LAN, committed where a stranger reads them, and a default that is right on exactly one machine and silently wrong everywhere else.

## The checkout path did not need naming at all

`pull-superproject.sh` is symlinked into `/usr/local/bin` from inside the checkout it maintains — that is what the README tells you to do and what the box actually does:

```
/usr/local/bin/gryt-pull-superproject -> /home/sivert/gryt/ops/internal/pull-superproject.sh
```

So the script already knows where the checkout is. Same trick `changelog-notes.mjs` uses with `import.meta.url`:

```bash
SELF=$(readlink -f "${BASH_SOURCE[0]}")
ROOT="${GRYT_ROOT:-$(cd "$(dirname "$SELF")/../.." && pwd)}"
```

`GRYT_ROOT` still wins, for an install that copies the script rather than links it.

## The other two are examples, so they read as examples

`<ollama-host>` and `<tunnel-host-address>`. Both files are `.example` — they get copied and filled in, and the deployed copies already hold the real values, so nothing on the box changes.

Also drops "on the machine this was written for" from the model comment, which was doing the same thing in prose.

## What to look at

**The `readlink -f` derivation is the only behaviour change here**, and it runs as `ExecStartPre` for two units — if it resolved wrong, the pull would silently target the wrong directory or nothing at all.

Verified on the box the way it is actually installed: copied the rewritten script into the checkout, symlinked it from `/tmp` the same shape as `/usr/local/bin/gryt-pull-superproject`, and ran it. It resolved to `/home/sivert/gryt`, fast-forwarded the checkout `1aaed05 -> 3c6a270`, and exited 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)