### PR TITLE
Refuse a drafted note the range cannot support (GRYT-734)

### DIFF
--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -656,6 +656,12 @@ function prompt(release, changes, style) {
     'This is the house style guide, in full. Follow it. The voice section and',
     'the bullet rules matter most.',
     '',
+    'Its examples are illustrations of a shape, never sentences to reuse. A',
+    'draft was rejected for heading a section about importing themes with',
+    '"Everyone has a face, and you can give it a name" — the guide\'s own',
+    'example, and about avatars. Take the shape and write your own sentence',
+    'about the commits in front of you.',
+    '',
     style,
     '',
     '─────────────────────────────────────────────────────────────────────',
@@ -679,6 +685,15 @@ function prompt(release, changes, style) {
     'These are the commits it contains, grouped by component, and they are the',
     'only source for what this release changed. Commit bodies are included where',
     'the author wrote one, and are usually the best source for why.',
+    '',
+    'A commit with no body gives you its subject and nothing else. It does not',
+    'give you a symptom, a cause, a scope, or who it affected. Three drafts were',
+    'rejected for taking one: "fix themed titlebar and identity settings" became',
+    'a titlebar that showed the wrong colour "especially on systems with dark',
+    'mode enabled", and a second section about names reverting and avatars',
+    'disappearing when the app reopened. The range said none of that. Where the',
+    'body is missing, write the subject in a reader\'s words and stop, or put the',
+    'commit in "omitted" — a short honest note beats a full one that is invented.',
     '',
     COMMITS,
     '─────────────────────────────────────────────────────────────────────',
@@ -795,6 +810,10 @@ function prompt(release, changes, style) {
     'privacy change, and privacy goes in Security. It gets its own section, it',
     'is not folded into a list of fixes, and it is not softened into the app',
     'respecting your privacy - say what it used to do and who could see it.',
+    '',
+    'British English. Colour, minimise, recognise, behaviour, organise. Gryt is',
+    'written in it everywhere else, and a note in American spelling reads as',
+    'coming from somewhere other than the rest of the site.',
     '',
     'Plain sentences only. No markdown, no bold, no links, no headings inside a',
     'paragraph. The site renders the shape itself.',
@@ -1040,6 +1059,44 @@ async function ask(text) {
    note. The failure this guard exists for was a model retelling an example
    note wholesale, and an instruction to cut adverbs is not something there is
    a wrong way to copy. */
+/* A heading lifted out of the style guide.
+
+   The guide is pasted into the prompt in full so the model can follow it, which
+   also puts its illustrations in reach. A draft headed a section about importing
+   themes with "Everyone has a face, and you can give it a name" — the guide's own
+   example of a heading that is a sentence rather than a label, and about avatars.
+
+   `contamination` above will not see this: it counts distinctive words across the
+   whole note against a threshold of twenty, and a borrowed heading is nine words
+   of ordinary English. This is the exact-match case, which is cheap to ask about
+   and has no false positive worth worrying about — a heading that appears verbatim
+   in the guide came from the guide. */
+export function borrowedHeading(entry, styleText) {
+  if (!styleText) return null
+  const flat = (t) =>
+    t.toLowerCase().replace(/[^a-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim()
+
+  /* The guide's examples are quoted, which is what makes them findable. Three
+     words up, because shorter quotes in it are single terms like "Avatars" and
+     a heading is allowed to contain those. */
+  const quoted = [...styleText.matchAll(/[“"]([^”"]{12,120})[”"]/g)]
+    .map((m) => flat(m[1]))
+    .filter((q) => q.split(' ').length >= 3)
+
+  for (const heading of [entry.headline, ...entry.sections.map((s) => s.heading)]) {
+    const h = flat(heading ?? '')
+    if (!h) continue
+    /* `includes` both ways: the draft that prompted this took "Everyone has a
+       face" and added ", and you can give it a name", so neither string
+       contains the other whole. */
+    const lifted = quoted.find((q) => h.includes(q) || q.includes(h))
+    if (lifted) {
+      return `the heading "${heading}" is an example out of the style guide, not a sentence about these commits`
+    }
+  }
+  return null
+}
+
 export function contamination(entry, exampleText, commitText) {
   if (!exampleText) return null
   const words = (t) => new Set((t.toLowerCase().match(/[a-z][a-z-]{4,}/g) ?? []))
@@ -1215,6 +1272,25 @@ export function claimsSecurityIn(text) {
 /* Sentences that would sit unchanged in any other project's release notes.
    The style guide calls this the portability test; this is the short version
    of it, drawn from what the drafts actually produced. */
+/* Spellings that say the note came from somewhere other than the rest of the
+   site. Gryt is written in British English throughout — the style guide, the
+   hand-written notes, the UI strings — and four drafts running came back with
+   the American ones. A hard problem rather than a soft one: it is not a matter
+   of taste, and it reaches the page. Only the pairs a release note actually
+   reaches for; this is not a dictionary. */
+const AMERICAN = [
+  [/\bcolors?\b/i, 'colour'],
+  [/\bminimiz(e|ed|es|ing)\b/i, 'minimise'],
+  [/\brecogniz(e|ed|es|ing)\b/i, 'recognise'],
+  [/\bbehaviors?\b/i, 'behaviour'],
+  [/\borganiz(e|ed|es|ing|ation)\b/i, 'organise'],
+  [/\bcustomiz(e|ed|es|ing)\b/i, 'customise'],
+  [/\binitializ(e|ed|es|ing)\b/i, 'initialise'],
+  [/\banaly(z|zed|zes|zing)\b/i, 'analyse'],
+  [/\bcanceled\b/i, 'cancelled'],
+  [/\bcentered?\b/i, 'centred'],
+]
+
 const FILLER = [
   /this change is for you/i,
   /we('| a)re (excited|pleased|happy)/i,
@@ -1445,6 +1521,46 @@ export function styleProblems(entry, parts) {
     if (hit) {
       problems.push(soft(`filler: "${hit.match(pattern)[0]}"`))
       break
+    }
+  }
+
+  /* British English, everywhere a reader looks. */
+  for (const line of readerProse(entry)) {
+    const wrong = AMERICAN.find(([shape]) => shape.test(line))
+    if (wrong) {
+      problems.push(hard(`American spelling, "${line.match(wrong[0])[0]}" — Gryt writes "${wrong[1]}"`))
+      break
+    }
+  }
+
+  /* A release of subject lines cannot support a note that explains anything.
+
+     Three drafts running were written from ranges where every commit was a
+     subject and nothing else, and every one of them invented the part a body
+     would have carried. 1.6.10's only commit was "fix themed titlebar and
+     identity settings"; the draft gave it a dark-mode symptom and a second
+     section about names reverting and avatars disappearing on restart.
+
+     Structural rather than a word list: if nothing in the range says why, a
+     paragraph explaining why came from somewhere else. One sentence per
+     section is the most a subject line can honestly carry, so more than that
+     is the tell. The count is of sentences across the whole note rather than
+     per section, because the invention shows up as volume. */
+  const anyBody = (parts ?? []).some((part) =>
+    (part.commits ?? []).some((c) => (c.body ?? '').trim()),
+  )
+  if (!anyBody && entry.sections.length) {
+    const sentences = entry.sections
+      .flatMap((s) => s.body)
+      .join(' ')
+      .split(/[.!?]+\s/)
+      .filter((x) => x.trim().length > 20).length
+    if (sentences > entry.sections.length) {
+      problems.push(
+        hard(
+          `no commit in this release has a body, and the note explains it in ${sentences} sentences across ${entry.sections.length} section(s) — there is nothing in the range to explain it from`,
+        ),
+      )
     }
   }
 
@@ -1809,7 +1925,10 @@ async function main() {
 
       const commitText = JSON.stringify(changes.parts)
       const judge = (draft) => {
-        const shape = validate(draft) ?? contamination(draft, workedExample(REPO), commitText)
+        const shape =
+          validate(draft) ??
+          borrowedHeading(draft, style) ??
+          contamination(draft, workedExample(REPO), commitText)
         /* A draft of the wrong shape, or one retelling the example, is not a
            draft. Nothing below is worth reading about it. */
         if (shape) return [hard(shape)]

--- a/ops/internal/changelog-notes.test.mjs
+++ b/ops/internal/changelog-notes.test.mjs
@@ -1,0 +1,185 @@
+/* eslint-env node */
+
+/**
+ * The three refusals added for GRYT-734, against the drafts that caused them.
+ *
+ * Eleven drafts were waiting in `/admin/changelog` on 2026-08-30 and all eleven
+ * were rejected by hand. Six failed for reasons a check can state, and the
+ * fixtures below are those drafts cut down to the part that failed. Run it:
+ *
+ *     node ops/internal/changelog-notes.test.mjs
+ *
+ * The existing guards are not tested here. They were written against drafts
+ * nobody kept, and inventing fixtures for them would test the fixture.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { borrowedHeading, styleProblems } from "./changelog-notes.mjs";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const style = readFileSync(join(REPO, "patch-notes-style.md"), "utf8");
+
+const said = (problems, pattern) =>
+  problems.some((p) => pattern.test(p.text ?? p.message ?? String(p)));
+
+/* ── A heading lifted out of the style guide (1.5.7) ──────────────────── */
+
+// The guide offers "Everyone has a face" as an example of a heading that is a
+// sentence rather than a label. It is about avatars. The draft put it over a
+// section about importing a theme from a link, with a clause added on the end —
+// so neither string contains the other whole, which is why the match is both
+// ways round.
+assert.ok(
+  borrowedHeading(
+    {
+      headline: "Gryt now lets you save and switch between custom themes",
+      sections: [
+        { heading: "Everyone has a face, and you can give it a name", body: ["You can now import a theme by pasting a link."] },
+      ],
+    },
+    style,
+  ),
+  "a heading extending one of the guide's examples is still the guide's example",
+);
+
+// A heading of its own is left alone, including one that happens to share
+// ordinary words with the guide.
+assert.equal(
+  borrowedHeading(
+    {
+      headline: "Gryt now lets server hosts keep their assigned ports",
+      sections: [
+        { heading: "Servers keep the ports they were given, and report conflicts when they happen", body: ["A server keeps the ports it was given at creation."] },
+      ],
+    },
+    style,
+  ),
+  null,
+  "a heading written for the commits must pass",
+);
+
+/* ── A note explaining a release that has nothing to explain from (1.6.10) ─ */
+
+const bodiless = [{ commits: [{ subject: "fix themed titlebar and identity settings (#164)", body: "" }] }];
+
+// What the draft actually did: two sections, six sentences, a dark-mode symptom
+// and a story about names reverting on restart. The range says none of it.
+assert.ok(
+  said(
+    styleProblems(
+      {
+        headline: "Themed titlebars and identity settings now work properly",
+        intro: ["This release fixes two long-standing issues."],
+        sections: [
+          {
+            heading: "The app now keeps your theme settings in the titlebar",
+            body: [
+              "Previously the titlebar would often show the wrong background, especially on systems with dark mode enabled. This made the app feel disconnected from your system settings. Now the titlebar matches what you expect.",
+            ],
+          },
+          {
+            heading: "Your identity settings are saved and applied correctly",
+            body: [
+              "Before this change your name and avatar would sometimes be lost when you reopened the app. Your name might revert to a default. Now those settings are saved every time.",
+            ],
+          },
+        ],
+        recap: [],
+        omitted: [],
+      },
+      bodiless,
+    ),
+    /no commit in this release has a body/,
+  ),
+  "a bodiless range explained at length is invention",
+);
+
+// One sentence per section is what a subject line can carry, so the same range
+// written honestly has to pass.
+assert.ok(
+  !said(
+    styleProblems(
+      {
+        headline: "The themed titlebar and identity settings are fixed",
+        intro: ["One fix, and the commit does not say more than that."],
+        sections: [
+          { heading: "The themed titlebar and identity settings are fixed", body: ["The commit says both were fixed and does not say how."] },
+        ],
+        recap: [],
+        omitted: [],
+      },
+      bodiless,
+    ),
+    /no commit in this release has a body/,
+  ),
+  "a short honest note about a bodiless range must pass",
+);
+
+// And a range that does have bodies is none of this check's business, however
+// long the note is.
+assert.ok(
+  !said(
+    styleProblems(
+      {
+        headline: "Leaving a server now forgets it properly",
+        intro: ["Leaving a server used to leave traces behind."],
+        sections: [
+          {
+            heading: "Leaving a server no longer leaves behind identity links or access tokens",
+            body: ["Leaving removed it from the sidebar and left the pinned identity. That mattered because removeServer is what drops the tokens. Matching is on the server id now."],
+          },
+        ],
+        recap: [],
+        omitted: [],
+      },
+      [{ commits: [{ subject: "Leaving a server forgets it (GRYT-233)", body: "Deleting a hosted server removed the rail entry keyed on its loopback address and nothing else." }] }],
+    ),
+    /no commit in this release has a body/,
+  ),
+  "a range with bodies can be explained at any length",
+);
+
+/* ── American spelling (1.5.10, and four others in the queue) ─────────── */
+
+const withBody = [{ commits: [{ subject: "Keep the titlebar on Gryt's own palette", body: "The titlebar followed the theme." }] }];
+
+for (const [wrong, right] of [
+  ["The titlebar would show the wrong background color.", "colour"],
+  ["Voice detection stopped when you minimize the window.", "minimise"],
+  ["The server would not recognize the identity.", "recognise"],
+  ["This changes the behavior of the mute button.", "behaviour"],
+]) {
+  assert.ok(
+    said(
+      styleProblems(
+        { headline: "A fix", intro: [wrong], sections: [{ heading: "A fix landed", body: [wrong] }], recap: [], omitted: [] },
+        withBody,
+      ),
+      /American spelling/,
+    ),
+    `"${wrong}" should be refused in favour of ${right}`,
+  );
+}
+
+assert.ok(
+  !said(
+    styleProblems(
+      {
+        headline: "A fix",
+        intro: ["The titlebar keeps its own colour now."],
+        sections: [{ heading: "The titlebar keeps its own colour", body: ["It no longer follows the theme."] }],
+        recap: [],
+        omitted: [],
+      },
+      withBody,
+    ),
+    /American spelling/,
+  ),
+  "British spelling must pass",
+);
+
+console.log("changelog-notes checks: ok");


### PR DESCRIPTION
I reviewed the eleven drafts waiting in `/admin/changelog` and rejected all of
them. This is the part of that worth fixing in code: six failed for reasons a
check can state, and three of those were one bug.

## What was wrong

**It writes sections from commits that have no body.** 1.6.7, 1.6.10 and 1.6.14
are drafted from ranges where every commit is a subject line and nothing else.
Each invented the part a body would have carried. 1.6.10's only commit is
`fix themed titlebar and identity settings (#164)`, and the draft gave it a
symptom — the wrong colour *"especially on systems with dark mode enabled"* —
and a second section about names reverting and avatars disappearing on restart.
Nothing in the range says any of it.

The prompt said bodies are "usually the best source for why" and never said what
to do when there is none.

**It reuses the guide's example headings.** 1.5.7 headed a section about
importing themes from a link with *"Everyone has a face, and you can give it a
name"* — `patch-notes-style.md`'s own illustration of a heading that is a
sentence rather than a label, and about avatars. The guide is pasted into the
prompt in full, so its examples are in reach as content.

**It writes American spellings.** `color`, `minimize`, `recognize`, `behavior`,
in five of the twenty-six entries.

## What changed

Three rules in the prompt, and three refusals beside the existing checks.

The invention one is the part worth looking at. It is structural rather than a
word list: if nothing in the range says why, then a paragraph saying why came
from somewhere else. So a bodiless range explained in more sentences than it has
sections is refused. One sentence per section is what a subject line can honestly
carry, and a short honest note about a bodiless range still passes.

`contamination` does not cover the borrowed heading — it counts distinctive words
across the whole note against a threshold of twenty, and a lifted heading is nine
words of ordinary English. The new check is exact-match against the guide's quoted
examples, both directions, because the draft took "Everyone has a face" and added
a clause so neither string contains the other whole.

## Measured

Run over the 26 entries currently in the queue, the three refuse 9 — including
all four inventions (1.6.7, 1.6.9, 1.6.10, 1.6.14), the borrowed heading, and
five spelling cases. 1.6.23, the one draft I thought was close to publishable,
passes all three.

`ops/internal/changelog-notes.test.mjs` covers them against the drafts that caused
them, with the fixtures cut down from the real entries. Each assertion fails with
its check removed — I checked all three by disabling them one at a time.

    node ops/internal/changelog-notes.test.mjs

## What this does not fix

The other five rejections were voice and shape — marketing lines, a section
carrying four unrelated fixes under a heading about a fifth, a source filename in
the recap. The prompt already covers all of that; the model is not following it,
and more prompt is not obviously the answer.

Worth deciding separately whether some of these releases should get a note at
all. 1.6.5 duplicates the hand-written 1.6.0 note, which already covers the
portable guest identity, the clock skew message and the issuer qualification.
The guide says a release with nothing above Under the hood should be skipped, and
the drafter has no way to conclude that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
