### PR TITLE
Publish sums and an attestation with every client release (GRYT-723)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -33,6 +33,12 @@ on:
 permissions:
   contents: write
   packages: write
+  # Both for `actions/attest-build-provenance`, which signs a statement about
+  # this build into sigstore's public transparency log (GRYT-723). `id-token`
+  # is how the runner proves to sigstore which workflow it is, and
+  # `attestations` is what lets it store the result against this repository.
+  id-token: write
+  attestations: write
 
 concurrency:
   # Shared with release-server.yml on purpose. Both workflows commit to the same
@@ -1298,6 +1304,122 @@ jobs:
           fi
 
           echo "All expected assets present."
+
+      # Something to check a download against, and something that is not just
+      # Sivert saying so (GRYT-723).
+      #
+      # The desktop app is signed and notarised, which stops a chat server
+      # reaching it, and until now that was the whole of the story: no hashes
+      # were published anywhere, so there was nothing to compare a download to
+      # even for somebody who wanted to.
+      #
+      # Here rather than in each build leg, because the sums have to cover the
+      # assets as they are on the release — after `electron-builder` has
+      # uploaded them and after the macOS leg has clobbered its own. A hash
+      # taken before the upload describes a file nobody downloads.
+      - name: Download the assets and write SHA256SUMS
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          TAG="v$VERSION"
+          mkdir -p dist
+
+          gh release download "$TAG" --repo "$OWNER/$REPO" --dir dist --clobber
+
+          # Removed rather than skipped. A re-run of this job would otherwise
+          # hash the previous run's sums into the new file, and the line would
+          # be wrong the moment the file is rewritten.
+          rm -f dist/SHA256SUMS.txt
+
+          cd dist
+          # A glob rather than `ls`, so a filename with a space in it stays one
+          # argument. Globs come out sorted, which keeps the file stable between
+          # runs and makes a diff between two releases only the lines that moved.
+          sha256sum -- * > ../SHA256SUMS.txt
+          mv ../SHA256SUMS.txt .
+
+          echo "Sums:"
+          sed 's/^/  /' SHA256SUMS.txt
+
+      # An attestation is the part that is not a promise. It says, in a public
+      # append-only log run by somebody who is not us, that these exact bytes
+      # came out of this workflow at this commit. A self-published hash next to
+      # a self-published binary proves only that the two were made by the same
+      # person; this is what a reader can check without trusting that person.
+      #
+      # `@gryt/voice` has done this on npm since GRYT-344, so the mechanism is
+      # already proven in this org. It was simply never on the client, which is
+      # the artifact anybody actually runs.
+      - name: Attest the release artifacts
+        uses: actions/attest-build-provenance@v4
+        with:
+          # Every installer, plus the sums file. Attesting the sums covers the
+          # blockmaps and the three channel `.yml` files transitively — they are
+          # listed in it, so a statement about it is a statement about them.
+          subject-path: |
+            dist/*.exe
+            dist/*.AppImage
+            dist/*.deb
+            dist/*.snap
+            dist/*.dmg
+            dist/*.zip
+            dist/SHA256SUMS.txt
+
+      - name: Upload SHA256SUMS
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh release upload "v$VERSION" dist/SHA256SUMS.txt \
+            --repo "$OWNER/$REPO" --clobber
+
+      - name: Say how to check a download
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          TAG="v$VERSION"
+
+          # Appended to whatever the notes already say rather than replacing
+          # them. They are generated from the manifest earlier in the release
+          # and this runs after that.
+          gh release view "$TAG" --repo "$OWNER/$REPO" --json body --jq .body > notes.md
+
+          # `printf` rather than a heredoc. Everything in this file is indented
+          # to sit inside a YAML block scalar, and a heredoc terminator has to
+          # start at column zero — `NOTES` at this indentation is not a
+          # terminator, so the whole block runs to end of file and the word
+          # itself lands in the release notes. One argument per line has no
+          # such rule.
+          printf '%s\n' \
+            "" \
+            "---" \
+            "" \
+            "### Checking this download" \
+            "" \
+            "\`SHA256SUMS.txt\` on this release has a hash for every file here." \
+            "" \
+            '```' \
+            "sha256sum --check --ignore-missing SHA256SUMS.txt" \
+            '```' \
+            "" \
+            "Every artifact is attested too, so you can check it came out of this" \
+            "repository rather than only that it matches a hash we published" \
+            "ourselves." \
+            "" \
+            '```' \
+            "gh attestation verify <file> --repo $OWNER/$REPO" \
+            '```' \
+            >> notes.md
+
+          gh release edit "$TAG" --repo "$OWNER/$REPO" --notes-file notes.md
 
       - name: Publish the release
         shell: bash


### PR DESCRIPTION
The desktop app is signed and notarised, which stops a chat server reaching it,
and that was the whole of the story. `release-client.yml` published no hashes at
all, so somebody who wanted to check a download had nothing to check it against.

Encryption takes the server out of the trusted set and leaves the client in it.
No protocol removes it — the client sees plaintext before any of this runs and
holds the keys — so what can change is whether "trust the client" is a promise or
something anybody can check.

## The two halves, and what each is worth

`SHA256SUMS.txt` is worth less than it looks. A hash published next to the binary
by the same person proves the two were made together; it catches a broken
download and nothing else.

The attestation is the half that is not a promise. `actions/attest-build-provenance`
signs a statement into Sigstore's public transparency log saying these exact bytes
came out of this workflow at this commit. `@gryt/voice` has done this on npm since
GRYT-344, so the mechanism is already proven in this org — it was simply never on
the artifact anybody actually runs.

Attesting `SHA256SUMS.txt` covers the blockmaps and the three channel `.yml` files
transitively: they are lines in it, so a statement about it is a statement about
them.

## Where it goes

In `publish-release` rather than in each build leg, because the sums have to
cover the assets as they are on the release — after `electron-builder` has
uploaded them and after the macOS leg has clobbered its own. A hash taken before
the upload describes a file nobody downloads.

## What to look at

**A release workflow cannot be dry-run, so I ran the shell.** Two bugs came out
of that, both of which would have shipped:

`sha256sum $(ls | sort)` splits a filename with a space in it into two arguments.
It is `sha256sum -- *` now, tested against `Gryt 1.0.0 mac.zip`.

The release-notes append was a heredoc, and everything in this file is indented
to sit inside a YAML block scalar. A heredoc terminator has to start at column
zero, so `NOTES` at this indentation is not a terminator: bash warns, the block
runs to end of file, and the word `NOTES` lands in the published release notes.
It is `printf` with one argument per line now, and the output was checked
character for character.

**`gh release download --clobber` pulls everything on the tag.** That includes
`manifest.json`, which is release metadata rather than an artifact. It ends up in
the sums, which I think is right — it is a file on the release and a reader can
check it — but it is a judgement call.

**Whether the notes edit is safe to re-run.** It reads the current body and
appends, so running `publish-release` twice would append the section twice. The
job only runs once per release today; it would matter if it were ever retried by
hand.

`v4`, not `v2` — the action is on v4.2.2.

Docs half: [docs#83](https://github.com/Gryt-chat/docs/pull/83).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>