### PR TITLE
Thirteen submodules, not twelve (GRYT-654)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Working rules for Gryt
 
 Gryt is a WebRTC voice chat platform maintained by one person. It's a superproject with
-twelve git submodules under `packages/`. Read these rules before making changes.
+thirteen git submodules under `packages/`. Read these rules before making changes.
 
 ## Review-required paths
 


### PR DESCRIPTION
One word in the first paragraph of `CLAUDE.md`.

`.gitmodules` has thirteen — auth, client, site, server, docs, sfu, image-worker, ui, cli, voice, mobile, bot, reports. `packages/reports` is the one the sentence predates.

Found while writing the `git clone --recurse-submodules` snippet on `/developers`, which tells the reader what they get *without* the flag and so had to be right about the number. The site said thirteen, this file said twelve.

Nothing else in the file counts anything — the review-required section is a list rather than a count, and `packages/reports` is already on it.

Closes GRYT-654.