### PR TITLE
Stop refusing a draft for starting two sections with "The" (GRYT-637)

### DIFF
--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -837,8 +837,19 @@ export function styleProblems(entry, parts) {
   }
 
   /* Two sections opening on the same word reads as a template rather than as
-     writing, and "Previously" is the one it always is. */
-  const firstWords = headings.map((h) => normalise(h).split(' ')[0]).filter(Boolean)
+     writing — but only when the word carries something. The reason the guide
+     gives is "Previously" in front of every contrast, not the definite article,
+     and two sections beginning "The" is ordinary English rather than a form
+     somebody filled in.
+
+     This blocked a draft twice before the distinction was made: the model
+     fixed the "Previously" it was told about and then had nowhere to go, which
+     is what a rule that is wrong looks like from the outside. 1.5.0 varies its
+     four openings — You, The, Somebody, Adding — so the rule matches the
+     writing; it just should not fire on the article. */
+  const firstWords = headings
+    .map((h) => normalise(h).split(' ')[0])
+    .filter((w) => w && !STOPWORDS.has(w))
   const repeated = firstWords.find((w, i) => firstWords.indexOf(w) !== i)
   if (repeated) problems.push(`more than one section starts with "${repeated}"`)
 


### PR DESCRIPTION
The rule against two sections opening on the same word blocked a draft twice in a row, and it was wrong to.

```
· attempt 1 sent back: "Previously" 2 times, and once is the limit;
                       more than one section starts with "the"; …
· attempt 2 sent back: more than one section starts with "the"; …
```

The reason the guide gives for that rule is *"Previously" in front of every contrast reads as a form somebody filled in*. That is about a word that carries something. Two sections beginning "The" is ordinary English, and the check was counting the definite article as evidence of a template.

What it looks like from the outside is worse than the rule being merely strict: the model fixed the `Previously` it was told about, could do nothing about the article, and came back with the same complaint. **A rule the model cannot satisfy is a release that never gets a note** — the risk [#136](https://github.com/Gryt-chat/gryt/pull/136)'s body named, and this is it happening.

First words now go through the same stopword list the sentence comparison uses. Two sections starting `Previously` still fails; two starting `The` does not.

## Why the rule is still right

1.5.0 opens its four sections **You**, **The**, **Somebody**, **Adding**. The rule does match the writing it exists to protect — it just should not fire on the article.

I checked that against the hand-written notes and briefly thought I had found a second bug, because `grep '^## '` shows 1.5.0 with two headings starting "The". The second is `## The short version`, which is the recap heading and sits below the rule, and the parser correctly excludes it. No bug there.

## How it was found

By reading rejections, not by reading code. Keeping **every attempt's verdict** in the rejected file — which went in with the revise loop in #136 — is what made "the same complaint twice" visible. Without it the file holds only the last reason and this reads as one ordinary refusal.

## Checked

`node .github/scripts/check-changelog-style.mjs` passes both directions, plus the two cases directly:

| | |
|---|---|
| two `The` openings | no longer flagged |
| two `Previously` openings | still flagged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)