### PR TITLE
Name both copy skills in the Style section (GRYT-655)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,13 +230,28 @@ state the thing. A test that catches most of it: if a sentence could move to ano
 project unchanged, it is filler, and it should be a fact, a number or a consequence
 specific to this one instead.
 
-`no-ai-slop` is installed for this, at `~/.claude/skills/no-ai-slop/`. Run it over prose
-rather than trying to hold the list in your head; that is the failure mode. On 2026-08-21
-it was installed, used once on a Discord message, and the docs written an hour later still
+**Two skills for this, and they do different jobs.** Run them over prose rather than
+trying to hold the lists in your head; that is the failure mode. On 2026-08-21 `no-ai-slop`
+was installed, used once on a Discord message, and the docs written an hour later still
 went out saying "Worth doing rather than skipping past".
 
-**On anything a person reads in the product, running it is not optional.** Run it on the
-copy before you commit, not as a later pass — the draft is what ships. In scope:
+- `no-ai-slop`, at `~/.claude/skills/no-ai-slop/`. For writing that sounds **generated** —
+  binary contrasts, faux-insight openers, importance puffery, fake-profound kickers. It
+  protects a distinctive voice while removing the tells.
+- `natural-writing`, at `~/.claude/skills/natural-writing/`. For writing that sounds
+  **stiff** — long sentences carrying three clauses, no contractions, "the operator" where
+  a person would say "whoever runs the server". Sivert's own rules, given on 2026-08-28
+  after the site's pages read like an essay rather than like somebody talking. His summary
+  of the test: would you say it out loud?
+
+On product copy, run both, slop first. They compose: one gets the AI out, the other gets
+the starch out.
+
+`packages/site/design.md` has a Voice section carrying the same rules for the site
+specifically, with worked before-and-after examples from the pass that produced them.
+
+**On anything a person reads in the product, running them is not optional.** Run them on
+the copy before you commit, not as a later pass — the draft is what ships. In scope:
 
 - UI strings in the client and the mobile app: labels, empty states, error messages,
   onboarding, settings hints, anything rendered on screen


### PR DESCRIPTION
One paragraph in `CLAUDE.md`, but it is the paragraph that decides whether a
skill ever gets run.

The Style section listed `no-ai-slop` and nothing else. That is not the skill
that would have caught what Sivert flagged on the site today: pages with no
contractions anywhere, and sentences carrying three clauses through a
semicolon. That is not slop, it is starch — and `no-ai-slop` is deliberately
built to leave a distinctive voice alone rather than to simplify it.

He gave the rules for the other half the same day. They are a skill now, at
`~/.claude/skills/natural-writing/`: simple words, short sentences, no marketing
voice, a banned-phrase list, and "would you say it out loud" as the test.

## Why this is worth a PR at all

This section is the only place in the repo that tells anybody which skill to run
on product prose. A skill missing from it is a skill nobody runs, and that
failure is already written down three lines above — `no-ai-slop` was installed
on 2026-08-21, used once on a Discord message, and the docs written an hour
later still went out saying "Worth doing rather than skipping past".

## What to look at

- **The two entries say when to run which**, because reaching for the wrong one
  produces nothing. Slop for writing that sounds generated; natural-writing for
  writing that sounds stiff; both on product copy, slop first.
- **"running it" became "running them"** in the sentence below, and the
  paragraph after it. Grammar only.
- The entry points at `packages/site/design.md`, which now carries the same
  rules for the site with before-and-after examples. If you would rather the
  rules lived in exactly one place, say so and I will cut one of them down to a
  pointer.

## Not in this PR

The skill itself lives in `~/.claude/skills/` and is not in any repository.
Same as `no-ai-slop`. If you would rather both were checked in under
`.claude/skills/` so they travel with the repo, that is a bigger change and its
own decision — tell me and I will open a task for it.

Closes GRYT-655.
