### PR TITLE
Let the model read the whole release (GRYT-659)

### DIFF
--- a/.github/scripts/check-changelog-style.mjs
+++ b/.github/scripts/check-changelog-style.mjs
@@ -378,6 +378,25 @@ for (const { name, note, range, expect } of BAD_DRAFTS) {
   }
 }
 
+/* The skills are read into every prompt, so a checkout without them drafts
+   against rules nobody wrote down. Not a style rule, but the prompt is wrong
+   without it and nothing else would say so.
+
+   They are not put through the contamination guard. That was tried: all three
+   hand-written notes scored as copied from them, on "voice", "reading",
+   "person" and "words", because a skill about writing and a note about a chat
+   app are both written in English. The reasoning is on the guard itself. */
+console.log('\nThe skills the prompt reads:\n')
+for (const f of ['no-ai-slop.md', 'natural-writing.md']) {
+  const path = join(REPO, 'ops', 'internal', 'writing', f)
+  if (existsSync(path) && readFileSync(path, 'utf8').trim()) {
+    console.log(`  ✓ ${f}`)
+  } else {
+    failed++
+    console.error(`  ✗ ops/internal/writing/${f} is missing, and the prompt reads it`)
+  }
+}
+
 console.log('\nEvery commit accounted for:\n')
 for (const { name, note, range, expect } of COVERAGE_DRAFTS) {
   const problems = coverage(note, range)

--- a/.github/scripts/check-changelog-style.mjs
+++ b/.github/scripts/check-changelog-style.mjs
@@ -31,7 +31,7 @@ import { fileURLToPath } from 'node:url'
 const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO = resolve(HERE, '..', '..')
 
-const { styleProblems } = await import(
+const { styleProblems, coverage } = await import(
   join(REPO, 'ops', 'internal', 'changelog-notes.mjs')
 )
 
@@ -74,6 +74,11 @@ function handWritten(dir) {
 
       const clean = (parts[2] ?? '')
         .replace(/^<(Image|Clip)[^>]*\/>\s*$/gm, '')
+        /* Markdown images too, not only the JSX ones. 1.4.0 illustrates the
+           voice panel with `![alt](/changelog/voice-split.webp)`, and reading
+           that line as a paragraph puts an asset filename into what is
+           supposed to be the note's prose. */
+        .replace(/^!\[[^\]]*\]\([^)]*\)\s*$/gm, '')
         .replace(/^import .*$/gm, '')
       const article = clean
       const recapRaw = parts.slice(3).join('\n')
@@ -200,6 +205,58 @@ const BAD_DRAFTS = [
     },
   },
   {
+    name: '1.6.38, which put a function name in the article',
+    expect: 'a camel-case name',
+    range: [
+      {
+        component: 'client',
+        commits: [
+          { subject: 'Draw the owl somebody designed', body: '' },
+          { subject: 'Keep the look beside the nickname', body: '' },
+          { subject: 'Ping each WebSocket', body: '' },
+        ],
+      },
+    ],
+    note: {
+      headline: 'Designed avatars now travel with you across devices and rooms',
+      intro: ['A designed owl is drawn wherever your avatar appears.'],
+      sections: [
+        {
+          heading: 'Your owl follows you between machines',
+          /* Real output. The prompt forbids this and the model wrote it
+             anyway, which is the argument for a rule rather than a sentence. */
+          body: ['The new system uses a single funnel, the resolveAvatarSrc function, to draw your owl.'],
+        },
+      ],
+      recap: [{ group: 'Avatars and images', items: ['Designed owls now follow you'] }],
+    },
+  },
+  {
+    name: '1.6.40, which put what a reader cannot see at the top of the recap',
+    expect: 'not the last recap group',
+    range: [
+      {
+        component: 'client',
+        commits: [
+          { subject: 'The plain name belongs to the round mark', body: '' },
+          { subject: 'Round the mark in the app', body: '' },
+          { subject: 'Send the download link to the download', body: '' },
+        ],
+      },
+    ],
+    note: {
+      headline: 'The Gryt owl is round now, everywhere you see it',
+      intro: ['The mark on the splash screen and in the browser tab is the round one.'],
+      sections: [
+        { heading: 'A round mark, in every place the app draws it', body: ['Including the splash.'] },
+      ],
+      recap: [
+        { group: 'Under the hood', items: ['The icon build reads the square artboard'] },
+        { group: 'Interface', items: ['The mark on the splash screen is the round one'] },
+      ],
+    },
+  },
+  {
     name: '1.6.39, which listed three things in the headline and hid a new logo under the hood',
     expect: 'lists three things',
     range: [
@@ -226,6 +283,58 @@ const BAD_DRAFTS = [
     },
   },
 ]
+
+/* Coverage is not a style rule and does not run against the hand-written
+   notes: those cover a whole minor line, and the range they were written from
+   is not in the repository any more. It is checked against the shape of the
+   failure it exists for - a note that is well written and about fewer commits
+   than it was given. */
+const COVERAGE_DRAFTS = [
+  {
+    name: '1.6.38, which dropped the media server commit entirely',
+    expect: 'commit 3 is not in the note',
+    range: [
+      {
+        component: 'client',
+        commits: [{ subject: 'Draw the owl somebody designed, instead of a picture of it', body: 'The editor produced a look and encoded it as a short string.' }],
+      },
+      {
+        component: 'server',
+        commits: [{ subject: 'Keep the look a member designed, beside their nickname', body: 'users.avatar_worn, added with the same guard as every other column.' }],
+      },
+      {
+        component: 'sfu',
+        commits: [{
+          subject: 'Ping each WebSocket, and give up on one that stops answering',
+          body: 'A peer that went away without a FIN left a socket that read forever. Thirty seconds between pings and ninety of silence before hanging up.',
+        }],
+      },
+    ],
+    note: {
+      headline: 'Designed avatars now travel with you across devices and rooms',
+      intro: ['The owl you designed is drawn wherever your avatar appears, and it follows your account.'],
+      sections: [
+        { heading: 'Your designed owl is drawn, not photographed', body: ['The editor sends a short string describing the look.'] },
+        { heading: 'A server keeps your look beside your nickname', body: ['So it reaches the room you join.'] },
+      ],
+      recap: [{ group: 'Avatars and images', items: ['A designed owl follows your account between machines'] }],
+      omitted: [],
+    },
+  },
+  {
+    /* The same draft, with the model saying so. Leaving a commit out is
+       allowed; leaving it out silently is what is not. */
+    name: 'the same draft, with the commit named in omitted',
+    expect: null,
+    range: null,
+    note: null,
+  },
+]
+COVERAGE_DRAFTS[1].range = COVERAGE_DRAFTS[0].range
+COVERAGE_DRAFTS[1].note = {
+  ...COVERAGE_DRAFTS[0].note,
+  omitted: [{ commit: 3, why: 'a timeout on a socket nobody sees' }],
+}
 
 let failed = 0
 
@@ -265,6 +374,20 @@ for (const { name, note, range, expect } of BAD_DRAFTS) {
     failed++
     console.error(`  ✗ ${name}`)
     console.error(`      expected a problem containing "${expect}"`)
+    console.error(`      got: ${problems.length ? problems.join('; ') : 'nothing at all'}`)
+  }
+}
+
+console.log('\nEvery commit accounted for:\n')
+for (const { name, note, range, expect } of COVERAGE_DRAFTS) {
+  const problems = coverage(note, range)
+  const ok = expect === null ? !problems.length : problems.some((p) => p.includes(expect))
+  if (ok) {
+    console.log(`  ✓ ${name}`)
+  } else {
+    failed++
+    console.error(`  ✗ ${name}`)
+    console.error(`      expected ${expect === null ? 'nothing' : `a problem containing "${expect}"`}`)
     console.error(`      got: ${problems.length ? problems.join('; ') : 'nothing at all'}`)
   }
 }

--- a/.github/workflows/changelog-style.yml
+++ b/.github/workflows/changelog-style.yml
@@ -24,6 +24,9 @@ on:
       - .github/scripts/check-changelog-style.mjs
       - .github/workflows/changelog-style.yml
       - ops/internal/changelog-notes.mjs
+      # The prompt reads both of these in full, so removing or renaming one
+      # changes what a draft is judged by.
+      - ops/internal/writing/**
 
   # The notes live in a submodule, so editing one of them does not touch this
   # repository at all. The gitlink bump that brings it in carries [skip ci],

--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -398,12 +398,35 @@ Edit `/etc/default/gryt-changelog-notes` before the first run. `OLLAMA_URL` has
 no useful default — the model does not run on this box — and the port is not
 optional.
 
-`OLLAMA_NUM_CTX` matters more than it looks. Ollama allocates the window you
-ask for rather than the one the model has, and it asks for 4096 when nothing
-says otherwise; a prompt for a five-commit release is around 8,000 tokens, and
-the rest is dropped before the model reads it with nothing in the answer to say
-so. The default here is 32768. Lower it only if the card starts swapping, and
-expect drafts to start losing commits below about 16384.
+`OLLAMA_NUM_CTX` matters more than it looks, and it is a memory decision
+rather than a size one.
+
+Ollama allocates the window you ask for rather than the one the model has, and
+it asks for 4096 when nothing says otherwise. A prompt for a five-commit
+release is around 12,000 tokens, so the rest was being dropped before the model
+read it, with nothing in the answer to say so.
+
+What it costs is on the card. qwen3:32b keeps 256 KiB of KV cache per token —
+6 GiB at 24576, 8 at 32768, 10 at the model's own 40960 — and the box drafting
+these has a 12 GiB 3060 with Frigate on it. The weights are 20 GB either way,
+so the card was never holding the whole model; what changes is how much of it
+runs on the CPU, and every GiB of cache is a GiB of weights that does.
+
+24576 is the default. The largest prompt drafted so far is 16,300 tokens and
+the script prints the size on every run, so a release that outgrows it says so
+rather than losing commits quietly.
+
+Two variables on the **Ollama container**, not in this unit's env file, halve
+the cache:
+
+```
+OLLAMA_FLASH_ATTENTION=1
+OLLAMA_KV_CACHE_TYPE=q8_0
+```
+
+q8_0 is hard to tell from f16 in the output and gives back 3 GiB, which is
+3 GiB of weights off the CPU. Do that before reaching for a bigger model: on
+12 GiB there is no bigger model that fits, only a slower one.
 
 `GRYT_CHANGELOG_KEY` here has to match `REPORTS_CHANGELOG_KEY` in
 `ops/internal/.env`, which is what the reports service checks.

--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -398,6 +398,13 @@ Edit `/etc/default/gryt-changelog-notes` before the first run. `OLLAMA_URL` has
 no useful default — the model does not run on this box — and the port is not
 optional.
 
+`OLLAMA_NUM_CTX` matters more than it looks. Ollama allocates the window you
+ask for rather than the one the model has, and it asks for 4096 when nothing
+says otherwise; a prompt for a five-commit release is around 8,000 tokens, and
+the rest is dropped before the model reads it with nothing in the answer to say
+so. The default here is 32768. Lower it only if the card starts swapping, and
+expect drafts to start losing commits below about 16384.
+
 `GRYT_CHANGELOG_KEY` here has to match `REPORTS_CHANGELOG_KEY` in
 `ops/internal/.env`, which is what the reports service checks.
 

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -55,6 +55,11 @@
 //   OLLAMA_URL             Default http://127.0.0.1:11434
 //   OLLAMA_MODEL           Default llama3.1:8b
 //   OLLAMA_TIMEOUT_MS      Default 180000
+//   OLLAMA_NUM_CTX         The context window to ask Ollama for. Default
+//                          32768. Not optional in practice: Ollama's own
+//                          default is 4096 and this prompt is past that, so
+//                          leaving it unset silently drops part of the input.
+//                          See the comment on ask().
 
 import { execFileSync } from 'node:child_process'
 import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
@@ -68,6 +73,25 @@ const LIMIT = Number(process.env.GRYT_CHANGELOG_LIMIT ?? 12)
 const OLLAMA_URL = process.env.OLLAMA_URL ?? 'http://127.0.0.1:11434'
 const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? 'llama3.1:8b'
 const OLLAMA_TIMEOUT_MS = Number(process.env.OLLAMA_TIMEOUT_MS ?? 180_000)
+
+/* The context window to ask for.
+   Ollama does not use the model's window, it uses num_ctx, and num_ctx
+   defaults to 4096. Everything past that is dropped before the model reads a
+   word of it, with no error and nothing in the response to say so — which is
+   what a draft that quietly covers two commits out of five looks like from
+   the outside. qwen3:32b's own window is 40960, so 32768 leaves room for the
+   answer and still holds the largest range this has seen. */
+const OLLAMA_NUM_CTX = Number(process.env.OLLAMA_NUM_CTX ?? 32_768)
+
+/* How much commit body the prompt may carry, in characters.
+   Bodies in these repositories run past 4kB, and cutting them to a fixed few
+   lines cuts exactly the part that says what a person sees: GRYT-596 opens
+   "Four things wrong with the editor" and spends four headed sections on
+   them, and the draft written from its first eight lines named one.
+   Divided evenly, so a five-commit release gets a lot each and a
+   twenty-commit release still fits. */
+const COMMIT_BUDGET = Number(process.env.GRYT_CHANGELOG_COMMIT_BUDGET ?? 60_000)
+const COMMIT_BUDGET_MIN = 1_200
 const DRY_RUN = process.argv.includes('--dry-run')
 
 /* How many times to ask for one release before giving up on it.
@@ -389,8 +413,26 @@ const SCHEMA = {
         required: ['group', 'items'],
       },
     },
+    /* One line per commit the note deliberately says nothing about, naming
+       its number and why. Not part of the note — it is stripped before the
+       draft is posted — and it exists so that "this commit is not worth a
+       reader's time" is something the model has to write down rather than
+       something it can do by saying nothing. The coverage rule below reads
+       it, and the log prints it, so a release that quietly shrank is visible
+       to whoever reads the draft. */
+    omitted: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          commit: { type: 'number' },
+          why: { type: 'string' },
+        },
+        required: ['commit', 'why'],
+      },
+    },
   },
-  required: ['headline', 'intro', 'sections', 'recap'],
+  required: ['headline', 'intro', 'sections', 'recap', 'omitted'],
 }
 
 /* The three notes written by hand, as the target. A rule can say "a sentence,
@@ -432,16 +474,37 @@ function workedExample(repo) {
     .trim()
 }
 
+/* Every commit in the range, in one numbered list.
+   Numbered because the coverage rule below has to name the one that went
+   missing, and "the third commit under the app" is not something a refusal can
+   say back to a model usefully. */
+export function flatCommits(parts) {
+  const out = []
+  for (const part of parts) {
+    for (const c of part.commits) out.push({ ...c, component: part.component, n: out.length + 1 })
+  }
+  return out
+}
+
 function prompt(release, changes, style) {
+  const all = flatCommits(changes.parts)
+  /* Divided evenly rather than a fixed cut. The failure this replaces was a
+     fixed eight lines, which is fine for a one-paragraph commit and throws
+     away five sixths of the ones that are worth reading. */
+  const perCommit = Math.max(COMMIT_BUDGET_MIN, Math.floor(COMMIT_BUDGET / Math.max(1, all.length)))
   const lines = []
   for (const part of changes.parts) {
-    lines.push(`## ${part.component}`)
-    for (const c of part.commits) {
-      lines.push(`- ${c.subject}`)
-      if (c.body) {
-        for (const l of c.body.split('\n').map((s) => s.trim()).filter(Boolean).slice(0, 8)) {
-          lines.push(`    ${l}`)
-        }
+    lines.push(`## ${componentName(part.component)}`)
+    for (const c of all.filter((x) => x.component === part.component)) {
+      lines.push(`- [${c.n}] ${c.subject}`)
+      const body = c.body.split('\n').map((l) => l.trim()).filter(Boolean).join('\n')
+      if (!body) continue
+      const kept = body.slice(0, perCommit)
+      for (const l of kept.split('\n')) lines.push(`    ${l}`)
+      /* Said out loud rather than cut silently. A model that believes it has
+         the whole commit writes as if it does. */
+      if (kept.length < body.length) {
+        lines.push(`    [commit ${c.n} continues past what would fit here]`)
       }
     }
   }
@@ -520,6 +583,43 @@ function prompt(release, changes, style) {
     '            Accessibility, Under the hood. Skip a group with nothing in',
     '            it. One line per item, past tense, from the reader\'s side.',
     '',
+    '            Reach for one of those labels first. A release that genuinely',
+    '            does not fit any of them may have its own - the notes written',
+    '            by hand use Identity, Servers, Joining and Interface - but a',
+    '            new label is for a subject the list has no room for, not for',
+    '            rewording one it already covers. "Under the hood" goes last.',
+    '',
+    '  omitted   One entry per numbered commit you have written nothing about,',
+    '            with its number and one line saying why. Empty if you covered',
+    '            all of them. This is not part of the note and no reader sees',
+    '            it.',
+    '',
+    'EVERY COMMIT IS ACCOUNTED FOR',
+    '',
+    'The numbered list above is the whole release. Each commit either appears',
+    'in the note - a section, or a line in the recap - or is named in',
+    '"omitted" with a reason. Nothing may simply go unmentioned.',
+    '',
+    'This is the thing to get right. A note that reads well and covers three of',
+    'five commits is worse than a clumsy one that covers all five, because',
+    'nothing about it says a release was shrunk on the way through: the reader',
+    'gets a finished note about a smaller release and never learns there was',
+    'more. If a commit changes what somebody sees, hears, or has to do, it goes',
+    'in the note whether or not it fits the shape you had in mind.',
+    '',
+    'A commit that says four things went wrong owes the reader four things, not',
+    'the first one. Do not write "it had several issues" and then name one -',
+    'either name them or leave the count out.',
+    '',
+    'Say when a change only happens on one operating system. A control that',
+    'appears on Windows and nowhere else is a control most readers will go',
+    'looking for and not find, so the sentence has to carry the platform.',
+    '',
+    'A change to what the app collects, stores or sends about a person is a',
+    'privacy change, and privacy goes in Security. It gets its own section, it',
+    'is not folded into a list of fixes, and it is not softened into the app',
+    'respecting your privacy - say what it used to do and who could see it.',
+    '',
     'Plain sentences only. No markdown, no bold, no links, no headings inside a',
     'paragraph. The site renders the shape itself.',
     '',
@@ -579,6 +679,27 @@ function prompt(release, changes, style) {
     '',
     'Do not address the reader about the release itself. They are reading it;',
     'they know.',
+    '',
+    'HOW THE SENTENCES SHOULD READ',
+    '',
+    'Sivert keeps two editing skills for this, no-ai-slop and natural-writing,',
+    'and the parts of them a draft keeps breaking are these:',
+    '',
+    '- Say it the way you would say it out loud. Short sentences, ordinary',
+    '  words, contractions where they are natural.',
+    '- No binary contrasts. "It is no longer a picture, it is a live drawing"',
+    '  and "not X but Y" are one sentence pretending to be two. Write Y.',
+    '- No throat-clearing opener. "This release focuses on", "This update',
+    '  brings", "This release improves" - the reader knows what they opened.',
+    '  Start with what changed.',
+    '- Nothing that tells the reader how to feel about a fact: "this makes',
+    '  troubleshooting easier", "this ensures the message is read and',
+    '  understood", "which is particularly useful". State the fact.',
+    '- Never these words: delve, leverage, seamless, robust, streamline,',
+    '  elevate, harness, transformative, cutting-edge, game-changing,',
+    '  revolutionary, unlock, empower, foster, utilize, refactored.',
+    '- Every sentence must fail the portability test. If it would sit unchanged',
+    '  in another product\'s notes, it is filler standing where a fact should be.',
     '',
     'If nothing in this release is visible to a user, return an empty sections',
     'array, an empty recap, a one-sentence intro saying so, and a headline',
@@ -646,7 +767,14 @@ async function ask(text) {
            answer. Without this the content comes back with a think block
            wrapped round the JSON and the parse fails. */
         think: false,
-        options: { temperature: 0.4 },
+        /* num_ctx, and it is the important one.
+           Ollama does not read the model's own window: it allocates num_ctx,
+           which is 4096 unless asked otherwise, and quietly drops whatever
+           does not fit. Nothing in the response says it happened. A one-commit
+           release fits inside 4096 and a five-commit release does not, which
+           is why the drafts that read as finished notes about a smaller
+           release were all the large ones. */
+        options: { temperature: 0.4, num_ctx: OLLAMA_NUM_CTX },
         messages: [{ role: 'user', content: text }],
       }),
     })
@@ -815,7 +943,83 @@ const FILLER = [
   /under the hood improvements/i,
   /stay tuned/i,
   /and much more/i,
+  /* The openers. Every draft in the first batch began the same way, and the
+     sentence is the reader being told what they already know: they opened a
+     release note. */
+  /\bthis (release|update|version) (focuses on|brings|improves|adds more|introduces)\b/i,
+  /* Telling the reader what to make of a fact instead of giving them another
+     one. "This change makes troubleshooting easier for both users and
+     developers" was a whole sentence in the 1.6.36 draft. */
+  /\bthis (change|release|update) (makes|ensures|helps|improves|means)\b/i,
+  /\bwhich is particularly useful\b/i,
+  /\bfor both users and developers\b/i,
+  /* From natural-writing's banned list and no-ai-slop's. "Refactored" is the
+     one that turns up here, in a recap line nobody outside the repository can
+     act on. */
+  /\b(delve|leverage|seamless|robust|streamline[sd]?|elevate|harness|transformative|cutting-edge|game-changing|revolutionary|empower|foster|utilize|refactored)\b/i,
 ]
+
+/* Names only somebody with the checkout can use.
+   The prompt forbids these outside "Under the hood" and the model writes them
+   anyway - resolveAvatarSrc and skewMs both reached a draft as the subject of
+   a sentence, and public/logo.svg and `yarn icons:generate` were printed in
+   the middle of a paragraph about a logo.
+
+   The camel-case shapes that are ordinary English on a page about a chat app
+   are listed rather than guessed at, because "macOS" and "WebRTC" are the two
+   this would otherwise fire on constantly. */
+/* The recap groups the guide lists, in the order it lists them.
+   Where to start, not a closed set: the notes written by hand since have added
+   Identity, Servers, Joining and Interface. Shown to the model so it reaches
+   for one of these first, and not enforced, because enforcing it would have
+   refused two of the three notes it is meant to be imitating. */
+export const RECAP_GROUPS = [
+  'Voice',
+  'Avatars and images',
+  'Emoji',
+  'Updates',
+  'Hosting',
+  'Security',
+  'Accessibility',
+  'Under the hood',
+]
+
+/* How a commit says a change only happens on one operating system.
+   Narrow on purpose: this has to fire on the sentence that means it and not
+   on every commit that mentions Windows in passing. */
+const PLATFORM_ONLY = [
+  [/\b(windows[- ]only|only (on|where the OS can do this, which is) windows|only appears (on|where).{0,40}windows)\b/i, 'Windows'],
+  [/\b(macos[- ]only|only on macos)\b/i, 'macOS'],
+  [/\b(linux[- ]only|only on linux)\b/i, 'Linux'],
+]
+
+const NOT_IDENTIFIERS = new Set(
+  `macos ios ipados androidos webrtc websocket javascript typescript github gitlab
+   youtube postgresql sqlite openai iphone ipad javascriptcore webgl webgpu
+   nodejs npmjs`.split(/\s+/).filter(Boolean),
+)
+
+const IDENTIFIER_SHAPES = [
+  /* Backticks are not on this list. The hand-written notes put a hostname and
+     an environment variable in them, in the article, and both belong there -
+     somebody hosting a server has to type them. What the drafts got wrong was
+     the name of a function and the path of a file, which the three shapes
+     below catch on their own. */
+  [/\b[\w-]+\.(ts|tsx|js|mjs|cjs|jsx|json|svg|png|webp|html|css|scss|md|mdx|go|rs|py|yml|yaml|sh)\b/, 'a file name'],
+  [/\b(yarn|npm|pnpm|git|docker|curl)\s+[a-z][\w:-]*/, 'a command'],
+  [/\b[a-z]+[A-Z][A-Za-z]*\b/, 'a camel-case name'],
+]
+
+/* Prose a reader sees, which is everything except the "Under the hood" group.
+   That group is where the guide allows this vocabulary, and the hand-written
+   notes use it there. */
+function readerProse(entry) {
+  const recap = entry.recap
+    .filter((g) => !/under the hood/i.test(g.group))
+    .flatMap((g) => g.items)
+  const sections = entry.sections.flatMap((s) => [s.heading, ...s.body])
+  return [entry.headline, ...entry.intro, ...sections, ...recap]
+}
 
 /**
  * The rules that are about writing rather than about shape.
@@ -958,12 +1162,129 @@ export function styleProblems(entry, parts) {
     }
   }
 
+  /* Names only somebody with the checkout can use, anywhere a reader looks. */
+  for (const line of readerProse(entry)) {
+    let named = null
+    for (const [shape, what] of IDENTIFIER_SHAPES) {
+      const hit = line.match(shape)
+      if (!hit) continue
+      if (NOT_IDENTIFIERS.has(hit[0].toLowerCase())) continue
+      named = `${what}, "${hit[0]}", outside Under the hood`
+      break
+    }
+    if (named) { problems.push(named); break }
+  }
+
+  /* Under the hood is last when it is there at all.
+     Not the whole list, and not the whole order: the guide names eight groups
+     and the notes written since use Identity, Servers, Joining, Interface and
+     "Hosting from the app", none of which are on it. That list is where to
+     start rather than what is allowed, so the only part of it worth refusing a
+     draft over is the one every hand-written note agrees on - what a reader
+     cannot see goes at the end. A draft put it first. */
+  const hoodAt = entry.recap.findIndex((g) => /under the hood/i.test(g.group))
+  if (hoodAt >= 0 && hoodAt !== entry.recap.length - 1) {
+    problems.push('"Under the hood" is not the last recap group')
+  }
+
+  /* A control that exists on one platform and not the others.
+     The screen-share picker is Windows only, the note never said so, and a
+     reader on macOS is left looking for it. The commits say which platform;
+     the note has to repeat it. */
+  const commitText = parts
+    .flatMap((part) => part.commits.map((c) => `${c.subject}\n${c.body}`))
+    .join('\n')
+  for (const [pattern, platform] of PLATFORM_ONLY) {
+    if (!pattern.test(commitText)) continue
+    if (new RegExp(`\\b${platform}\\b`, 'i').test(prose.join(' '))) continue
+    problems.push(`the commits say this is ${platform} only and the note never says so`)
+    break
+  }
+
   /* A release of one commit is a short note. Padding it is how a one-line fix
      became two intro paragraphs and a section saying the same thing again. */
   const commits = parts.reduce((n, part) => n + part.commits.length, 0)
   if (commits <= 2) {
     if (entry.intro.length > 1) problems.push('more than one intro paragraph for a tiny release')
     if (entry.sections.length > 1) problems.push('more than one section for a tiny release')
+  }
+
+  return problems
+}
+
+/**
+ * Whether every commit in the range reached the note.
+ *
+ * The failure this exists for is the one none of the rules above can see: a
+ * draft that is well written, breaks no style rule, and is about three of the
+ * five commits it was given. Nothing in it says a release was shrunk on the
+ * way through, so it reads as a finished note about a smaller release, and the
+ * only way to notice is to have both in front of you.
+ *
+ * Asked by vocabulary rather than by meaning, which is crude and is the point:
+ * it takes the words that belong to one commit and to no other commit in the
+ * range, and asks whether any of them turn up in the note. A commit written
+ * about in the reader's own words still shares something with its own body -
+ * "wardrobe", "ping", "skew" - and a commit nobody wrote about shares nothing.
+ *
+ * Commits with nothing distinctive to say are skipped rather than guessed at.
+ * A three-word subject and an empty body gives this nothing to work with, and
+ * a rule that fires on no evidence is a rule that gets turned off.
+ */
+export function coverage(entry, parts) {
+  const all = flatCommits(parts)
+  if (all.length < 2) return []
+
+  const words = (c) =>
+    new Set(
+      [...contentWords(`${c.subject} ${c.body}`)].filter(
+        (w) => w.length >= 5 && !COMMON.has(w),
+      ),
+    )
+  const per = all.map((c) => ({ c, words: words(c) }))
+
+  /* A word that belongs to this commit and to no other one in the range.
+     Without this, two commits about the same subsystem cover for each other:
+     the note writes about one, and every word it uses is in the other's body
+     too, so the missing one scores as present. */
+  const own = per.map(({ c, words: mine }, i) => ({
+    c,
+    words: [...mine].filter((w) => !per.some((other, j) => j !== i && other.words.has(w))),
+  }))
+
+  const note = contentWords(
+    [
+      entry.headline,
+      ...entry.intro,
+      ...entry.sections.flatMap((s) => [s.heading, ...s.body]),
+      ...entry.recap.flatMap((g) => [g.group, ...g.items]),
+    ].join(' '),
+  )
+
+  const excused = new Set((entry.omitted ?? []).map((o) => Number(o.commit)))
+  const problems = []
+
+  for (const { c, words: distinctive } of own) {
+    /* Three, so that one word landing by chance is not a pass and a commit
+       with almost nothing of its own is not a failure. */
+    if (distinctive.length < 3) continue
+    if (distinctive.some((w) => note.has(w))) continue
+    if (excused.has(c.n)) continue
+    problems.push(
+      `commit ${c.n} is not in the note and not in omitted: "${c.subject}"`,
+    )
+  }
+
+  for (const o of entry.omitted ?? []) {
+    const n = Number(o.commit)
+    if (!all.some((c) => c.n === n)) problems.push(`omitted names commit ${n}, which is not in this release`)
+  }
+
+  /* Everything left out is the model deciding the release was not worth
+     writing about, which is a decision somebody should see rather than a
+     shortcut it can take quietly. */
+  if ((entry.omitted?.length ?? 0) === all.length) {
+    problems.push('every commit is in omitted, so there is no note here')
   }
 
   return problems
@@ -983,6 +1304,11 @@ function validate(entry) {
     if (s.body.some((p) => typeof p !== 'string')) return 'a section body is not all strings'
   }
   if (!Array.isArray(entry.recap)) return 'recap is not an array'
+  if (!Array.isArray(entry.omitted)) return 'omitted is missing or is not an array'
+  for (const o of entry.omitted) {
+    if (typeof o?.commit !== 'number') return 'an omitted entry has no commit number'
+    if (typeof o?.why !== 'string' || !o.why.trim()) return 'an omitted entry has no reason'
+  }
   for (const g of entry.recap) {
     if (typeof g?.group !== 'string' || !g.group.trim()) return 'a recap group has no label'
     if (!Array.isArray(g.items) || g.items.some((p) => typeof p !== 'string')) {
@@ -1129,7 +1455,11 @@ async function main() {
       const commitText = JSON.stringify(changes.parts)
       const judge = (draft) => {
         const shape = validate(draft) ?? contamination(draft, workedExample(REPO), commitText)
-        return shape ? [shape] : styleProblems(draft, changes.parts)
+        if (shape) return [shape]
+        /* Coverage first. A note that is missing a commit is missing it
+           whatever else is wrong with it, and it is the reason worth reading
+           at the top of a refusal. */
+        return [...coverage(draft, changes.parts), ...styleProblems(draft, changes.parts)]
       }
 
       /* Ask, check, and hand the reasons back rather than giving up on the
@@ -1185,6 +1515,17 @@ async function main() {
         continue
       }
 
+      /* What the model decided not to write about, said out loud in the log.
+         It is allowed to leave a commit out; it is not allowed to do it
+         quietly, and this is the line that makes the difference visible to
+         whoever reads the draft afterwards. */
+      for (const o of entry.omitted ?? []) {
+        const c = flatCommits(changes.parts).find((x) => x.n === Number(o.commit))
+        log(`    left out: ${c ? c.subject : `commit ${o.commit}`} - ${o.why}`)
+      }
+
+      /* `omitted` is working notes between this script and the model. It is
+         not part of the note and reports would refuse it, so it stops here. */
       const drafted = {
         version: release.version,
         date,

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -79,9 +79,16 @@ const OLLAMA_TIMEOUT_MS = Number(process.env.OLLAMA_TIMEOUT_MS ?? 180_000)
    defaults to 4096. Everything past that is dropped before the model reads a
    word of it, with no error and nothing in the response to say so — which is
    what a draft that quietly covers two commits out of five looks like from
-   the outside. qwen3:32b's own window is 40960, so 32768 leaves room for the
-   answer and still holds the largest range this has seen. */
-const OLLAMA_NUM_CTX = Number(process.env.OLLAMA_NUM_CTX ?? 32_768)
+   the outside.
+
+   Not simply set to the model's own 40960, because this is memory on a card
+   rather than a number. qwen3:32b keeps 256 KiB of KV cache per token, so
+   40960 is 10 GiB of a 12 GiB card before a single layer of the model is on
+   it — and the weights are 20 GB, so every GiB the cache takes is a GiB of
+   them left on the CPU. The largest prompt this has produced is 16,300
+   tokens; 24576 covers it with the answer and costs 6 GiB, or 3 with a
+   quantised cache. See ops/internal/README.md. */
+const OLLAMA_NUM_CTX = Number(process.env.OLLAMA_NUM_CTX ?? 24_576)
 
 /* How much commit body the prompt may carry, in characters.
    Bodies in these repositories run past 4kB, and cutting them to a fixed few

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -486,6 +486,33 @@ export function flatCommits(parts) {
   return out
 }
 
+/**
+ * The two editing skills, whole.
+ *
+ * `ops/internal/writing/` holds a copy of each, because the box the drafter
+ * runs on has no ~/.claude/skills and a rule the model is judged by should not
+ * come off a laptop that may be shut.
+ *
+ * Whole rather than summarised. The first version of this was fifteen lines of
+ * the patterns these drafts kept producing, which is somebody deciding in
+ * advance which of the rules matter — and the openers and the binary contrasts
+ * were only two of the things the drafts got wrong.
+ *
+ * They cost about 4,000 tokens together. That is affordable now and was not
+ * before: with num_ctx at its default this would have pushed the commits out
+ * of the window, which is the bug directly above.
+ */
+function writingSkills(repo) {
+  const dir = join(repo, 'ops/internal/writing')
+  return ['no-ai-slop.md', 'natural-writing.md']
+    .map((f) => {
+      const path = join(dir, f)
+      if (!existsSync(path)) { log(`  ! ${f} is not in this checkout`); return null }
+      return readFileSync(path, 'utf8').trim()
+    })
+    .filter(Boolean)
+}
+
 function prompt(release, changes, style) {
   const all = flatCommits(changes.parts)
   /* Divided evenly rather than a fixed cut. The failure this replaces was a
@@ -521,6 +548,21 @@ function prompt(release, changes, style) {
     '',
     style,
     '',
+    '─────────────────────────────────────────────────────────────────────',
+    'HOW THE SENTENCES SHOULD READ',
+    '',
+    'Two editing skills, in full. Sivert runs both over prose before it ships,',
+    'and a draft is held to the same thing. Read them the way an editor would:',
+    'they are about the sentences, and everything above is about the shape.',
+    '',
+    'Both were written for somebody working with a person, and two parts of',
+    'that do not apply to you. They describe a choice between editing a draft',
+    'and auditing one - you are doing neither, you are writing the note. And',
+    'they ask for a note afterwards saying what changed - do not write one.',
+    'You return the JSON shape described at the end of this prompt and nothing',
+    'else. Everything else in them applies.',
+    '',
+    ...writingSkills(REPO).flatMap((text) => [text, '']),
     '─────────────────────────────────────────────────────────────────────',
     `THE RELEASE YOU ARE WRITING ABOUT: Gryt ${release.version}, ${release.date}`,
     '',
@@ -680,26 +722,20 @@ function prompt(release, changes, style) {
     'Do not address the reader about the release itself. They are reading it;',
     'they know.',
     '',
-    'HOW THE SENTENCES SHOULD READ',
+    'FROM THE TWO EDITING SKILLS ABOVE, THE FOUR A DRAFT KEEPS BREAKING',
     '',
-    'Sivert keeps two editing skills for this, no-ai-slop and natural-writing,',
-    'and the parts of them a draft keeps breaking are these:',
+    'All of both applies. These four are the ones that have actually come back',
+    'refused, so check them last before you answer:',
     '',
-    '- Say it the way you would say it out loud. Short sentences, ordinary',
-    '  words, contractions where they are natural.',
-    '- No binary contrasts. "It is no longer a picture, it is a live drawing"',
-    '  and "not X but Y" are one sentence pretending to be two. Write Y.',
-    '- No throat-clearing opener. "This release focuses on", "This update',
-    '  brings", "This release improves" - the reader knows what they opened.',
-    '  Start with what changed.',
-    '- Nothing that tells the reader how to feel about a fact: "this makes',
-    '  troubleshooting easier", "this ensures the message is read and',
-    '  understood", "which is particularly useful". State the fact.',
-    '- Never these words: delve, leverage, seamless, robust, streamline,',
-    '  elevate, harness, transformative, cutting-edge, game-changing,',
-    '  revolutionary, unlock, empower, foster, utilize, refactored.',
-    '- Every sentence must fail the portability test. If it would sit unchanged',
-    '  in another product\'s notes, it is filler standing where a fact should be.',
+    '- The throat-clearing opener. "This release focuses on", "This update',
+    '  brings", "This release improves". The reader knows what they opened.',
+    '- The binary contrast. "It is no longer a picture, it is a live drawing".',
+    '  Write the second half and drop the first.',
+    '- Telling the reader what to make of a fact: "this makes troubleshooting',
+    '  easier", "this ensures the message is read and understood". Give them',
+    '  another fact instead.',
+    '- The portability test, on every sentence. If it would sit unchanged in',
+    '  another product\'s notes, it is filler standing where a fact should be.',
     '',
     'If nothing in this release is visible to a user, return an empty sections',
     'array, an empty recap, a one-sentence intro saying so, and a headline',
@@ -802,13 +838,30 @@ async function ask(text) {
   }
 }
 
-/* Words that belong to the example and to nothing in this release.
+/* Words that belong to the material shown to the model and to nothing in this
+   release.
    The example is there to show the shape, and a model that has just read a
    finished note is very willing to write that note again — the 1.6.43 draft
    came back describing 24-word backups and certificate authorities, none of
    which appear anywhere in its commit range. Telling it not to is not enough,
-   so this checks. */
-function contamination(entry, exampleText, commitText) {
+   so this checks.
+
+   The two editing skills are deliberately not put through it, and the reason
+   is worth keeping. They are the same hazard on paper — fifteen kilobytes of
+   worked sentences about deploy times and sponsor trackers, none of which has
+   ever been in a Gryt release — so they were, and all three hand-written
+   notes came back scoring 40 to 46. The borrowed words were "voice",
+   "reading", "person", "words": ordinary English about writing, which is what
+   a skill about writing is made of and what a release note is written in. The
+   threshold underneath this is calibrated against one short note, and there
+   is no version of it that separates a 15kB corpus of general prose from a
+   note that happens to be written in English.
+
+   What is left instead is that the skills are rules rather than a finished
+   note. The failure this guard exists for was a model retelling an example
+   note wholesale, and an instruction to cut adverbs is not something there is
+   a wrong way to copy. */
+export function contamination(entry, exampleText, commitText) {
   if (!exampleText) return null
   const words = (t) => new Set((t.toLowerCase().match(/[a-z][a-z-]{4,}/g) ?? []))
   const inCommits = words(commitText)
@@ -1450,6 +1503,20 @@ async function main() {
 
       log(`${release.version}: ${count} commits since ${prev.version}`)
       const text = prompt(release, changes, style)
+
+      /* Say how big the prompt is, every time.
+         The whole of this release was one silent overflow: num_ctx defaulted
+         to 4096, the prompt was past it, and what came back was a well
+         written note about the commits that happened to fit. Nothing in the
+         answer says that happened, so the only defence is knowing the number
+         before it is sent. Four characters to the token is rough and is on
+         the safe side for English prose. */
+      const estimate = Math.ceil(text.length / 4)
+      log(`  prompt ${(text.length / 1024).toFixed(1)} kB, about ${estimate} tokens of ${OLLAMA_NUM_CTX}`)
+      if (estimate > OLLAMA_NUM_CTX * 0.85) {
+        log(`  ! this is close enough to num_ctx that part of it may be dropped before the model reads it`)
+        log(`    raise OLLAMA_NUM_CTX, or lower GRYT_CHANGELOG_COMMIT_BUDGET (${COMMIT_BUDGET})`)
+      }
       if (DRY_RUN) { console.log(`\n───── prompt for ${release.version} ─────\n${text}\n`); continue }
 
       const commitText = JSON.stringify(changes.parts)

--- a/ops/internal/systemd/gryt-changelog-notes.env.example
+++ b/ops/internal/systemd/gryt-changelog-notes.env.example
@@ -11,8 +11,12 @@
 # the repository is not.
 OLLAMA_URL=http://<ollama-host>:11434
 
-# The largest model that fits on the card. qwen3:32b where this was written.
-# Roughly eight minutes per release on that one.
+# qwen3:32b where this was written, roughly eight minutes per release.
+#
+# It does not fit on the card and never did. Q4 weights are about 20 GB against
+# a 3060's 12 GiB, so Ollama keeps what fits and runs the rest on the CPU —
+# which is most of where those eight minutes go, and why raising the context
+# below costs time as well as memory.
 #
 # Not a knob to turn down. qwen3:14b is around three minutes and reads flatter
 # for it — in one run it copied a headline word for word from a hand-written
@@ -33,13 +37,32 @@ OLLAMA_MODEL=qwen3:32b
 # release with one commit in it: a one-commit prompt fits and a five-commit
 # prompt does not.
 #
-# 32768 holds the largest range this has drafted and leaves the answer room.
-# qwen3:32b's own window is 40960, so this is the ceiling worth asking for; a
-# model with a smaller window will quietly give you its own.
+# Pick it against the card, not against the model. qwen3:32b holds 256 KiB of
+# KV cache per token:
 #
-# It costs memory on the card. Lower it if the box starts swapping, and expect
-# the drafts to start losing commits again when it goes under about 16384.
-#OLLAMA_NUM_CTX=32768
+#   16384   4 GiB      20480   5 GiB
+#   24576   6 GiB      32768   8 GiB      40960  10 GiB
+#
+# On a 12 GiB 3060 with Frigate already holding about 0.9, asking for the
+# model's full 40960 leaves nothing for the model itself. The weights are
+# 20 GB and the card takes what fits, so every GiB the cache uses is a GiB of
+# weights running on the CPU instead.
+#
+# 24576 is the default here: the largest prompt this has drafted is 16,300
+# tokens, and that leaves the answer room without spending the card on cache.
+# The script prints the prompt size on every run and says so past 85% of this,
+# so a release that outgrows it says which number to change.
+#
+# Halve those figures with a quantised cache, on the Ollama container rather
+# than here:
+#
+#   OLLAMA_FLASH_ATTENTION=1
+#   OLLAMA_KV_CACHE_TYPE=q8_0
+#
+# q8_0 is close enough to f16 to be hard to tell apart in the output, and the
+# 3 GiB it gives back is 3 GiB of weights that stop running on the CPU. Worth
+# doing before reaching for a bigger model.
+#OLLAMA_NUM_CTX=24576
 
 # Where drafts are posted. Required — this script does not publish anything
 # itself. The reports service holds each note until somebody has read it at

--- a/ops/internal/systemd/gryt-changelog-notes.env.example
+++ b/ops/internal/systemd/gryt-changelog-notes.env.example
@@ -24,6 +24,23 @@ OLLAMA_MODEL=qwen3:32b
 # a half-written note is not written at all.
 #OLLAMA_TIMEOUT_MS=1800000
 
+# How much of the prompt the model is allowed to see, in tokens.
+#
+# Ollama does not use the model's own window. It allocates num_ctx, and num_ctx
+# is 4096 unless something asks for more — so everything past 4096 was being
+# dropped before the model read it, with no error and nothing in the answer to
+# say so. That is what produced twelve drafts where every clean one came from a
+# release with one commit in it: a one-commit prompt fits and a five-commit
+# prompt does not.
+#
+# 32768 holds the largest range this has drafted and leaves the answer room.
+# qwen3:32b's own window is 40960, so this is the ceiling worth asking for; a
+# model with a smaller window will quietly give you its own.
+#
+# It costs memory on the card. Lower it if the box starts swapping, and expect
+# the drafts to start losing commits again when it goes under about 16384.
+#OLLAMA_NUM_CTX=32768
+
 # Where drafts are posted. Required — this script does not publish anything
 # itself. The reports service holds each note until somebody has read it at
 # reports.gryt.chat/admin/changelog, and it is what writes the file the site
@@ -54,4 +71,14 @@ GRYT_CHANGELOG_KEY=
 
 # How many releases back to consider on each run. Only affects a first run with
 # a backlog; after that there is at most one new release to draft.
+#
+# It is also the answer to "why are there only twelve notes": the backlog goes
+# back further than this, and the ones past it were never looked at. Raise it,
+# let one run finish, and put it back — at eight minutes a release, a run over
+# thirty of them takes most of an evening.
 #GRYT_CHANGELOG_LIMIT=12
+
+# How much commit body the prompt may carry in total, in characters, divided
+# evenly between the commits in the range. Bodies here run past 4kB and the
+# part that says what a person sees is rarely in the first paragraph.
+#GRYT_CHANGELOG_COMMIT_BUDGET=60000

--- a/ops/internal/writing/README.md
+++ b/ops/internal/writing/README.md
@@ -1,0 +1,33 @@
+# The editing skills, as the drafter reads them
+
+Two files, copied whole. `changelog-notes.mjs` reads both into every prompt.
+
+They are Sivert's editing skills, the ones `CLAUDE.md` tells a person to run
+over prose before it ships. The drafter had a summary of them for one commit —
+fifteen lines of the patterns its own output kept producing — and a summary is
+somebody deciding in advance which rules matter. These are the whole files, so
+the model is held to the same thing a person is.
+
+## Why they are here and not read from `~/.claude/skills`
+
+The drafter runs on the box that hosts Gryt. Nothing on it has a
+`~/.claude/skills`, and a rule the model is judged by is not something to load
+from a laptop that may not be on.
+
+## Keeping them in step
+
+Nothing does. They are copies, and the originals live on Sivert's Mac at
+`~/.claude/skills/no-ai-slop/SKILL.md` and
+`~/.claude/skills/natural-writing/SKILL.md`. Editing one of those does not
+reach here, and the drafter will keep quoting whichever version was last
+copied.
+
+Copied 2026-08-28.
+
+## What the drafter ignores in them
+
+Both files are written for an agent working with a person: they describe two
+jobs, one of which is asking the user for a draft, and they ask for a "What
+changed" section afterwards. None of that applies to a script filling a fixed
+JSON shape, and the prompt says so above them rather than the files being
+edited down — a file trimmed to fit is the summary again.

--- a/ops/internal/writing/natural-writing.md
+++ b/ops/internal/writing/natural-writing.md
@@ -1,0 +1,113 @@
+---
+name: natural-writing
+description: Rewrite text so it sounds like a person talking — simple words, short sentences, no marketing voice. Use when the user says writing sounds strange, stiff, academic, or "not how a person talks", asks for it plainer or simpler, or is writing product copy, docs, a README, release notes or a landing page.
+---
+
+# Natural writing
+
+Make it sound like something you would actually say out loud.
+
+This is Sivert's brief, kept in his words where it was already clear. The point
+is not to make writing friendly or casual for its own sake. The point is that a
+reader should never have to slow down.
+
+## Two jobs
+
+**Rewrite (default).** The user hands over a draft, or points at a page. Rewrite
+it against the rules below and say what changed. Keep every fact.
+
+**Check.** The user asks whether something reads naturally, or asks you to go
+over a page without changing it. Quote each line that breaks a rule, name the
+rule, and give the fix in a few words. Do not rewrite.
+
+## The rules
+
+### Language
+
+- **Simple words.** Write like you talk to a friend.
+- **Short sentences.** Break a complex thought into pieces.
+- **Be direct.** Say what you mean without extra words.
+- **Natural flow.** Starting a sentence with "and", "but" or "so" is fine.
+- **Real voice.** Do not force friendliness or fake excitement.
+
+### Style
+
+- **Conversational grammar.** Simple structures, not academic ones.
+- **Cut fluff.** Drop adjectives and adverbs that are not doing anything.
+- **Use examples.** Show a specific case instead of an abstraction.
+- **Be honest.** Admit limits. Do not oversell.
+- **Write like texting.** Direct, the way you would actually say it.
+- **Simple connectors:** "here's the thing", "and", "but".
+
+## Banned
+
+Never write these:
+
+> delve, dive into, unleash, game-changing, revolutionary, transformative,
+> leverage, optimize, unlock potential, unlock the secrets, transform your life,
+> embark, elevate, harness, seamless, robust, cutting-edge, paradigm shift
+
+And the shapes they come in:
+
+| Instead of | Write |
+|---|---|
+| "Let's dive into…" | "Here's how it works" |
+| "Unleash your potential" | "This can help you" |
+| "Game-changing solution" | "Here's what I found" |
+| "Revolutionary approach" | "This might work for you" |
+| "Leverage this strategy" | "Here's the thing" |
+| "Optimize your workflow" | "And that's why it matters" |
+| — | "But here's the problem" |
+| — | "So here's what happened" |
+
+## How to do it
+
+Work sentence by sentence. Most of the fix is four moves:
+
+1. **Contract.** "It is not" → "It isn't". "There is nothing" → "There's
+   nothing". In JSX use `&rsquo;`, not a bare apostrophe.
+2. **Cut at the join.** A sentence carrying two or three clauses through a
+   semicolon is two or three sentences. "Voice is routed through an SFU for
+   fan-out, so the SFU is on the path, and it is run by the server owner" →
+   "Voice goes through an SFU so it can reach everyone at once. That puts the
+   SFU on the path too. The server owner runs that as well."
+3. **Take the ordinary word.** "Infrastructure you control" → "machines you
+   control". "Persistent channels" → "channels that stay put". "Engagement
+   mechanics" → "nothing built to keep you scrolling".
+4. **Name who does the thing.** "The operator" → "whoever runs the server".
+   "Uploads are streamed in parts" → "uploads go up in parts".
+
+## What not to touch
+
+- **Facts.** Every number, price, port, version, licence, name and caveat comes
+  through unchanged. This is a pass over how the sentences read, not over what
+  they claim. If a rewrite would drop a caveat, keep the caveat and write a
+  second sentence.
+- **Code, identifiers, log lines, test names, comments.** Nobody browses them,
+  and comments are often load-bearing.
+- **Legal text.** Privacy policies, terms, licences. The formal register is the
+  point of them.
+- **First-person writing that already sounds like the author.** If somebody is
+  telling you why they built something and it already sounds like them, put the
+  contractions back and leave the rest alone.
+
+## The check before you finish
+
+Read each line and ask:
+
+- Would you say it out loud?
+- Does it use words a normal person uses?
+- Does it sound like marketing?
+- Is it honest about what the thing does not do?
+- Does it get to the point?
+
+If a sentence could be moved to another company's page unchanged, it is filler.
+Cut it or replace it with a fact.
+
+## Related
+
+`no-ai-slop` is the other half of this and they compose. That one removes AI
+tells and protects a distinctive voice; this one makes the result simple and
+spoken. Run `no-ai-slop` when the problem is that writing sounds generated. Run
+this one when the problem is that it sounds stiff, clever or academic. On
+product copy, running both is normal — slop first, then this.

--- a/ops/internal/writing/no-ai-slop.md
+++ b/ops/internal/writing/no-ai-slop.md
@@ -1,0 +1,97 @@
+---
+name: no-ai-slop
+description: Edit drafts into sharper, more human writing while preserving the writer's personal voice, or detect AI-slop patterns without rewriting. Use when the user wants a draft clearer, more direct, more opinionated, or less AI-sounding, or asks whether writing reads as AI.
+---
+
+# No AI slop
+
+You are a sharp human editor. Preserve the user's point and personal voice while making the writing clearer and more alive. Remove AI patterns without turning distinctive writing into generic polished prose.
+
+## Two jobs
+
+**Edit (default).** The user shares a draft to fix. Make the minimum effective edit with the rules below and return the edited draft plus a What changed section.
+
+**Detect.** The user asks whether a piece is AI slop, or asks to audit, scan, or flag a draft without rewriting. Name each pattern from this skill that appears, quote the line, and give the fix in a few words. Do not rewrite, score the draft, or guess whether AI wrote it. AI detectors guess. Named patterns are evidence the user can check. Offer to edit the draft after.
+
+## What to ask for
+
+If the user has not provided a draft, ask them to paste it.
+
+If the audience or format is unclear, ask one question: Who is this for and where will it be published?
+
+If the goal is unclear, ask what the reader should think, feel, or do after reading it.
+
+## Editing principles
+
+- **Preserve the writer's real voice.** First notice the draft's vocabulary, cadence, bluntness, humor, uncertainty, digressions, and level of polish. Keep the traits that feel personal to the writer. Do not make every paragraph equally tidy or rewrite distinctive lines merely for consistency.
+- **Make the minimum effective edit.** Fix AI patterns, errors, repetition, and unclear passages. Leave strong human sentences alone. A rough draft with a real voice should still sound like the same person after editing.
+- **Lead with the point when the setup adds nothing.** Cut generic throat-clearing. Keep a personal aside, story, or admission when it creates context, tension, or character.
+- **Front-load only when it improves clarity.** Put conclusions early when that helps the reader. Do not force every section and paragraph into the same point-detail-background shape.
+- **Keep the user's meaning.** Don't invent claims, examples, stats, or opinions. If something is unclear, ask.
+- **Open it up, don't dumb it down.** Keep the substance, nuance, and precision. Strip out only what makes it hard to read: jargon, long sentences, abstract nouns, and tangled structure.
+- **Use active voice.** "The team shipped it Tuesday" beats "the decision emerged." Never let inanimate things do human verbs.
+- **Make every sentence earn its place.** Cut empty qualifiers and throat-clearing. Keep phrases such as "I think," "maybe," or "to be honest" when they express real uncertainty, self-awareness, or the writer's spoken rhythm.
+- **Untangle sentences without flattening the cadence.** Split sentences and paragraphs when they are genuinely hard to follow. Keep longer spoken sentences, fragments, and changes in pace when they are clear and characteristic of the writer.
+- **Be concrete and specific.** Abstraction is where writing goes to die. "The integration improved efficiency" becomes "The integration cut deploy time from 40 minutes to 4." Names, numbers, dates, mechanisms, and examples beat abstractions.
+- **Use the portability test.** If a sentence could move unchanged to another person, company, country, or product, it is probably filler. Cut it or replace it with a fact, example, mechanism, consequence, or judgment specific to this subject.
+- **Always show, don't tell the reader what to think.** Make facts, actions, examples, and consequences carry the emphasis. Cut commentary that labels a point important, surprising, subtle, or obvious instead of demonstrating why. If the surrounding prose already shows the point, trust the reader and delete the commentary.
+- **Protect the specific fact.** Don't smooth a useful detail into generic importance. "The tool significantly improves engineering productivity" becomes "The tool cut review time from 30 minutes to 8."
+- **Make verbs do the work.** Replace weak verb phrases with direct verbs. "Made a decision" becomes "decided." "Has the ability to" becomes "can."
+- **Know the job.** Before structure or word choice, know what the piece is trying to do and who it is for.
+- **Preserve useful edge and character.** Keep strong opinions, blunt language, humor, profanity, self-interruptions, and honest admissions when they belong to the writer. Don't replace them with safer or more professional wording.
+- **Keep structure unless it's hurting the piece.** Preserve the writer's progression and detours when they carry personality. If you reorganize, say why in the What changed section.
+
+## Words to cut
+
+Banned outright: delve, foster, leverage, utilize, facilitate, empower, streamline, robust, cutting-edge, paradigm shift, game changer, this is huge, this changes everything, tapestry, realm, beacon, multifaceted, meticulous, intricate, paramount, transformative, elevate, embark, supercharge, harness, ever-evolving.
+
+Often-empty adverbs: just, literally, honestly, simply, actually, truly, fundamentally, importantly, crucially, inherently, inevitably. Cut them when they add nothing. Keep them when they carry emphasis, uncertainty, contrast, or the writer's natural spoken rhythm.
+
+Often-empty phrases: it's worth noting, it's important to note, at the end of the day, when it comes to, at its core, in today's world, in the age of, in the world of, the reality is, the truth is, in terms of, with regard to, in order to, going forward, in this article, let's dive in. Cut them when they delay the point. Keep an occasional phrase when it is part of the writer's recognizable voice and the sentence still earns its place.
+
+## Patterns to cut
+
+**Binary contrasts.** "This is not X. It's Y." / "The question isn't X, it's Y." / "It's not just X but Y." State Y directly. "The question isn't the model. It's the eval." becomes "The eval matters more than the model."
+
+**Throat-clearing openers.** "Here's the thing," "Here's what I mean," "Let me be clear," "I'll be honest," "The uncomfortable truth is." Cut them and state the point.
+
+**Faux-insight setups.** "This is the part most people skip," "What most people get wrong," "Here's what nobody tells you," "The part everyone misses." These flatter the writer as the lone expert. Cut the setup and make the claim stand on its own. "The part everyone misses: distribution is the real moat" becomes "Distribution is the moat."
+
+**Colon reveals.** A noun phrase, a colon, then a lowercase dramatic reveal: "The detail that makes it work: a separate agent grades it." "The best part: it learns." Rewrite as a plain sentence ("A separate agent does the grading, which is what makes it work"). Use colons for lists, labels, and quotes, not fake drama. Prefer sentence case after a colon unless grammar, a proper noun, a title, or code requires otherwise.
+
+**Superficial analysis.** Cut trailing `-ing` clauses that pretend to explain meaning: "highlighting," "underscoring," "reflecting," "showcasing." "The launch adds file search, highlighting the team's commitment to better workflows" becomes "The launch adds file search, so users can find old drafts without leaving the editor."
+
+**Importance puffery.** "Stands as a testament," "marks a pivotal moment," "plays a vital role," "solidifies its position," "underscores its significance." State the fact and let the reader judge whether it matters. "The launch marks a pivotal moment for the company" becomes "The launch is the company's first paid product."
+
+**Interpretive metadiscourse.** Cut lines that step outside the subject to tell the reader what to notice, how much weight to give it, or how to interpret the prose: "That last part matters more than it sounds," "The key point is," "As you can see," "This distinction matters," and redundant "In other words." If the point is clear, delete the aside. Otherwise, replace it with support or facts already in the content.
+
+**Weasel attribution.** "Experts agree," "industry reports suggest," "many argue," "widely regarded as," "studies show." Name the source or cut the claim. If the user has no source, ask instead of inventing one.
+
+**Fake-strong verbs.** Prefer "is" and "has" when they are clearer. "The app serves as a centralized hub for sponsor management" becomes "The app tracks sponsors, drafts, due dates, and approvals in one place."
+
+**Synonym cycling.** If the clear word is right, repeat it. Don't rotate terms for style. "The agent reviews the draft. The assistant scores the piece. The tool suggests fixes" becomes "The agent reviews the draft, scores it, and suggests fixes."
+
+**Negative listing.** "Not a X. Not a Y. A Z." Just say Z.
+
+**Dramatic fragmentation.** "X. And Y. And Z." or "That's it. That's the whole thing." Use complete sentences.
+
+**Robotic rhythm.** Avoid repeated sentence shapes, identical paragraph structures, and stacked punchy fragments. Vary the shape only when it helps the point.
+
+**Rhetorical setups.** "What if I told you...", "Think about it:", "Plot twist:", and self-answered "Question? Answer." pairs. Drop them and make the point.
+
+**Fake-profound kickers.** Cut the final "deep" line when it turns the point into a cute metaphor, aphorism, or mic-drop sentence. Do not rewrite it into a better metaphor. Do not preserve the rhythm. Delete it, then end on the clearest concrete sentence already in the draft. If the ending needs more closure, add a plain takeaway or next action.
+
+**Summary-recap endings.** "In conclusion," "Ultimately," "Overall," or a final paragraph that restates the piece. The reader was just there. End on the last concrete point, takeaway, or next action instead.
+
+**Formatting slop.** Emoji in headings, bold sprinkled mid-sentence for emphasis, bullet lists where two sentences of prose would read better, and headers over two-sentence sections. Format should follow the content, not decorate it.
+
+**Em dashes.** Do not use them as a default rhythm crutch. In short copy, use none. In longer drafts, 1-2 are fine if they clearly beat commas, periods, or parentheses. Remove clusters and decorative dashes.
+
+## Workflow
+
+1. Read the full draft before editing.
+2. Identify the core point and 3-5 voice signals to preserve, such as vocabulary, cadence, bluntness, humor, uncertainty, or digressions. Keep this note internal. If you cannot identify the core point, ask the user.
+3. For a detect request, return the findings report described in Two jobs and stop.
+4. For an edit, make the minimum effective changes, then check the edited draft against `eval.md` yourself.
+5. If any check fails, fix the draft and run the checks again.
+6. Output the full edited draft and a short **What changed** section.


### PR DESCRIPTION
Twelve drafts were waiting at /admin/changelog. Nine were wrong, and every
one of the three that was not came from a release with a single commit in
it. Every release with three or more lost at least one commit, and the note
said nothing about the loss — 1.6.38 dropped the media server change while
its own component line said Voice, and 1.6.39 wrote "it had four issues"
and then named one.

Two causes, and neither is visible from the outside. A draft that covers
three of five commits reads as a finished note about a smaller release.

**num_ctx was never set.** Ollama does not use the model's window, it
allocates num_ctx, and num_ctx is 4096 unless something asks for more.
Everything past it is dropped before the model reads a word, with no error
and nothing in the answer to say so. Measured on this range, the prompts
run 5,200 to 12,300 tokens. One commit fits inside 4096. Five do not, which
is exactly the line the good drafts fell on.

**Commit bodies were cut to eight lines.** Bodies here run to 4kB and the
part that says what a person sees is rarely in the first paragraph.
Measured across the six multi-commit releases in the queue, the model was
seeing 17-20% of what the authors wrote: 24 lines of 145 for 1.6.39, whose
GRYT-596 opens "Four things wrong with the editor" and spends four headed
sections on them.

The budget is 60kB now, divided evenly across the range, and a body that
still does not fit says so in the prompt rather than ending mid-sentence.

1.6.40 is the case that says these are two separate faults rather than one:
its bodies fit in eight lines each and it still lost three commits of five.

## Coverage is checked, not asked for

`coverage()` takes the words that belong to one commit and to no other in
the range, and asks whether any of them reached the note. A commit written
about in the reader's own words still shares something with its own body;
one nobody wrote about shares nothing. Below three distinctive words it
says nothing rather than guessing.

Leaving a commit out is allowed. Doing it silently is not: the model fills
an `omitted` array with the commit number and a reason, the log prints
each one, and the field is stripped before the draft is posted. A commit
that is neither in the note nor in `omitted` sends the draft back.

## Smaller rules, from the same twelve

- Names only somebody with the checkout can use: `resolveAvatarSrc` and
  `skewMs` were both the subject of a sentence, and `public/logo.svg` and
  a yarn command were printed mid-paragraph. Camel case, file names and
  commands are refused outside Under the hood. Backticks are not on that
  list — the hand-written notes put a hostname and an env var in them and
  both belong there.
- Under the hood is last in the recap. Not the whole list and not the whole
  order: the guide names eight groups and the notes written since use
  Identity, Servers, Joining, Interface and "Hosting from the app", so
  enforcing membership refused two of the three notes the drafter is
  imitating. Worth deciding separately whether the guide's list should
  catch up.
- A change that only happens on one operating system has to say so. The
  1.6.34 draft never said the screen-share picker is Windows only, which
  sends every macOS reader looking for a control that is not there.
- The openers, and the sentences that tell a reader how to feel about a
  fact. Both lists come from no-ai-slop and natural-writing, the two
  editing skills Sivert already keeps, reduced to the patterns these drafts
  actually produced.

## What to look at

The `coverage()` heuristic is the part I am least sure of. It is
vocabulary, not meaning, so a note that covers a commit in words that share
nothing with its body would be refused wrongly. The three-word floor and
the `omitted` escape are what keep that from being fatal, and both fixtures
for it are in the CI check.

`prompt()` now shows the model "The app" and "Voice" rather than `client`
and `sfu`. The rules two screens below tell it never to write those words,
and it was being handed them as headings.

The style check grew fixtures for each new rule, and one fix of its own:
it read `![alt](/changelog/voice-split.webp)` as a paragraph, so an asset
filename was sitting in what it treats as 1.4.0's prose.

Not in here: the queue only went back twelve releases because that is
`GRYT_CHANGELOG_LIMIT`'s default and the timer uses it. The backfill in the
README is what reaches the other 23.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Second commit: both editing skills, in full

The summary above became the whole of `no-ai-slop` and `natural-writing`,
copied into `ops/internal/writing/` and read into every prompt. Sivert runs
both over prose before it ships; a draft is now held to the same files rather
than to fifteen lines I picked out of them.

They cost about 4,000 tokens — prompts go from 5,200–12,300 to 9,200–16,300
against a window of 32,768. That is affordable only because of `num_ctx` in the
first commit, which is why a summary was the right call while the window was
4096 and is not now.

Copied rather than read from `~/.claude/skills`, because the box has no home
directory with skills in it. Nothing keeps the copies in step; that and the
date they were taken are written down beside them.

Both files are addressed to an agent working with a person — a choice between
editing and auditing, and a "What changed" note afterwards. The prompt says
which parts do not apply rather than the files being trimmed, since a file
trimmed to fit is the summary again.

## A rule I tried and removed

I put the skills through the contamination guard, on the same grounds as the
worked example: 15kB of finished sentences about deploy times and sponsor
trackers, none of it ever in a Gryt release.

All three hand-written notes scored 40–46 against a threshold of 20, on
"voice", "reading", "person" and "words". A skill about writing is ordinary
English about writing and so is a release note. The rule is wrong, not the
notes, so it is not in here — the reasoning is on the guard, and CI now asserts
only that both files exist.

## Also

Every run logs the prompt size against `num_ctx` and says so past 85% of it.
This whole release was one silent overflow; the number that would have shown it
should not need somebody to go looking.

## Worth deciding before merge

`natural-writing` is Sivert's own and says so in its first paragraph.
`no-ai-slop` arrived on the Mac on 2026-08-22 with no licence, README or
repository beside it, and this repository is public and AGPL.
