### PR TITLE
Give STUN two providers, not one (GRYT-669)

### DIFF
--- a/ops/.env.example
+++ b/ops/.env.example
@@ -26,7 +26,19 @@
 # SFU_PUBLIC_HOST=wss://sfu.example.com
 # Multiple SFU URLs (comma-separated) for LAN + public access:
 # SFU_PUBLIC_HOST=wss://sfu.example.com,ws://192.168.1.100:5005
-# STUN_SERVERS=stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
+# STUN. Two providers on purpose, not three servers for redundancy's sake.
+#
+# Gryt has no TURN relay, deliberately, so a call that cannot find a direct path
+# does not happen — which makes the reflexive candidate the whole ballgame. A
+# list from one provider is one blocklist entry away from no voice at all, and
+# ad-blocking resolvers do block Google's: on a home network running AdGuard,
+# stun.l.google.com resolved to 0.0.0.0 and a call hung for sixteen seconds
+# before failing with a toast blaming the user's network (GRYT-669).
+#
+# Cloudflare first because it answered fastest from that network (9ms median
+# against 32ms), and because being a different operator is the point — one
+# provider blocked should cost latency, not the call.
+# STUN_SERVERS=stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
 
 # Public IP(s) the SFU advertises in ICE candidates (required when behind NAT /
 # Cloudflare Tunnel so clients know where to send UDP media).

--- a/ops/deploy/compose/.env.example
+++ b/ops/deploy/compose/.env.example
@@ -164,7 +164,7 @@ VOICE_MAX_USERS=
 # metal, 1:1 NAT. Most cloud and Docker setups remap UDP source ports, so STUN
 # is doing real work there.
 DISABLE_STUN=false
-STUN_SERVERS=stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
+STUN_SERVERS=stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
 
 # ── LAN discovery (mDNS) ────────────────────────────────────────────────────
 # The server writes an avahi service file to /etc/avahi/services when that

--- a/ops/deploy/compose/beta.local.yml
+++ b/ops/deploy/compose/beta.local.yml
@@ -49,7 +49,7 @@ services:
       JWT_SECRET: ${NT_JWT_SECRET:?Set NT_JWT_SECRET in .env.beta}
       SFU_WS_HOST: ws://sfu:5005
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5015}
-      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
+      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-20}
       GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}

--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -70,7 +70,7 @@ services:
       - "${ICE_UDP_MUX_PORT:-4443}:${ICE_UDP_MUX_PORT:-4443}/udp"
     environment:
       PORT: "5005"
-      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
+      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       ICE_UDP_MUX_PORT: ${ICE_UDP_MUX_PORT:-4443}
       ICE_ADVERTISE_IP: ${ICE_ADVERTISE_IP:-}
     networks:
@@ -124,7 +124,7 @@ services:
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env}
       SFU_WS_HOST: ws://sfu:${SFU_PORT:-5015}
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5015}
-      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
+      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-20}
       GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}

--- a/ops/deploy/compose/dev.yml
+++ b/ops/deploy/compose/dev.yml
@@ -11,7 +11,7 @@ services:
       - "${ICE_UDP_MUX_PORT:-3478}:${ICE_UDP_MUX_PORT:-3478}/udp"
     environment:
       - PORT=5005
-      - STUN_SERVERS=stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
+      - STUN_SERVERS=stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
       # All media flows over this one UDP port. It has to be published above.
       - ICE_UDP_MUX_PORT=${ICE_UDP_MUX_PORT:-3478}
       # Optional: control what IP is advertised in ICE candidates
@@ -40,7 +40,7 @@ services:
       - PORT=5000
       - SERVER_NAME=Gryta Krutt
       - SFU_WS_HOST=ws://sfu:5005
-      - STUN_SERVERS=stun:stun.l.google.com:19302
+      - STUN_SERVERS=stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3777,http://127.0.0.1:15738,https://app.gryt.chat}
       - SERVER_PASSWORD=changeme-1
       - GRYT_SERVER_ENABLED=true
@@ -85,7 +85,7 @@ services:
       - PORT=5000
       - SERVER_NAME=Techial
       - SFU_WS_HOST=ws://sfu:5005
-      - STUN_SERVERS=stun:stun.l.google.com:19302
+      - STUN_SERVERS=stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3777,http://127.0.0.1:15738,https://app.gryt.chat}
       - SERVER_PASSWORD=changeme-2
       - GRYT_SERVER_ENABLED=true

--- a/ops/deploy/compose/prod.local.yml
+++ b/ops/deploy/compose/prod.local.yml
@@ -40,7 +40,7 @@ services:
       JWT_SECRET: ${NT_JWT_SECRET:?Set NT_JWT_SECRET in .env.prod}
       SFU_WS_HOST: ws://sfu:5005
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
-      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
+      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-}
       GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -64,7 +64,7 @@ services:
       - "${ICE_UDP_MUX_PORT:-3478}:${ICE_UDP_MUX_PORT:-3478}/udp"
     environment:
       PORT: "5005"
-      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
+      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       ICE_UDP_MUX_PORT: ${ICE_UDP_MUX_PORT:-3478}
       ICE_ADVERTISE_IP: ${ICE_ADVERTISE_IP:-}
       DISABLE_STUN: ${DISABLE_STUN:-false}
@@ -112,7 +112,7 @@ services:
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env}
       SFU_WS_HOST: ws://sfu:${SFU_PORT:-5005}
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
-      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
+      STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-}
       GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
       GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
@@ -265,7 +265,7 @@ services:
   #     # The same SFU as the first server, on purpose.
   #     SFU_WS_HOST: ws://sfu:${SFU_PORT:-5005}
   #     SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
-  #     STUN_SERVERS: ${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
+  #     STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
   #     GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}
   #     GRYT_OIDC_ISSUER: ${GRYT_OIDC_ISSUER:-https://auth.gryt.chat/realms/gryt}
   #     GRYT_OIDC_AUDIENCE: ${GRYT_OIDC_AUDIENCE:-gryt-web}

--- a/ops/deploy/host/.env.example
+++ b/ops/deploy/host/.env.example
@@ -23,7 +23,7 @@ ICE_UDP_MUX_PORT=3478
 # ICE_ADVERTISE_IP=203.0.113.10
 
 # STUN servers (comma-separated)
-STUN_SERVERS=stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
+STUN_SERVERS=stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
 
 # What the browser should use to reach the SFU websocket (public URL).
 # This must be a WSS URL that terminates TLS at Cloudflare.

--- a/ops/deploy/host/compose.yml
+++ b/ops/deploy/host/compose.yml
@@ -73,7 +73,7 @@ services:
       - ./.env
     environment:
       PORT: "5005"
-      STUN_SERVERS: "${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
+      STUN_SERVERS: "${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
       ICE_UDP_MUX_PORT: "${ICE_UDP_MUX_PORT:-3478}"
       ICE_ADVERTISE_IP: "${ICE_ADVERTISE_IP:-}"
       DISABLE_STUN: "${DISABLE_STUN:-false}"

--- a/ops/dev/common.env.sh
+++ b/ops/dev/common.env.sh
@@ -21,7 +21,7 @@ export S3_FORCE_PATH_STYLE="${S3_FORCE_PATH_STYLE:-true}"
 # Local defaults for SFU + STUN in dev
 export SFU_WS_HOST="${SFU_WS_HOST:-ws://127.0.0.1:5005}"
 export SFU_PUBLIC_HOST="${SFU_PUBLIC_HOST:-wss://sfu.example.com}"
-export STUN_SERVERS="${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
+export STUN_SERVERS="${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
 
 # CORS allowlist (http://127.0.0.1:15738 = Electron desktop app)
 export CORS_ORIGIN="${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3777,https://app.gryt.chat}"

--- a/ops/helm/gryt/examples/development-values.yaml
+++ b/ops/helm/gryt/examples/development-values.yaml
@@ -10,7 +10,7 @@ gryt:
     apiUrl: "https://auth.gryt.chat"
   
   stun:
-    servers: "stun:stun.l.google.com:19302"
+    servers: "stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302"
 
 # SFU Configuration
 sfu:

--- a/ops/helm/gryt/examples/production-values.yaml
+++ b/ops/helm/gryt/examples/production-values.yaml
@@ -13,7 +13,7 @@ gryt:
     apiUrl: "https://auth.gryt.chat"
   
   stun:
-    servers: "stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302"
+    servers: "stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302"
 
 # SFU Configuration
 sfu:

--- a/ops/helm/gryt/values.yaml
+++ b/ops/helm/gryt/values.yaml
@@ -29,9 +29,21 @@ gryt:
     # Gryt authentication API endpoint
     apiUrl: "https://auth.gryt.chat"
   
-  # STUN server configuration (TURN is intentionally not required)
+  # STUN. Two providers on purpose, not three servers for redundancy's sake.
+  #
+  # Gryt has no TURN relay, deliberately, so a call that cannot find a direct
+  # path does not happen — which makes the reflexive candidate the whole
+  # ballgame. A list from one provider is one blocklist entry away from no voice
+  # at all, and ad-blocking resolvers do block Google's: on a home network
+  # running AdGuard, stun.l.google.com resolved to 0.0.0.0 and a call hung for
+  # sixteen seconds before failing with a toast blaming the user's network
+  # (GRYT-669).
+  #
+  # Cloudflare first because it answered fastest from that network (9ms median
+  # against 32ms), and because being a different operator is the point — one
+  # provider blocked should cost latency, not the call.
   stun:
-    servers: "stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302"
+    servers: "stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302"
 
 # SFU (Selective Forwarding Unit) configuration
 sfu:

--- a/ops/start_dev.sh
+++ b/ops/start_dev.sh
@@ -41,7 +41,7 @@ LAN_IP="${LAN_IP:-$(detect_lan_ip || true)}"
 
 SFU_WS_HOST="${SFU_WS_HOST:-ws://127.0.0.1:5005}"
 SFU_PUBLIC_HOST="${SFU_PUBLIC_HOST:-ws://${LAN_IP:-127.0.0.1}:5005}"
-STUN_SERVERS="${STUN_SERVERS:-stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
+STUN_SERVERS="${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
 # 3666 is the Vite dev server port (packages/client/vite.config.ts); the server
 # matches Origin exactly, so it must be listed verbatim.
 CORS_ORIGIN="${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3666,http://127.0.0.1:3666,https://app.gryt.chat}"


### PR DESCRIPTION
Somebody's call hung for sixteen seconds and then told them their network might not allow voice traffic. It does — the retry a second and a half later connected in 74ms. This is why.

## The finding

On that network — a home one running AdGuard — `stun.l.google.com` **resolves to 0.0.0.0**. Every Gryt server ships a STUN list of exactly that host plus `stun1.l.google.com`, so one blocklist entry took out half the pool, and the remaining half dropped the one request that mattered.

Measured from the same public address the report came from, twelve binding requests each:

```
stun.l.google.com     12/12 lost   (resolves to 0.0.0.0)
stun1.l.google.com     0/12 lost   median 32ms
stun.cloudflare.com    0/12 lost   median  9ms
```

Then four real `RTCPeerConnection`s, which turned up something the packet probe could not:

| iceServers | first srflx | gathering after 8s |
|---|---|---|
| both Google (**today's default**) | 78ms | **still gathering** |
| the blocked one alone | **never** | still gathering |
| the working one alone | 23ms | **complete** |
| + Cloudflare | 16ms | still gathering |

**An unreachable entry holds ICE gathering open.** It is not a wasted slot, it is a stall — which is the shape of the sixteen seconds in the report.

## The change

Default is now `stun.cloudflare.com` first, then both Google. Cloudflare because it was fastest from that network and, more to the point, because it is a **different operator**. Gryt has no TURN relay on purpose, which makes the reflexive candidate the whole ballgame; a list from one provider is one blocklist entry away from no voice at all.

Three files had the blocked host as the *only* STUN server — `dev.yml` twice and the Helm development example. On this network those produce no reflexive candidate whatsoever.

The reasoning is written into `ops/.env.example` and `ops/helm/gryt/values.yaml` so the next person does not tidy it back to one provider.

## Deploying

Nothing here changes a running deployment. There is no STUN line in `ops/.env` on the box, so pp/nt/prod are resolving the compose default today and pick this up on the next pull plus `up -d --no-deps <servers>`. That is your call, not mine.

## Also worth doing, and not in this PR

**The AdGuard block is still there.** This change routes around it; it does not fix it. `stun.l.google.com` will keep resolving to 0.0.0.0 on your network, which costs every WebRTC app on it — not just Gryt. An allowlist entry fixes that (`@@||stun.l.google.com^`), and per the notes `@@` beats `$important`. Your DNS, so I have not touched it.

## What I am not claiming

That this fully explains her failure. It explains the blocked server and the stalled gathering, both measured. It does not explain why `stun1` — which answers reliably in my probes — returned nothing on her first attempt specifically. One dropped UDP request with the redundant server blackholed is the most likely story, and this change is what makes that survivable rather than fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
