### PR TITLE
Refuse an American spelling in Under the hood too (GRYT-755)

### DIFF
--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -1524,8 +1524,19 @@ export function styleProblems(entry, parts) {
     }
   }
 
-  /* British English, everywhere a reader looks. */
-  for (const line of readerProse(entry)) {
+  /* British English, everywhere — including Under the hood.
+
+     `readerProse` drops that recap group because identifiers are allowed in it,
+     and this check reused it at first. A spelling is not an identifier: a reader
+     reads Under the hood, and "consistent behavior" in it is as wrong as it
+     would be anywhere else. A draft got through with exactly that (GRYT-755). */
+  const everyLine = [
+    entry.headline,
+    ...entry.intro,
+    ...entry.sections.flatMap((s) => [s.heading, ...s.body]),
+    ...entry.recap.flatMap((g) => [g.group, ...g.items]),
+  ]
+  for (const line of everyLine) {
     const wrong = AMERICAN.find(([shape]) => shape.test(line))
     if (wrong) {
       problems.push(hard(`American spelling, "${line.match(wrong[0])[0]}" — Gryt writes "${wrong[1]}"`))

--- a/ops/internal/changelog-notes.test.mjs
+++ b/ops/internal/changelog-notes.test.mjs
@@ -165,6 +165,31 @@ for (const [wrong, right] of [
   );
 }
 
+/* An American spelling in Under the hood is still an American spelling.
+
+   `readerProse` drops that group so identifiers can live in it, and the check
+   reused it at first. The 1.6.18 draft got through with "consistent behavior"
+   as an Under the hood recap line (GRYT-755). */
+assert.ok(
+  said(
+    styleProblems(
+      {
+        headline: "Popups now appear above dialogs",
+        intro: ["Two fixes to the interface."],
+        sections: [{ heading: "Dropdowns inside modals are visible again", body: ["They were behind the dialog."] }],
+        recap: [
+          { group: "Interface", items: ["Dropdowns inside modals are visible again"] },
+          { group: "Under the hood", items: ["Moved camera cleanup into a single function to ensure consistent behavior"] },
+        ],
+        omitted: [],
+      },
+      withBody,
+    ),
+    /American spelling/,
+  ),
+  "Under the hood is read by the same reader as everything else",
+);
+
 assert.ok(
   !said(
     styleProblems(


### PR DESCRIPTION
A gap in what I shipped in gryt#150, found by the next draft the box produced.

## What was wrong

The British-spelling refusal scanned `readerProse(entry)`, which drops the Under
the hood recap group on purpose — that exclusion exists so identifiers like a
package name are allowed in the one place the guide permits them.

A spelling is not an identifier. A reader reads Under the hood like everything
else, so an American spelling in it should be refused like any other.

The 1.6.18 draft, written about twenty minutes after #150 landed on the box, came
back with this and the check passed it:

    Under the hood
      - Moved camera cleanup logic into a single function to ensure consistent behavior

## What changed

The spelling check scans every line of the note. `readerProse` still backs the
identifier check, where the exclusion is correct.

## Checked

A case from that exact draft is in `ops/internal/changelog-notes.test.mjs`. Put
the old scope back and it fails; `node .github/scripts/check-changelog-style.mjs`
is still "All good" against the hand-written notes.

## Note on the draft itself

1.6.18 is rejected, for that spelling and for the same recap line being explained
in the article directly above it — Under the hood is for what a reader cannot
see, and that had just been explained to them. Its facts were right, which is
worth saying: the two commits both have bodies and the note follows them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
