### PR TITLE
Add packages/crypto, and stop keeping the submodule list twice (GRYT-732)

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -40,6 +40,7 @@ on:
           - mobile
           - bot
           - reports
+          - crypto
 
 permissions:
   contents: write
@@ -93,7 +94,28 @@ jobs:
         run: |
           set -euo pipefail
 
-          SUBMODULES="packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice packages/mobile packages/bot packages/reports"
+          # Read out of `.gitmodules` rather than written down here, and shared
+          # with the commit step through `$GITHUB_ENV` rather than written down
+          # there as well.
+          #
+          # There used to be two hand-kept copies of this list, and they drifted
+          # twice by the same route: a submodule added to one and not the other.
+          # `mobile` first, then `reports`. The symptom is nasty — the list in
+          # the commit step is only used when a push is rejected and the commit
+          # is rebuilt, so the missing submodule's bump is silently dropped on
+          # exactly the runs nobody is watching, and everything looks fine
+          # otherwise. `.gitmodules` is the file that already decides what a
+          # submodule is.
+          SUBMODULES="$(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' \
+            | awk '{ print $2 }' | sort | tr '\n' ' ')"
+
+          if [[ -z "${SUBMODULES// /}" ]]; then
+            echo "::error::No submodules found in .gitmodules."
+            exit 1
+          fi
+
+          echo "Submodules: $SUBMODULES"
+          echo "SUBMODULES=$SUBMODULES" >> "$GITHUB_ENV"
 
           # Clone straight from the URL rather than `git submodule update`,
           # which insists on the recorded gitlink and so fails on a broken one.
@@ -210,6 +232,10 @@ jobs:
             update_submodule "packages/reports" "$DEFAULT_SUBMODULE_BRANCH"
           fi
 
+          if [[ "$SELECTED" == "all" || "$SELECTED" == "crypto" ]]; then
+            update_submodule "packages/crypto" "$DEFAULT_SUBMODULE_BRANCH"
+          fi
+
       - name: Commit changes
         shell: bash
         run: |
@@ -240,10 +266,11 @@ jobs:
             git fetch origin "$TARGET_BRANCH"
             git reset --hard "origin/$TARGET_BRANCH"
 
-            # Every submodule, not most of them. mobile was missing, so a
-            # rejected push rebuilt the commit without it and silently dropped
-            # whatever bump had just been made.
-            for path in packages/client packages/server packages/sfu packages/image-worker packages/docs packages/site packages/auth packages/ui packages/cli packages/voice packages/mobile packages/bot; do
+            # `$SUBMODULES` comes from `.gitmodules` by way of `$GITHUB_ENV`,
+            # set in "Initialize top-level submodules". It was a second
+            # hand-kept copy of that list until GRYT-732, and it had already
+            # drifted twice — see the note where it is built.
+            for path in $SUBMODULES; do
               [[ -d "$path" ]] || continue
               git -C "$path" fetch origin main
               git -C "$path" checkout -B main origin/main

--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,7 @@
 	path = packages/reports
 	url = https://github.com/Gryt-chat/reports.git
 	branch = main
+[submodule "packages/crypto"]
+	path = packages/crypto
+	url = https://github.com/Gryt-chat/crypto.git
+	branch = main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ these paths, but they never merge without Sivert reading the whole diff:
 ```
 packages/sfu/**                                    # WebRTC media plane, RTP, ICE, SVC
 packages/auth/**                                   # identity certificate authority
+packages/crypto/**                                 # message encryption, published to npm
 packages/image-worker/**                           # decodes untrusted uploads
 packages/reports/**                                # public POST endpoint, stranger-written input
 packages/server/src/auth/**                        # challenge-response, JWT validation
@@ -37,6 +38,12 @@ Rules for these paths:
 - **Don't bundle *unrelated* edits.** A change here shouldn't carry along a docs typo or a
   CI tweak. The other half of the same fix is not unrelated — that belongs with it, or in
   its own PR opened at the same time and cross-linked. Don't drop it.
+
+`packages/crypto` is published to npm, which none of the others are. A change there
+becomes what the desktop app and the phone both do the next time either pins a new version,
+and a published version cannot be taken back the way a commit can. It is also the only
+place where getting the bytes wrong makes messages already sent unreadable rather than
+making the next one fail.
 
 Three of these look like exceptions but aren't:
 


### PR DESCRIPTION
`@gryt/crypto` is the message encryption both clients run, moved out of the
client so there is one implementation rather than two. It has been its own
repository since yesterday and was not a submodule, so the superproject had no
gitlink for it and `Update Submodules` had never heard of it.

## The review-required list

`packages/crypto/**` goes on it, and `guide/ai.mdx` gains the same row in
[docs#84](https://github.com/Gryt-chat/docs/pull/84). The two drifting apart is
the failure this repository is most exposed to, and this is exactly the change
that would cause it.

The paragraph next to it says the two things that are true of this path and not
of the others. Both apps run it, and it is published to npm, so a mistake is a
mistake in both at once and a published version cannot be taken back the way a
commit can.

## And the list that was written down twice

`Update Submodules` kept the set of submodules in two places: `SUBMODULES` in the
initialise step, and a second copy in the retry loop of the commit step.

They have drifted twice, both times by the same route — added to one and not the
other. `mobile` first, which the comment there already records, and `reports`,
which was still missing when I went to add `crypto`.

That list is only read when a push is rejected and the commit is rebuilt, so a
missing submodule silently loses its bump on exactly the runs nobody is watching,
and every other run looks fine. Adding a third careful comment did not seem like
the answer.

`SUBMODULES` now comes out of `.gitmodules` — the file that already decides what
a submodule is — and reaches the commit step through `$GITHUB_ENV`. Both
hand-kept lists are gone.

## What to look at

**The derivation, which I ran rather than read.** Against the real `.gitmodules`
it produces 14 paths: the hand-written list plus `crypto`. The `$GITHUB_ENV` line
is a single-line assignment, so it does not need the heredoc delimiter form. It
exits non-zero if `.gitmodules` yields nothing, rather than looping over an empty
list and reporting success.

**The dropdown and the per-submodule `if` blocks are still by hand.** Those are
genuinely per-submodule rather than a copy of a set, so `crypto` is added to both
in the ordinary way. If you would rather the whole step were generated, that is a
bigger change than this one.

**The gitlink points at `crypto`'s `main` as of now**, which is crypto#1 merged.
Nothing in the superproject builds from it — the clients pull the published
package — so the gitlink is a record rather than a dependency.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>