### PR TITLE
Ask structurally whether a release was filed as invisible (GRYT-637)

### DIFF
--- a/.github/scripts/check-changelog-style.mjs
+++ b/.github/scripts/check-changelog-style.mjs
@@ -166,6 +166,40 @@ const BAD_DRAFTS = [
     },
   },
   {
+    name: '1.6.31, which filed a whole privacy fix as invisible',
+    expect: 'every recap line is under the hood',
+    range: [
+      {
+        component: 'client',
+        commits: [
+          {
+            subject: 'Do not send the log unless asked, and show the payload (GRYT-532) (#232)',
+            body: 'The form attached the last 300 console lines to every report. host is the server address, often a home IP or a personal domain.',
+          },
+        ],
+      },
+    ],
+    /* Real output, and the third draft running to put the whole user-visible
+       change under the hood. The word matching missed it on morphology alone —
+       "avoids sending" against "no longer sends". */
+    note: {
+      headline: 'Gryt no longer sends server addresses in crash reports',
+      intro: ['This release removes a privacy risk in the crash reporting form.'],
+      sections: [
+        {
+          heading: 'The app only sends logs when asked',
+          body: ['It used to attach the last 300 console lines to every report.'],
+        },
+      ],
+      recap: [
+        {
+          group: 'Under the hood',
+          items: ['The app now avoids sending server addresses in crash logs unless requested'],
+        },
+      ],
+    },
+  },
+  {
     name: '1.6.39, which listed three things in the headline and hid a new logo under the hood',
     expect: 'lists three things',
     range: [

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -740,6 +740,13 @@ const STOPWORDS = new Set(`a an and are as at be been but by can do does for fro
   their them then there these they this to up was were what when which who will
   with you your`.split(/\s+/).filter(Boolean))
 
+/* Deliberately not stemmed.
+   Making "sends" and "sending" the same word would have caught one more recap
+   line filed under the hood, and it also made the containment check below
+   refuse 1.4.0's "The image worker ships with the app now" — a genuinely
+   invisible change, in a note whose article is about images. That is the third
+   time tuning that measure moved the problem rather than fixing it, so the
+   structural rule underneath does the work instead and this stays literal. */
 const contentWords = (text) =>
   new Set(normalise(text).split(' ').filter((w) => w && !STOPWORDS.has(w)))
 
@@ -927,6 +934,20 @@ export function styleProblems(entry, parts) {
     if (visible) {
       problems.push(`"${visible}" is under the hood, and the note explains it above`)
     }
+  }
+
+  /* Under the hood as the only group.
+     A note with sections in it has just described something a reader can see,
+     so a recap whose only heading is "Under the hood" is not summarising that
+     note — it is filing the whole release as invisible. Three drafts running
+     did exactly this, and the word matching above missed two of them by a hair
+     either way.
+
+     Asked structurally instead: no threshold, no vocabulary, nothing to tune,
+     and nothing for a change of wording to slip past. The hand-written notes
+     have eight, five and four recap groups. */
+  if (entry.sections.length && entry.recap.length === 1 && underHood) {
+    problems.push('every recap line is under the hood, for a release with sections in it')
   }
 
   for (const pattern of FILLER) {


### PR DESCRIPTION
**Three drafts running** have put the whole user-visible change under **Under the hood**. The newest is a privacy fix — Gryt used to attach the server's address to crash reports, often a home IP or a personal domain — written up correctly and then summarised as one line in the one group that means *you cannot see this*:

```
* Under the hood -> ['The app now avoids sending server addresses in crash logs unless requested']
```

That was the only recap group in the note.

The word-matching check missed it by a hair, on morphology alone: the recap said *"avoids sending server addresses"*, the paragraph said *"no longer sends"*.

## Stemming was the wrong fix

Making `sends` and `sending` the same word caught that one — and made the same check refuse 1.4.0's *"The image worker ships with the app now. It used to exist only for Docker-hosted servers"*. That is a genuinely invisible change, in a note whose article is about images, so of course it shares vocabulary.

**That is the third time tuning that measure moved the problem instead of fixing it.** It stays literal, and something else does the work.

## Asked structurally instead

A note with sections in it has just described something a reader can see. A recap whose only group is *Under the hood* is therefore not summarising that note — it is filing the release as invisible.

No threshold, no vocabulary, nothing to tune, and nothing for a change of wording to slip past. The hand-written notes have eight, five and four recap groups, so the rule has no opinion about them at all.

## What this does not catch

A release with **two** recap groups, one of them Under the hood holding something visible. The containment check still covers what it covers and still misses what it misses — this narrows the hole rather than closing it.

Worth stating plainly, because the alternative reading is that Under the hood is now handled, and it is not.

## Checked

The live draft is in the fixtures now, so this exact failure cannot come back quietly. `node .github/scripts/check-changelog-style.mjs` passes both directions: three hand-written notes clean, four real bad drafts caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)