### PR TITLE
Run main() when the script is reached through its symlink (GRYT-663)

### DIFF
--- a/.github/scripts/check-changelog-style.mjs
+++ b/.github/scripts/check-changelog-style.mjs
@@ -24,7 +24,9 @@
 // Run by .github/workflows/changelog-style.yml on any pull request touching the
 // rules, the notes or this file.
 
-import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { readFileSync, readdirSync, existsSync, mkdtempSync, symlinkSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -386,6 +388,39 @@ for (const { name, note, range, expect } of BAD_DRAFTS) {
    hand-written notes scored as copied from them, on "voice", "reading",
    "person" and "words", because a skill about writing and a note about a chat
    app are both written in English. The reasoning is on the guard itself. */
+/* The unit invokes this script through a symlink, and for a week that meant it
+   did nothing at all: Node resolves a module to its real path, the guard on the
+   last line compared that against the name it was invoked as, and the two never
+   matched. It exited 0 in one second every hour, which is what a run with
+   nothing to do looks like.
+
+   Checked by invoking it the way the unit does, against a directory that is not
+   a checkout. main() gets as far as reading patch-notes-style.md and fails,
+   which is fine — the assertion is that it got that far at all. A script whose
+   entry point is broken prints nothing. */
+console.log('\nThe entry point, reached the way the unit reaches it:\n')
+{
+  const link = join(mkdtempSync(join(tmpdir(), 'gryt-entry-')), 'changelog-notes.mjs')
+  symlinkSync(join(REPO, 'ops', 'internal', 'changelog-notes.mjs'), link)
+  let output = ''
+  try {
+    output = execFileSync(process.execPath, [link, '--dry-run'], {
+      encoding: 'utf8',
+      env: { ...process.env, GRYT_CHANGELOG_REPO: mkdtempSync(join(tmpdir(), 'gryt-norepo-')) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 60_000,
+    })
+  } catch (err) {
+    output = `${err.stdout ?? ''}${err.stderr ?? ''}`
+  }
+  if (output.includes('[changelog]')) {
+    console.log('  ✓ main() runs when the script is a symlink')
+  } else {
+    failed++
+    console.error('  ✗ nothing happened — the guard on the last line is comparing the wrong paths')
+  }
+}
+
 console.log('\nThe skills the prompt reads:\n')
 for (const f of ['no-ai-slop.md', 'natural-writing.md']) {
   const path = join(REPO, 'ops', 'internal', 'writing', f)

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -62,7 +62,7 @@
 //                          See the comment on ask().
 
 import { execFileSync } from 'node:child_process'
-import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
@@ -1657,8 +1657,33 @@ async function main() {
 /* Only when run, not when imported.
    The style rules below are exported so CI can check them against the notes
    written by hand, and a module that drafts a changelog as a side effect of
-   being imported is a module nobody can test. */
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+   being imported is a module nobody can test.
+
+   Both sides resolved, because one of them already was. Node resolves an ES
+   module to its real path, so `import.meta.url` is the file in the checkout
+   while `process.argv[1]` is whatever name it was invoked as — and the README
+   tells you to invoke it as a symlink in /usr/local/lib, so that a git pull
+   updates the script without reinstalling anything. The two never matched, so
+   the unit loaded this file, defined everything in it, and exited 0 without
+   drafting.
+
+   It ran hourly for a week like that. Nothing failed: one second, success, no
+   output, which is indistinguishable from a run with nothing to do. Every note
+   in the queue came from somebody running the backfill by hand from the real
+   path.
+
+   realpathSync throws on a path that is not there, which argv[1] can be under
+   a shell that made it up, so the comparison falls back to the raw value
+   rather than taking the process down on its last line. */
+function invokedDirectly() {
+  const argv = process.argv[1]
+  if (!argv) return false
+  let resolved = argv
+  try { resolved = realpathSync(argv) } catch { /* use it as given */ }
+  return import.meta.url === pathToFileURL(resolved).href
+}
+
+if (invokedDirectly()) {
   main().catch((err) => {
     console.error('[changelog] failed:', err)
     process.exit(1)


### PR DESCRIPTION
The hourly timer has never drafted a note. It ran, exited 0 in about a
second, and logged nothing, which is exactly what a run with nothing to do
looks like — so for a week nothing said otherwise. Every note in the queue
was written by somebody running the backfill by hand: all twelve were
drafted inside three hours on 2026-08-27.

The last line of the file is a guard so that importing the module does not
draft a changelog as a side effect, and it compared `import.meta.url`
against `pathToFileURL(process.argv[1])`. Node resolves an ES module to its
real path, so the left side was the file in the checkout and the right side
was `/usr/local/lib/gryt/changelog-notes.mjs`, which is the symlink the
README tells you to install so that a git pull updates the script. They
never matched. main() never ran.

Measured on the box:

    node /usr/local/lib/gryt/changelog-notes.mjs --dry-run   nothing, exit 0
    node /home/sivert/gryt/ops/internal/...      --dry-run   drafts

and systemd's own record of the 23:05 run: started 23:05:08, finished
23:05:09, Result=success, ExecMainStatus=0, journal empty. StandardOutput
is `journal`, so there was no output rather than nowhere to put it.

Both sides are resolved now. realpathSync throws on a path that is not
there, which argv[1] can be, so it falls back to the raw value rather than
taking the process down on its last line.

CI invokes the script the way the unit does — through a symlink, against a
directory that is not a checkout — and asserts it gets far enough to fail
on the missing style guide. Reverting the fix turns that check red, which
is the only reason it is worth having: the failure it catches is silence,
and nothing else in the suite would notice.

Not fixed here, and its own task: GRYT-662, the ExecStartPre pull. It has
its own two reasons for failing and they are unrelated to this one. The
reason both went unseen is the same though — this unit succeeds at doing
nothing, loudly enough for systemd and quietly enough for everyone else.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)