### PR TITLE
Hand a refused draft back instead of throwing it away (GRYT-637)

### DIFF
--- a/.github/scripts/check-changelog-style.mjs
+++ b/.github/scripts/check-changelog-style.mjs
@@ -63,14 +63,20 @@ function handWritten(dir) {
     .filter((f) => f.endsWith('.mdx'))
     .sort()
     .map((file) => {
+      /* Four parts, not three: the two rules around the frontmatter, then the
+         article, then the rule above "The short version" and the recap after
+         it. Reading only the first three silently dropped every recap, and an
+         empty recap passes every recap rule — which is why the check below
+         refuses a note that parsed to nothing. */
       const raw = readFileSync(join(dir, file), 'utf8')
-      const [, front, body] = raw.split(/^---$/m)
-      const headline = front.match(/^headline:\s*(.+)$/m)?.[1]?.trim() ?? ''
+      const parts = raw.split(/^---$/m)
+      const headline = parts[1]?.match(/^headline:\s*(.+)$/m)?.[1]?.trim() ?? ''
 
-      const clean = body
+      const clean = (parts[2] ?? '')
         .replace(/^<(Image|Clip)[^>]*\/>\s*$/gm, '')
         .replace(/^import .*$/gm, '')
-      const [article, recapRaw = ''] = clean.split(/^---$/m)
+      const article = clean
+      const recapRaw = parts.slice(3).join('\n')
 
       const chunks = article.split(/^## /m)
       const paragraphs = (text) =>
@@ -81,16 +87,20 @@ function handWritten(dir) {
         return { heading: heading.trim(), body: paragraphs(rest.join('\n')) }
       })
 
+      /* Line by line, not block by block. A blank line sits between the bold
+         label and its bullets, so splitting on blank lines separated every
+         group from its own items and each of these notes tested with an empty
+         recap — which meant the recap rules were never exercised against the
+         writing they are supposed to be judged by. */
       const recap = []
-      for (const block of recapRaw.split(/\n{2,}/)) {
-        const group = block.match(/^\*\*(.+?)\*\*/)?.[1]
-        if (!group) continue
-        const items = block
-          .split('\n')
-          .slice(1)
-          .map((line) => line.replace(/^[-*]\s*/, '').trim())
-          .filter(Boolean)
-        recap.push({ group, items })
+      for (const line of recapRaw.split('\n')) {
+        const label = line.match(/^\*\*(.+?)\*\*\s*$/)?.[1]
+        if (label) {
+          recap.push({ group: label, items: [] })
+          continue
+        }
+        const item = line.match(/^[-*]\s+(.*)$/)?.[1]
+        if (item && recap.length) recap[recap.length - 1].items.push(item.trim())
       }
 
       return { name: file.replace(/\.mdx$/, ''), headline, intro: paragraphs(chunks[0]), sections, recap }
@@ -194,12 +204,20 @@ if (!existsSync(notes)) {
 console.log('The notes written by hand, which must all pass:\n')
 for (const note of handWritten(notes)) {
   const problems = styleProblems(note, WIDE_RANGE)
+  const shape = `${note.sections.length} sections, ${note.recap.length} recap groups, ${note.recap.reduce((n, g) => n + g.items.length, 0)} items`
   if (problems.length) {
     failed++
-    console.error(`  ✗ ${note.name} was refused by its own house style:`)
+    console.error(`  ✗ ${note.name} (${shape}) was refused by its own house style:`)
     for (const p of problems) console.error(`      ${p}`)
   } else {
-    console.log(`  ✓ ${note.name}`)
+    console.log(`  ✓ ${note.name} (${shape})`)
+  }
+
+  /* A note that parsed to nothing passes every rule, which is not the same as
+     passing. The parser has been wrong about this once already. */
+  if (!note.sections.length || !note.recap.length) {
+    failed++
+    console.error(`  ✗ ${note.name} parsed to an empty ${note.sections.length ? 'recap' : 'article'} — the parser is wrong, not the note`)
   }
 }
 

--- a/.github/scripts/check-changelog-style.mjs
+++ b/.github/scripts/check-changelog-style.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+//
+// The changelog drafter's style rules, checked against writing we already
+// trust and writing we already know is bad.
+//
+// `styleProblems` in ops/internal/changelog-notes.mjs is what decides whether a
+// drafted release note is written or thrown away. It is a pile of thresholds
+// and word lists, and every one of them was tuned by hand against real output —
+// which means every one of them can be quietly broken by the next person who
+// tightens a number.
+//
+// Two directions, and the first matters more:
+//
+//   1. The three notes written by hand must pass clean. They are the target the
+//      whole drafter is aiming at, so a rule that refuses one of them is not a
+//      rule, it is a bug. Tuning these checks produced two such bugs — `auth`
+//      matching "unauthenticated", and short headings scoring as duplicates
+//      because they are mostly stopwords — and both were found this way.
+//
+//   2. The drafts that were actually wrong must still be caught. The fixtures
+//      below are trimmed from real output off the box, including the fabricated
+//      security section that started all of this.
+//
+// Run by .github/workflows/changelog-style.yml on any pull request touching the
+// rules, the notes or this file.
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO = resolve(HERE, '..', '..')
+
+const { styleProblems } = await import(
+  join(REPO, 'ops', 'internal', 'changelog-notes.mjs')
+)
+
+/* A range big enough that the "tiny release" rules stay out of the way, and
+   with real security words in a subject, because the hand-written notes cover
+   whole minor lines and 1.6.0's identity work genuinely was security work. */
+const WIDE_RANGE = [
+  {
+    component: 'client',
+    commits: [
+      {
+        subject: 'feat: keychain-sealed identity with an encrypted backup',
+        body: 'credential handling, signature checks and permission changes',
+      },
+      ...Array.from({ length: 40 }, (_, i) => ({ subject: `change ${i}`, body: '' })),
+    ],
+  },
+]
+
+/**
+ * The hand-written notes, in the shape the model is asked to fill.
+ *
+ * Parsed rather than transcribed, so a note that gets edited is still what the
+ * check runs against. Everything before the first `##` is the intro, and the
+ * block below the rule is the recap.
+ */
+function handWritten(dir) {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.mdx'))
+    .sort()
+    .map((file) => {
+      const raw = readFileSync(join(dir, file), 'utf8')
+      const [, front, body] = raw.split(/^---$/m)
+      const headline = front.match(/^headline:\s*(.+)$/m)?.[1]?.trim() ?? ''
+
+      const clean = body
+        .replace(/^<(Image|Clip)[^>]*\/>\s*$/gm, '')
+        .replace(/^import .*$/gm, '')
+      const [article, recapRaw = ''] = clean.split(/^---$/m)
+
+      const chunks = article.split(/^## /m)
+      const paragraphs = (text) =>
+        text.split(/\n{2,}/).map((p) => p.trim()).filter(Boolean)
+
+      const sections = chunks.slice(1).map((chunk) => {
+        const [heading, ...rest] = chunk.split('\n')
+        return { heading: heading.trim(), body: paragraphs(rest.join('\n')) }
+      })
+
+      const recap = []
+      for (const block of recapRaw.split(/\n{2,}/)) {
+        const group = block.match(/^\*\*(.+?)\*\*/)?.[1]
+        if (!group) continue
+        const items = block
+          .split('\n')
+          .slice(1)
+          .map((line) => line.replace(/^[-*]\s*/, '').trim())
+          .filter(Boolean)
+        recap.push({ group, items })
+      }
+
+      return { name: file.replace(/\.mdx$/, ''), headline, intro: paragraphs(chunks[0]), sections, recap }
+    })
+}
+
+/* Trimmed from drafts the box actually produced. The comment on each is the
+   reason it was refused, and the reason the rule exists. */
+const BAD_DRAFTS = [
+  {
+    name: '1.6.41, which invented a security section',
+    expect: 'claims security, and nothing in the commits is about security',
+    range: [
+      {
+        component: 'client',
+        commits: [
+          {
+            subject: "fix: learn a server's scheme instead of guessing it forever (#254)",
+            /* "unauthenticated" is the trap: it contains "auth", and the first
+               version of the security check cleared this draft because of it. */
+            body: 'ensureSchemeKnown does one unauthenticated GET to /info per host. A preflight may not be redirected, so it fails as a CORS error.',
+          },
+        ],
+      },
+    ],
+    note: {
+      headline: 'Gryt now remembers whether your server uses HTTP or HTTPS.',
+      intro: ['A problem where Gryt would get stuck using the wrong protocol.'],
+      sections: [
+        {
+          heading: 'Gryt learns the scheme when you first join',
+          body: ['It used to assume HTTP and never change its mind.'],
+        },
+        {
+          heading: 'Gryt no longer risks insecure connections',
+          body: ['This change improves security by using the correct protocol.'],
+        },
+      ],
+      recap: [{ group: 'Hosting', items: ['Gryt remembers the scheme'] }],
+    },
+  },
+  {
+    name: '1.6.42, which used the headline again as a heading and padded a one-commit release',
+    expect: 'is the headline again',
+    range: [
+      {
+        component: 'client',
+        commits: [{ subject: 'fix: tint voice tiles from the designed owl', body: '' }],
+      },
+    ],
+    note: {
+      headline: 'Voice tiles now use the right colour for designed owls.',
+      intro: ['One paragraph.', 'And a second one, for a single commit.'],
+      sections: [
+        {
+          heading: 'Voice tiles now use the correct colour for designed owls',
+          body: ['If you have ever noticed a tile looking off, this change is for you.'],
+        },
+      ],
+      recap: [
+        { group: 'Voice', items: ['Voice tiles now use the correct colour for designed owls'] },
+      ],
+    },
+  },
+  {
+    name: '1.6.39, which listed three things in the headline and hid a new logo under the hood',
+    expect: 'lists three things',
+    range: [
+      {
+        component: 'client',
+        commits: [
+          { subject: 'The new Gryt mark', body: '' },
+          { subject: 'Save an owl to a file', body: '' },
+          { subject: 'Give the avatar editor a backdrop', body: '' },
+        ],
+      },
+    ],
+    note: {
+      headline: 'Gryt now lets you save custom avatars, adds a new logo, and fixes the avatar editor',
+      intro: ['A new mark, a clearer way to save avatars, and a more usable editor.'],
+      sections: [
+        { heading: 'Gryt has a new brand mark', body: ['A violet owl on a dark indigo ground.'] },
+        { heading: 'You can save avatars in four formats', body: ['SVG first.'] },
+        { heading: 'The editor has a backdrop and a way out', body: ['It could not be dismissed.'] },
+      ],
+      recap: [
+        { group: 'Under the hood', items: ['Updated the Gryt brand mark to a new design'] },
+      ],
+    },
+  },
+]
+
+let failed = 0
+
+const notes = join(REPO, 'packages', 'site', 'content', 'changelog')
+if (!existsSync(notes)) {
+  console.error(`✗ ${notes} is not here — the site submodule needs checking out`)
+  process.exit(1)
+}
+
+console.log('The notes written by hand, which must all pass:\n')
+for (const note of handWritten(notes)) {
+  const problems = styleProblems(note, WIDE_RANGE)
+  if (problems.length) {
+    failed++
+    console.error(`  ✗ ${note.name} was refused by its own house style:`)
+    for (const p of problems) console.error(`      ${p}`)
+  } else {
+    console.log(`  ✓ ${note.name}`)
+  }
+}
+
+console.log('\nDrafts that were wrong, which must still be caught:\n')
+for (const { name, note, range, expect } of BAD_DRAFTS) {
+  const problems = styleProblems(note, range)
+  const caught = problems.some((p) => p.includes(expect))
+  if (caught) {
+    console.log(`  ✓ ${name}`)
+  } else {
+    failed++
+    console.error(`  ✗ ${name}`)
+    console.error(`      expected a problem containing "${expect}"`)
+    console.error(`      got: ${problems.length ? problems.join('; ') : 'nothing at all'}`)
+  }
+}
+
+if (failed) {
+  console.error(`\n${failed} check${failed === 1 ? '' : 's'} failed.`)
+  process.exit(1)
+}
+console.log('\nAll good.')

--- a/.github/workflows/changelog-style.yml
+++ b/.github/workflows/changelog-style.yml
@@ -1,0 +1,64 @@
+name: Changelog style
+
+# Checks that the drafter's style rules still pass the notes written by hand,
+# and still catch the drafts that were wrong.
+#
+# `styleProblems` decides whether a drafted release note is written or thrown
+# away. It is thresholds and word lists, every one tuned against real output, so
+# every one can be quietly broken by the next person who adjusts a number. Two
+# were broken that way while being written — `auth` matched "unauthenticated"
+# and cleared a fabricated security section, and short headings scored as
+# duplicates of the headline because they are mostly stopwords.
+#
+# A rule that refuses one of the three hand-written notes is not a rule, it is a
+# bug, and this is what says so.
+#
+# Like avatar-parity, this lives in the superproject: the rules are in `ops/`
+# and the notes they are judged against are in the `site` submodule, and nowhere
+# else can see both.
+
+on:
+  # So a change to the rules is exercised by the pull request that makes it.
+  pull_request:
+    paths:
+      - .github/scripts/check-changelog-style.mjs
+      - .github/workflows/changelog-style.yml
+      - ops/internal/changelog-notes.mjs
+
+  # The notes live in a submodule, so editing one of them does not touch this
+  # repository at all. The gitlink bump that brings it in carries [skip ci],
+  # which is why avatar-parity is on a schedule too — same reason here.
+  schedule:
+    - cron: "41 6 * * *"
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: changelog-style-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Rules against the notes written by hand
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Only the one submodule. `submodules: true` would fetch all twelve to
+      # read three MDX files.
+      - name: Check out the site submodule
+        run: git submodule update --init --depth 1 packages/site
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # No install step on purpose: the check imports the drafter directly and
+      # the drafter has no dependencies outside node: builtins. If that ever
+      # stops being true, this failing is the right way to find out.
+      - name: Check the style rules
+        run: node .github/scripts/check-changelog-style.mjs

--- a/.github/workflows/discord-ci-notify.yml
+++ b/.github/workflows/discord-ci-notify.yml
@@ -12,6 +12,7 @@ on:
   workflow_run:
     workflows:
       - Avatar parity
+      - Changelog style
       - Release Client
       - Release Server
       - Sync Vikunja task

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -933,9 +933,30 @@ async function reports(path, init = {}) {
 /* Versions reports has already been given a draft for, in any state. A
    rejected one is not in this list, so a note somebody refused is drafted
    again on the next tick — which is what rejecting it is for. */
+/**
+ * Versions reports has already been given a draft for.
+ *
+ * Told apart from a configuration problem on purpose. A refused key or a
+ * missing route means somebody has to go and fix something, and exiting 0 on
+ * that would hide it for as long as nobody looked. Anything else — the service
+ * restarting for a deploy, a connection refused for two seconds — is not this
+ * script's problem and not worth a failed unit every hour, because a unit that
+ * cries wolf hourly is a unit whose real failure nobody reads.
+ */
 async function alreadyDrafted() {
-  const { versions } = await reports('/v1/changelog/versions')
-  return new Set(Array.isArray(versions) ? versions : [])
+  let last
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const { versions } = await reports('/v1/changelog/versions')
+      return new Set(Array.isArray(versions) ? versions : [])
+    } catch (err) {
+      last = err
+      if (/reports 4\d\d/.test(err.message)) throw err
+      log(`! reports did not answer (${err.message}); attempt ${attempt} of 3`)
+      await new Promise((r) => setTimeout(r, attempt * 2000))
+    }
+  }
+  return { unreachable: last }
 }
 
 async function postDraft(entry) {
@@ -974,8 +995,23 @@ async function main() {
   fetchTags()
 
   const style = readFileSync(join(REPO, 'patch-notes-style.md'), 'utf8')
-  const all = releases()
+
+  /* `gh` reaches the network, and the network is allowed to be down for a
+     minute. Same reasoning as the reports call below: nothing here is urgent
+     and the next tick is an hour away. */
+  let all
+  try {
+    all = releases()
+  } catch (err) {
+    log(`! could not list releases (${String(err.message).split('\n')[0]}) — nothing to do this run`)
+    return
+  }
+
   const have = DRY_RUN || DUMP ? new Set() : await alreadyDrafted()
+  if (have.unreachable) {
+    log(`! reports is unreachable (${have.unreachable.message}) — nothing to do this run`)
+    return
+  }
   if (REDRAFT) {
     have.delete(REDRAFT)
     log(`drafting ${REDRAFT} again, replacing the draft reports already has`)

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -92,8 +92,57 @@ const DUMP_DIR = resolve(process.env.GRYT_CHANGELOG_DUMP ?? join(HERE, 'changelo
 
 const log = (...a) => console.log('[changelog]', ...a)
 
+/**
+ * Who owns the checkout, and where their home is.
+ *
+ * Everything this script shells out to belongs to that person rather than to
+ * the process: the git objects, and gh's login, which lives in their
+ * ~/.config/gh/hosts.yml. The unit runs as root, so running either directly
+ * gets git refusing the repository as dubiously owned and gh refusing outright:
+ *
+ *   To get started with GitHub CLI, please run:  gh auth login
+ *
+ * which is what failed the hourly unit, with a stack trace and exit 1, in the
+ * one place a stack trace is least useful. pull-superproject.sh has done this
+ * since it was written; the drafter simply never needed to until it started
+ * fetching tags of its own.
+ *
+ * Worked out rather than configured. The alternative is a `User=` in the unit
+ * or a name in the env file, and a machine's user account has no business being
+ * in a public repository.
+ */
+const owner = (() => {
+  if (process.getuid?.() !== 0) return null
+  try {
+    const name = execFileSync('stat', ['-c', '%U', REPO], { encoding: 'utf8' }).trim()
+    if (!name || name === 'root') return null
+    /* HOME is not changed by `runuser -u`, so without this gh looks in
+       /root/.config and finds nothing — the same failure, one layer along. */
+    const home = execFileSync('getent', ['passwd', name], { encoding: 'utf8' })
+      .trim().split(':')[5]
+    return home ? { name, home } : null
+  } catch {
+    return null
+  }
+})()
+
+
+
+/* Not on a normal user's PATH — it lives in /usr/sbin, which is root's, and
+   root is the only one who can use it anyway. pull-superproject.sh has the same
+   two lines for the same reason. */
+const RUNUSER = (() => {
+  for (const path of ['/usr/sbin/runuser', '/sbin/runuser', '/usr/bin/runuser']) {
+    if (existsSync(path)) return path
+  }
+  return null
+})()
+
 function sh(cmd, args, opts = {}) {
-  return execFileSync(cmd, args, {
+  const [run, argv] = owner && RUNUSER
+    ? [RUNUSER, ['-u', owner.name, '--', 'env', `HOME=${owner.home}`, cmd, ...args]]
+    : [cmd, args]
+  return execFileSync(run, argv, {
     encoding: 'utf8',
     maxBuffer: 32 * 1024 * 1024,
     ...opts,
@@ -188,7 +237,7 @@ function releases() {
  */
 function fetchTags() {
   try {
-    execFileSync('git', ['-C', REPO, 'fetch', '--quiet', '--tags', 'origin'], { stdio: 'ignore' })
+    sh('git', ['-C', REPO, 'fetch', '--quiet', '--tags', 'origin'], { stdio: 'pipe' })
   } catch {
     /* Not fatal. Whatever tags are already here still work, and the manifest
        check says plainly which releases cannot be reached. */
@@ -213,7 +262,7 @@ const NOISE = /^(release:|chore:|ci:|build:|Version Packages|Merge (pull request
    checkout that must not draft notes off half the changes. */
 function have(dir, sha) {
   try {
-    execFileSync('git', ['-C', dir, 'cat-file', '-e', `${sha}^{commit}`], { stdio: 'ignore' })
+    sh('git', ['-C', dir, 'cat-file', '-e', `${sha}^{commit}`], { stdio: 'pipe' })
     return true
   } catch {
     return false
@@ -224,7 +273,7 @@ function reach(dir, sha) {
   if (have(dir, sha)) return true
   for (const args of [['fetch', '--quiet', 'origin', sha], ['fetch', '--quiet', '--unshallow', 'origin']]) {
     try {
-      execFileSync('git', ['-C', dir, ...args], { stdio: 'ignore' })
+      sh('git', ['-C', dir, ...args], { stdio: 'pipe' })
       if (have(dir, sha)) return true
     } catch { /* try the next one */ }
   }

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -845,9 +845,28 @@ export function styleProblems(entry, parts) {
      is the evidence. The new brand mark went in there while the intro two
      paragraphs above called it the most visible change in the release. */
   const underHood = entry.recap.find((g) => /under the hood/i.test(g.group))
-  const visible = underHood?.items.find((item) => headings.some((h) => overlap(item, h) > 0.4))
-  if (visible) {
-    problems.push(`"${visible}" is under the hood, and the note has a section about it`)
+  if (underHood) {
+    /* Two ways of asking the same question. The heading comparison catches an
+       item that restates a heading; the containment one catches the same fact
+       worded differently, which is what actually happens — "The app no longer
+       defaults to HTTP for servers added before HTTPS logic existed" shares
+       almost nothing with the heading above it and every word with the
+       paragraph underneath.
+
+       The hand-written notes put real invisible things here — a compiled
+       SQLite library swapped for Node's, React 19, the client compiling in CI —
+       and none of them appear in their own article, which is the whole point:
+       if it was worth explaining, the reader can see it. */
+    const article = contentWords([...headings, ...prose].join(' '))
+    const visible = underHood.items.find((item) => {
+      if (headings.some((h) => overlap(item, h) > 0.4)) return true
+      const words = [...contentWords(item)]
+      if (words.length < 4) return false
+      return words.filter((w) => article.has(w)).length / words.length > 0.7
+    })
+    if (visible) {
+      problems.push(`"${visible}" is under the hood, and the note explains it above`)
+    }
   }
 
   for (const pattern of FILLER) {
@@ -1002,19 +1021,30 @@ async function main() {
          fixes them readily once it is told which ones. */
       let entry = null
       let problems = []
+      /* Every attempt's verdict, kept for the rejected file. A release that
+         fails all three is the interesting case, and the question it raises is
+         whether a rule is satisfiable rather than whether the model is bad —
+         which you can only answer by seeing whether the same reason came back
+         every time or whether it was chasing a different one each round. */
+      const history = []
       for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
         try {
           entry = await ask(attempt === 1 ? text : text + retryPrompt(entry, problems))
         } catch (err) {
           log(`  ! model failed: ${err.message}`)
+          history.push({ attempt, error: err.message })
           entry = null
           break
         }
         problems = judge(entry)
+        history.push({ attempt, problems })
         if (!problems.length) break
         log(`  · attempt ${attempt} sent back: ${problems.join('; ')}`)
       }
       if (!entry) continue
+      if (history.length > 1 && !problems.length) {
+        log(`    accepted on attempt ${history.length}`)
+      }
 
       const bad = problems.length ? problems.join('; ') : null
       if (bad) {
@@ -1027,7 +1057,11 @@ async function main() {
           mkdirSync(dir, { recursive: true })
           writeFileSync(
             join(dir, `${release.version}.json`),
-            `${JSON.stringify({ version: release.version, reason: bad, entry }, null, 2)}\n`,
+            `${JSON.stringify(
+              { version: release.version, reason: bad, attempts: history, entry },
+              null,
+              2,
+            )}\n`,
           )
           log(`    kept for inspection: ${join(dir, `${release.version}.json`)}`)
         } catch { /* the draft is lost, which is the status quo */ }

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -45,6 +45,10 @@
 //                          "latest beta" also drafts the pre-releases, which
 //                          the site hides behind a toggle.
 //   GRYT_CHANGELOG_LIMIT   how many releases back to consider. Default 12.
+//   GRYT_CHANGELOG_ATTEMPTS  how many times to ask for one release before
+//                          giving up on it. Default 3. A refused draft is
+//                          handed back with the reasons rather than thrown
+//                          away, which is what usually fixes it.
 //   GRYT_CHANGELOG_DUMP    with --dump, where to write drafts for inspection.
 //                          Default ./changelog/drafts beside this file. Nothing
 //                          reads what is written there.
@@ -55,7 +59,7 @@
 import { execFileSync } from 'node:child_process'
 import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO = resolve(process.env.GRYT_CHANGELOG_REPO ?? join(HERE, '..', '..'))
@@ -65,6 +69,14 @@ const OLLAMA_URL = process.env.OLLAMA_URL ?? 'http://127.0.0.1:11434'
 const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? 'llama3.1:8b'
 const OLLAMA_TIMEOUT_MS = Number(process.env.OLLAMA_TIMEOUT_MS ?? 180_000)
 const DRY_RUN = process.argv.includes('--dry-run')
+
+/* How many times to ask for one release before giving up on it.
+   Each attempt is a full generation — eight minutes on qwen3:32b — so this is
+   the difference between a release drafted and eight minutes wasted, and also
+   the difference between a backfill of five hours and one of fifteen. Three is
+   enough in practice: the second attempt fixes it almost every time, because
+   what gets refused is two sentences rather than the whole note. */
+const ATTEMPTS = Math.max(1, Number(process.env.GRYT_CHANGELOG_ATTEMPTS ?? 3))
 
 /* Where a draft goes. */
 const REPORTS_URL = (process.env.GRYT_CHANGELOG_URL ?? '').replace(/\/$/, '')
@@ -247,6 +259,32 @@ function commitsFor(component, from, to) {
   }
 }
 
+/**
+ * What to call each part of Gryt on a page a user reads.
+ *
+ * The manifest names repositories, and a repository name is the wrong register
+ * for release notes — "sfu" and "imageWorker" mean nothing to somebody deciding
+ * whether they need to update anything. Mapped here rather than asked of the
+ * model, because this is a fact off the manifest diff and the prompt goes out
+ * of its way to forbid the model writing these words at all: a draft that
+ * leaked "the SFU handles disconnections more clearly" into a headline is what
+ * that rule is for.
+ *
+ * The point of showing them is the question prose cannot answer at a glance —
+ * a self-hoster wants to know whether the server moved or whether this is only
+ * the app (GRYT-231).
+ */
+const COMPONENT_NAMES = {
+  client: 'The app',
+  server: 'The server',
+  sfu: 'Voice',
+  imageWorker: 'Images',
+}
+
+function componentName(key) {
+  return COMPONENT_NAMES[key] ?? key
+}
+
 function changesBetween(prevTag, tag) {
   const a = manifestAt(prevTag)
   const b = manifestAt(tag)
@@ -398,6 +436,12 @@ function prompt(release, changes, style) {
     '            for somebody deciding whether to read on. Do not name the',
     '            version number in it; the page already shows that. Do not list',
     '            three things to sound complete — pick what matters and say it.',
+    '            "Gryt now lets you save custom avatars, adds a new logo, and',
+    '            fixes the avatar editor" is three headlines pretending to be',
+    '            one, and it tells a reader nothing about which of the three is',
+    '            worth their time. Pick the one somebody would mention first and',
+    '            write that. The other two have sections; they do not need to be',
+    '            in the headline as well.',
     '            These are the headlines written by hand, and they are the',
     '            target:',
     '',
@@ -405,15 +449,23 @@ function prompt(release, changes, style) {
     '',
     '  intro     One or two paragraphs, no heading, before everything else.',
     '            What this release is about: what was wrong, or what changed',
-    '            direction, or what somebody notices first. Not a summary of',
-    '            the sections below. If the release is small, one sentence',
-    '            saying so is the right answer.',
+    '            direction, or what somebody notices first.',
+    '',
+    '            Never a summary of the sections below. "The most visible change',
+    '            is the new logo, but the improvements to the editor are where',
+    '            the work matters" is a table of contents in prose, and the',
+    '            reader is about to read the sections anyway. If the second',
+    '            paragraph is listing what the first three headings say, there',
+    '            should not be a second paragraph.',
     '  sections  The article. Two to four, each about one thing that changed,',
     '            in the order the guide gives: what you notice, then what a',
     '            host notices, then what a careful person asks about. Each has',
     '            a heading that is a sentence rather than a label, and a body',
-    '            of one to three paragraphs. Security is always its own',
-    '            section and is never softened.',
+    '            of one to three paragraphs.',
+    '',
+    '            A heading must not be the headline again. The headline is',
+    '            directly above it on the page; a section that repeats it',
+    '            spends the reader\'s first heading saying nothing.',
     '  recap     The short version. Groups from the guide\'s list: Voice,',
     '            Avatars and images, Emoji, Updates, Hosting, Security,',
     '            Accessibility, Under the hood. Skip a group with nothing in',
@@ -441,7 +493,9 @@ function prompt(release, changes, style) {
     '',
     'A section belongs in "Under the hood" only if a user cannot see it. A',
     'redesigned hover card is something they can see, so it is not under the',
-    'hood.',
+    'hood. Neither is a new logo, a new colour, a new button or anything else',
+    'you wrote a section about — if it was worth a section, the reader can see',
+    'it, and filing it under the hood in the recap contradicts your own note.',
     '',
     'Do not start more than one section with the same word. "Previously" in',
     'front of every contrast reads as a form someone filled in. Vary it, or',
@@ -450,9 +504,72 @@ function prompt(release, changes, style) {
     'Every fact must come from the commits above. Do not invent a number, a',
     'date, a feature or a reason.',
     '',
+    'SECURITY',
+    '',
+    'If the commits contain a security fix, it gets its own section and is',
+    'never softened. If they do not, this release has no security section and',
+    'you must not write one. A shape is not a reason: a note about a connection',
+    'that failed is not a note about security, however easy it is to describe',
+    'it that way. The same goes for the Security group in the recap.',
+    '',
+    'HOW LONG',
+    '',
+    'Match the release. One or two commits is one section and one short intro',
+    'paragraph — say the thing and stop. Two paragraphs and three headings',
+    'about a single fix is the same sentence three times, and a reader can',
+    'tell. A release with nothing much in it is allowed to have a short note;',
+    'that is information too.',
+    '',
+    'WHAT NOT TO WRITE',
+    '',
+    'No sentence that would read the same in another product\'s release notes.',
+    'If it would survive a find-and-replace of the word Gryt, it is filler and',
+    'it is taking the place of a fact. "Improves the user experience", "keeps',
+    'the visual language consistent", "this change is for you" — none of these',
+    'say anything. Say what changed and who notices.',
+    '',
+    'Do not address the reader about the release itself. They are reading it;',
+    'they know.',
+    '',
     'If nothing in this release is visible to a user, return an empty sections',
     'array, an empty recap, a one-sentence intro saying so, and a headline',
     'saying it is a maintenance release.',
+    '',
+  ].join('\n')
+}
+
+/**
+ * What to send back when a draft was refused.
+ *
+ * Rejecting a draft and waiting for the next tick throws away eight minutes of
+ * GPU and gets the same mistakes again, because nothing about the next run is
+ * different. Telling the model what it broke, with the draft in front of it, is
+ * the one thing that changes the answer.
+ *
+ * The previous answer goes in as well as the reasons. Without it the model
+ * writes a new note from scratch and loses whatever was already right — and
+ * most of what these drafts get wrong is two sentences in an otherwise sound
+ * article.
+ */
+function retryPrompt(previous, problems) {
+  return [
+    '',
+    '─────────────────────────────────────────────────────────────────────',
+    'YOUR LAST ANSWER WAS REFUSED',
+    '',
+    'You have already written this note once. It was checked and sent back.',
+    'Here it is:',
+    '',
+    JSON.stringify(previous, null, 2),
+    '',
+    'It was refused for these reasons, and only these:',
+    '',
+    ...problems.map((p) => `  - ${p}`),
+    '',
+    'Write it again with those fixed. Everything else was fine — keep it.',
+    'Do not start over, do not change what was not named above, and do not',
+    'add anything to make up for what you are removing. A note that gets',
+    'shorter because a section was wrong is a shorter note, not a worse one.',
     '',
   ].join('\n')
 }
@@ -549,6 +666,208 @@ const COMMON = new Set(`about after again against along already also although al
   together
   under until upon used uses using usually very want well were what when where
   whether which while with within without would your yours` .split(/\s+/).filter(Boolean))
+
+/* ── The house style, as code ────────────────────────────────────────────
+   Everything below is also a rule in the prompt, and the prompt is where a
+   model is meant to learn it. These exist because it demonstrably does not.
+   The first drafts off the box broke the "Previously" rule twice in one note,
+   wrote a security section for a release with no security in it, and used the
+   headline again as the first section heading — all while being told not to.
+
+   A rule the model can ignore is a suggestion. A rule here is a rule: a draft
+   that breaks one is not written and the next run tries again. */
+
+/** Comparable form, so "the same sentence" survives punctuation and case. */
+export function normalise(text) {
+  return String(text).toLowerCase().replace(/[^a-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+/* Ignored when comparing two sentences, because a short heading is mostly
+   these and they make any two English sentences look alike. Without this,
+   1.5.0's "The client is a server" scored 0.8 against its own headline —
+   four words shared, and all four of them were "the", "is", "a" and "server". */
+const STOPWORDS = new Set(`a an and are as at be been but by can do does for from
+  has have how if in into is it its more no not now of on or so than that the
+  their them then there these they this to up was were what when which who will
+  with you your`.split(/\s+/).filter(Boolean))
+
+const contentWords = (text) =>
+  new Set(normalise(text).split(' ').filter((w) => w && !STOPWORDS.has(w)))
+
+/**
+ * How much two sentences are the same sentence.
+ *
+ * Against the longer of the two, not the shorter. A headline often covers two
+ * things and a section takes one of them — 1.5.0's headline is about not
+ * needing an account *and* the app being a server, and its first heading is
+ * "You do not need an account". Measured against the heading that is a perfect
+ * score; measured against the headline it is a quarter, which is the honest
+ * answer. Restating the whole headline still scores high, because then there
+ * is nothing in the longer one that the shorter one left out.
+ */
+export function overlap(a, b) {
+  const x = contentWords(a)
+  const y = contentWords(b)
+  if (!x.size || !y.size) return 0
+  const shared = [...x].filter((w) => y.has(w)).length
+  return shared / Math.max(x.size, y.size)
+}
+
+/* Words that make a change a security change.
+   Not `auth` on its own, and not a bare substring match. The first version of
+   this check used both, and cleared a security section for 1.6.41 — a CORS
+   preflight failing behind a proxy — because the commit body happens to
+   contain "one unauthenticated GET to /info". `auth` also lives inside
+   "author" and "authoritative", and `escap` inside "landscape". */
+const SECURITY_WORDS = new RegExp(
+  '\\b(security|vulnerabilit(y|ies)|exploit|cve-\\d|xss|csrf|clickjack' +
+    '|injection|sanitis|sanitiz|spoof|privilege|credential|password|passphrase' +
+    '|secret|encrypt|decrypt|signature|certificate|keychain|authenticat' +
+    '|authoris|authoriz|permission)\\b',
+  'gi',
+)
+
+/**
+ * Whether the range actually contains a security change.
+ *
+ * A subject that says so is taken at its word — that is somebody labelling
+ * their own commit. A body is weaker evidence, because a commit explains
+ * mechanism and mechanism mentions authentication in passing, so a body has to
+ * raise the subject twice over before it counts.
+ *
+ * The failure this exists to stop is the model reaching for a security section
+ * because the house style asks for one, not because the release had one.
+ */
+export function hasSecurityChange(parts) {
+  const subjects = parts.flatMap((part) => part.commits.map((c) => c.subject)).join('\n')
+  if (SECURITY_WORDS.test(subjects)) return true
+
+  const bodies = parts.flatMap((part) => part.commits.map((c) => c.body)).join('\n')
+  const distinct = new Set((bodies.match(SECURITY_WORDS) ?? []).map((w) => w.toLowerCase()))
+  return distinct.size >= 2
+}
+
+/* Sentences that would sit unchanged in any other project's release notes.
+   The style guide calls this the portability test; this is the short version
+   of it, drawn from what the drafts actually produced. */
+const FILLER = [
+  /this change is for you/i,
+  /we('| a)re (excited|pleased|happy)/i,
+  /visual language/i,
+  /user experience/i,
+  /seamless/i,
+  /under the hood improvements/i,
+  /stay tuned/i,
+  /and much more/i,
+]
+
+/**
+ * The rules that are about writing rather than about shape.
+ *
+ * Returned as a list rather than the first failure, because a draft that
+ * breaks three of these is worth seeing all three of at once when it lands in
+ * `rejected/`. Reading a refusal is how the first fabricated draft was
+ * diagnosed, and one reason at a time makes that three runs instead of one.
+ */
+export function styleProblems(entry, parts) {
+  const problems = []
+  const headings = entry.sections.map((s) => s.heading)
+  const prose = [...entry.intro, ...entry.sections.flatMap((s) => s.body)]
+
+  /* At most once in the whole note. It is the obvious way to write a contrast
+     and it reads as a form somebody filled in when every paragraph has it. */
+  const previously = prose.join(' ').match(/\bpreviously\b/gi)?.length ?? 0
+  if (previously > 1) problems.push(`"Previously" ${previously} times, and once is the limit`)
+
+  /* The headline is already on the page, directly above. A section that
+     repeats it spends the reader's first heading saying nothing new. */
+  for (const heading of headings) {
+    if (overlap(entry.headline, heading) > 0.6) {
+      problems.push(`the heading "${heading}" is the headline again`)
+    }
+  }
+
+  /* Two sections opening on the same word reads as a template rather than as
+     writing, and "Previously" is the one it always is. */
+  const firstWords = headings.map((h) => normalise(h).split(' ')[0]).filter(Boolean)
+  const repeated = firstWords.find((w, i) => firstWords.indexOf(w) !== i)
+  if (repeated) problems.push(`more than one section starts with "${repeated}"`)
+
+  /* The recap is the short version, not the headings again. Somebody who read
+     the article should still find something in it. */
+  const items = entry.recap.flatMap((g) => g.items)
+  const echoes = items.filter((item) => headings.some((h) => overlap(item, h) > 0.7))
+  if (items.length && echoes.length === items.length) {
+    problems.push('every recap line is one of the section headings again')
+  }
+
+  /* Security is its own section when there is security in the release, and no
+     section at all when there is not. The prompt used to say "always", which
+     is a shape to fill rather than a fact to report. */
+  /* Anywhere in the note, not just in a heading. The draft that started this
+     had "Security:" in a heading and was caught by that, but the same
+     fabrication written as "Gryt no longer risks insecure connections" with
+     "this change improves security" in the body would have gone straight
+     through — the claim is what matters, not where it is made. */
+  const claimsSecurity = [...headings, ...entry.recap.map((g) => g.group), ...prose].some(
+    (text) => /\b(security|insecure|vulnerab)/i.test(text),
+  )
+  if (claimsSecurity && !hasSecurityChange(parts)) {
+    problems.push('the note claims security, and nothing in the commits is about security')
+  }
+
+  /* A heading is a sentence. "Security:" and "Performance:" are labels with a
+     sentence stapled on. */
+  const labelled = headings.find((h) => /^[A-Z][A-Za-z ]{0,20}:/.test(h))
+  if (labelled) problems.push(`the heading "${labelled}" is a label, not a sentence`)
+
+  /* "A, B, and C" in the headline. The guide says pick what matters and say
+     it, and a list of three is the model sounding complete instead of
+     choosing — "Gryt now lets you save custom avatars, adds a new logo, and
+     fixes the avatar editor" is three releases' worth of headline for one.
+
+     Counting commas alone would refuse 1.6.0's hand-written headline, which
+     has two of them and names one thing: the middle segment is "even without
+     an account", a qualifier rather than a list item. So a segment that opens
+     with a subordinator does not count towards the list. */
+  const segments = entry.headline.split(',').map((seg) => seg.trim()).filter(Boolean)
+  const subordinator = /^(even|which|so|because|though|although|while|if|when|unless|and then)\b/i
+  if (
+    segments.length >= 3 &&
+    /^and\b/i.test(segments[segments.length - 1]) &&
+    !segments.slice(1, -1).some((seg) => subordinator.test(seg))
+  ) {
+    problems.push('the headline lists three things rather than naming the one that matters')
+  }
+
+  /* Under the hood is for what a user cannot see. A release that got a whole
+     section about it is, by construction, something they can — the note itself
+     is the evidence. The new brand mark went in there while the intro two
+     paragraphs above called it the most visible change in the release. */
+  const underHood = entry.recap.find((g) => /under the hood/i.test(g.group))
+  const visible = underHood?.items.find((item) => headings.some((h) => overlap(item, h) > 0.4))
+  if (visible) {
+    problems.push(`"${visible}" is under the hood, and the note has a section about it`)
+  }
+
+  for (const pattern of FILLER) {
+    const hit = prose.find((paragraph) => pattern.test(paragraph))
+    if (hit) {
+      problems.push(`filler: "${hit.match(pattern)[0]}"`)
+      break
+    }
+  }
+
+  /* A release of one commit is a short note. Padding it is how a one-line fix
+     became two intro paragraphs and a section saying the same thing again. */
+  const commits = parts.reduce((n, part) => n + part.commits.length, 0)
+  if (commits <= 2) {
+    if (entry.intro.length > 1) problems.push('more than one intro paragraph for a tiny release')
+    if (entry.sections.length > 1) problems.push('more than one section for a tiny release')
+  }
+
+  return problems
+}
 
 /* Anything the model got wrong in a way that would reach the page. A bad entry
    is not written at all; the next run tries again. */
@@ -671,15 +990,33 @@ async function main() {
       const text = prompt(release, changes, style)
       if (DRY_RUN) { console.log(`\n───── prompt for ${release.version} ─────\n${text}\n`); continue }
 
-      let entry
-      try {
-        entry = await ask(text)
-      } catch (err) {
-        log(`  ! model failed: ${err.message}`)
-        continue
+      const commitText = JSON.stringify(changes.parts)
+      const judge = (draft) => {
+        const shape = validate(draft) ?? contamination(draft, workedExample(REPO), commitText)
+        return shape ? [shape] : styleProblems(draft, changes.parts)
       }
-      const bad = validate(entry)
-        ?? contamination(entry, workedExample(REPO), JSON.stringify(changes.parts))
+
+      /* Ask, check, and hand the reasons back rather than giving up on the
+         first refusal. The rules the model breaks are the same few every time —
+         "Previously" twice, a visible change filed under the hood — and it
+         fixes them readily once it is told which ones. */
+      let entry = null
+      let problems = []
+      for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+        try {
+          entry = await ask(attempt === 1 ? text : text + retryPrompt(entry, problems))
+        } catch (err) {
+          log(`  ! model failed: ${err.message}`)
+          entry = null
+          break
+        }
+        problems = judge(entry)
+        if (!problems.length) break
+        log(`  · attempt ${attempt} sent back: ${problems.join('; ')}`)
+      }
+      if (!entry) continue
+
+      const bad = problems.length ? problems.join('; ') : null
       if (bad) {
         log(`  ! rejected: ${bad}`)
         /* Kept, because a refusal nobody can read is a refusal nobody can
@@ -705,7 +1042,16 @@ async function main() {
         intro: entry.intro,
         sections: entry.sections,
         recap: entry.recap,
-        source: { since: prev.version, commits: count, model: OLLAMA_MODEL },
+        source: {
+          since: prev.version,
+          commits: count,
+          model: OLLAMA_MODEL,
+          /* Which parts of Gryt moved, in the order the manifest lists them.
+             Straight off the diff, so there is nothing here for a model to get
+             wrong, and the page can answer "is this just the app?" without the
+             prose having to say a word about it. */
+          components: changes.parts.map((part) => componentName(part.component)),
+        },
         /* The range this was written from, so whoever reads the note can check
            a claim against the commits rather than agree with prose that reads
            well. Checking is what caught the paraphrased security section; the
@@ -742,7 +1088,13 @@ async function main() {
   )
 }
 
-main().catch((err) => {
-  console.error('[changelog] failed:', err)
-  process.exit(1)
-})
+/* Only when run, not when imported.
+   The style rules below are exported so CI can check them against the notes
+   written by hand, and a module that drafts a changelog as a side effect of
+   being imported is a module nobody can test. */
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error('[changelog] failed:', err)
+    process.exit(1)
+  })
+}

--- a/patch-notes-style.md
+++ b/patch-notes-style.md
@@ -103,8 +103,14 @@ neither. If the only honest bullet is "we tidied up", write nothing.
 
 ## Security
 
-Its own section, never folded into bug fixes, and never softened. Say what was
-wrong and what it meant, in the same voice as everything else:
+When a release contains one. Most do not, and a release with no security fix in
+it has no security section — the drafter read this heading as a shape to fill
+and wrote one about insecure connections for a release whose only commit was a
+CORS preflight failing behind a proxy.
+
+When there is one: its own section, never folded into bug fixes, and never
+softened. Say what was wrong and what it meant, in the same voice as everything
+else:
 
 > - SVG uploads are refused. An SVG can carry scripts, and Gryt was serving them
 >   from its own address


### PR DESCRIPTION
Read six drafts off the box against their commit ranges. The good news first: **nothing in them is invented any more.** Every claim traces to a commit, which was the thing that mattered and the reason the gate exists.

What is left is writing, and it is the same few faults every time:

- a headline listing three things instead of naming the one that matters
- `Previously` in two sections, when the rule is once in the whole note
- a visible change filed under **Under the hood**, once while the intro two paragraphs above called it the most visible thing in the release
- a second intro paragraph that is a table of contents for the sections below

The prompt already forbade all of those. I sharpened it twice, the second time with the actual bad sentences as counter-examples. It did not stop them.

## The rules as code

`styleProblems()` refuses a draft that breaks them, and every rule in it is also a rule in the prompt. A rule the model can ignore is a suggestion.

**Two of these checks were wrong when written**, and both were caught by running them against the three notes written by hand:

- `auth` matched **"one unauthenticated GET to /info"** and cleared the fabricated security section it was written for. A security claim now needs the word in a commit *subject*, or two distinct security words in bodies.
- Comparing a heading to the headline flagged 1.5.0's *"The client is a server"*, because a short heading is mostly stopwords. Content words only, measured against the **longer** sentence — so a heading taking one half of a two-part headline scores low, and one restating the whole thing scores high.

The security check reads bodies too, not just headings. The draft that started this said `Security:` in a heading and was caught by that; the same fabrication written as *"no longer risks insecure connections"* would have walked straight through.

## Revise rather than discard

The important one. Refusing a draft throws away eight minutes of GPU and gets the same mistakes next run, because nothing about the next run is different. A refused draft now goes back with the list of what it broke and an instruction to fix exactly that.

The previous answer goes back with it. Without it the model writes a new note from scratch and loses whatever was already right, and most of what gets refused is two sentences in an otherwise sound article.

`GRYT_CHANGELOG_ATTEMPTS`, default 3.

**It works.** 1.6.41 was refused on attempt one for padding a one-commit release, and came back on attempt two with one intro paragraph, one section, `Previously` once and every claim traceable:

> Gryt now remembers how your server handles secure connections

## What is not checked, and should be said out loud

There is **no check for "this intro paragraph summarises the sections below"**. The overlap is semantic rather than lexical, and a check that sometimes refuses good notes would be worse than none. It stays a prompt rule and something the reviewer catches. Saying so here because a gap nobody wrote down is a gap somebody later assumes is covered.

## Components

`source.components` off the manifest diff — *The app*, *The server*, *Voice*, *Images* — mapped in code and never written by the model. Answers [GRYT-231](https://tasks.sivert.io), open since August, on a reader not being able to tell from "1.6.43" whether the server moved or whether it is only the app. Pairs with [reports#23](https://github.com/Gryt-chat/reports/pull/23) and [site#50](https://github.com/Gryt-chat/site/pull/50), both merged and deployed.

## CI

`.github/workflows/changelog-style.yml`, following `avatar-parity`: the real rules over the three hand-written notes, which must pass, and over three fixtures trimmed from real bad drafts, which must be caught. Listed in `discord-ci-notify.yml`, because an unlisted workflow notifies nobody.

That needed one fix to the drafter: it called `main()` on import, so importing it tried to draft a changelog. A module that does work on import is a module nobody can test.

**Two parser bugs in that check**, both of which meant the recap rules were never actually exercised against the writing they are judged by:

- Splitting the MDX on `/^---$/m` gives four parts, not three — the rule above "The short version" makes another. Reading the first three dropped every recap.
- Splitting the recap on blank lines separated each bold label from its own bullets, so every group parsed with zero items.

An empty recap passes every recap rule, which is not the same as passing. The check now refuses a note that parsed to an empty article or recap, and prints what it parsed.

## What to look at

**Whether the thresholds are right**, and specifically whether any of them is unsatisfiable. A check that always fires is a release that never gets a note. `GRYT_CHANGELOG_ATTEMPTS` bounds the cost but not that risk. The rejected file keeps every attempt's verdict for exactly this question — the same reason each round means the rule is wrong, a different one each round means the model is flailing.

**The 0.7 containment threshold on Under the hood.** It is the newest and the least exercised. The reason to trust it is that the hand-written notes put genuinely invisible things there — a compiled SQLite library swapped for Node's, React 19, the client compiling in CI — and none of those appear in their own articles.

## Checked

`node .github/scripts/check-changelog-style.mjs` passes both directions. Run against the real Ollama on dev.lan across six drafts and five releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)