### PR TITLE
Stop git shouting about tags from before the manifest existed

### DIFF
--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -286,9 +286,29 @@ function fetchTags() {
   }
 }
 
+/**
+ * The manifest a tag shipped with, or null for a tag from before there was one.
+ *
+ * Quiet on the way out. The manifest starts at v1.2.12, so every older tag
+ * fails this, and git writes its own complaint to stderr before the catch
+ * here ever sees it:
+ *
+ *   fatal: path '.release/manifest.json' exists on disk, but not in 'v1.1.4'
+ *
+ * Two of those per tag, ahead of the line that says it was handled, which
+ * makes the first screen of every run read like something broke. Nothing did —
+ * those six releases predate the record and can never have notes. `stderr`
+ * ignored rather than captured, since the only thing said about the failure is
+ * the "skipping" line the caller already prints.
+ */
 function manifestAt(tag) {
   try {
-    return JSON.parse(sh('git', ['show', `${tag}:.release/manifest.json`], { cwd: REPO }))
+    return JSON.parse(
+      sh('git', ['show', `${tag}:.release/manifest.json`], {
+        cwd: REPO,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }),
+    )
   } catch {
     return null
   }


### PR DESCRIPTION
Every run opens with six of these:

    fatal: path '.release/manifest.json' exists on disk, but not in 'v1.1.4'

twice per tag, ahead of the line saying it was handled. Nothing is wrong.
The manifest starts at v1.2.12, so the six tags older than that have none
and are skipped, which is permanent and correct — those releases cannot
have notes drafted from a record that did not exist yet.

manifestAt already catches the failure. What it cannot catch is git
writing to stderr before the exception reaches it, and the unit inherits
stderr, so the first screen of a run reads like something broke. stderr
ignored on that one call rather than captured: the only thing worth saying
about the failure is the "skipping" line the caller already prints.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)