### PR TITLE
Embed the services matching the channel being released (GRYT-724)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -149,20 +149,45 @@ jobs:
           # that installing could never clear, because the next build was
           # untagged too. GRYT-306.
           #
-          # Stable tags only, deliberately, on every channel. A beta client is a
-          # beta of the client; embedding a prerelease of the media plane in it
-          # is a separate decision, and versionCheck resolves `latest` from the
-          # newest non-prerelease release, so a prerelease here would put the
-          # nag straight back.
+          # Which tag depends on the channel being released (GRYT-724). This
+          # used to be stable-only on every channel, so a beta of the client
+          # carried the newest stable server — and a feature whose halves land
+          # in the client and the server shipped a release apart. 1.7.0-beta.1
+          # went out with the role-gated call button from GRYT-712 and an
+          # embedded server that did not publish the permission it asks about.
+          #
+          # The comment here used to say a prerelease "would put the nag
+          # straight back", because versionCheck resolved `latest` from the
+          # newest non-prerelease release. GRYT-722 changed that: a server on a
+          # beta now places itself on the beta channel and compares against the
+          # newest beta, so the reason no longer holds.
+          if [[ "${{ github.event.inputs.channel }}" == "beta" ]]; then
+            # Plain releases too, so a stable newer than the last beta wins.
+            tag_pattern='v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?'
+          else
+            tag_pattern='v[0-9]+\.[0-9]+\.[0-9]+'
+          fi
+
           for path in packages/server packages/sfu packages/image-worker; do
             git -C "$path" fetch origin main --tags --force
 
-            tag=$(git -C "$path" tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
-              | grep -Ex 'v[0-9]+\.[0-9]+\.[0-9]+' \
-              | head -1)
+            # versionsort.suffix is what makes -v:refname semver precedence
+            # rather than string order. Measured on git 2.50.1: without it
+            # v1.6.15-beta.1 sorts above v1.6.15, so the beta would be picked
+            # over the release it led to. The stable-only filter used to hide
+            # that; it does not any more.
+            tag=$(git -C "$path" \
+                -c versionsort.suffix=-alpha \
+                -c versionsort.suffix=-beta \
+                -c versionsort.suffix=-rc \
+                tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+              | grep -Ex "$tag_pattern" \
+              | head -1 || true)
 
+            # `|| true` above because grep exits 1 on no match and pipefail is
+            # on, which killed the step before this guard could say why.
             if [[ -z "$tag" ]]; then
-              echo "::error::No stable release tag in $path. Release it before releasing the client."
+              echo "::error::No release tag in $path for the ${{ github.event.inputs.channel }} channel. Release it before releasing the client."
               exit 1
             fi
 


### PR DESCRIPTION
The other half of server#98. That fixed the parser; this stops a beta of the
client carrying a stable server.

## What was wrong

`release-client.yml` pinned the three embedded services to their newest stable
tag on every channel. So 1.7.0-beta.1 went out with the role-gated call button
from GRYT-712 and an embedded server from 27 August that does not publish the
permission the button asks about. A feature whose halves land in the client and
the server shipped a release apart.

The comment justifying it said a prerelease "would put the nag straight back",
because `versionCheck` resolved `latest` from the newest non-prerelease release.
GRYT-722 changed that, so the reason no longer holds and the comment now says
what actually applies.

## What changed

The tag pattern depends on the channel being dispatched. `latest` is stable only,
exactly as before. `beta` also accepts `-alpha.N`, `-beta.N` and `-rc.N`, and
still accepts plain releases so a stable newer than the last beta wins.

Tags rather than main is unchanged — that is what closed GRYT-306 and it should
stay.

## The bit worth checking

**`versionsort.suffix`.** Git's `-v:refname` is not semver precedence on its own.
Measured on git 2.50.1 with both tags present:

```
default                     with versionsort.suffix
v1.6.15-beta.1              v1.6.15
v1.6.15                     v1.6.15-rc.1
                            v1.6.15-beta.2
```

Without the config a beta sorts above the release it led to, so the beta channel
would keep embedding a prerelease after its stable shipped. The old stable-only
filter hid this; it does not any more, which is why the three `-c` flags are
there.

## Measured

Ran the selection against the real repositories, both channels:

| | latest | beta |
|---|---|---|
| server | v1.6.12 (7248046) | v1.6.15-beta.1 (06fe53e) |
| sfu | v1.0.57 (7bd718a) | v1.0.57 |
| image-worker | v1.2.2 (ad5d029) | v1.2.2 |

`latest` is identical to what 1.7.0-beta.1 actually shipped, so stable releases
are unaffected. On `beta` the server moves to the commit carrying GRYT-712 and
GRYT-717. The SFU and image worker fall back to stable because neither has a
newer prerelease, which is the intended behaviour rather than a gap.

Also changed `grep | head -1` to end in `|| true`. `pipefail` is on and grep exits
1 on no match, so the "release it before releasing the client" error was
unreachable — the step died first with no explanation.

YAML parses; the step is `Move release submodules into place`.

## What this does not do

Nothing reaches anyone until the next client release, and the SFU's GRYT-715
support still is not embedded on either channel because it sits on an untagged
commit. Tag the SFU if that should ship.

`describeVersion` in the client's `build-embedded-server.mjs` picks the highest
tag pointing at HEAD with a plain `--sort=-v:refname`, which has the same
prerelease ordering weakness. It only matters for a commit carrying both a
prerelease and a stable tag, which is rarer, but it becomes reachable now.
Filed separately rather than widened into here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
