### PR TITLE
Attest the server release and both container images (GRYT-760)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1041,6 +1041,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Build and push Docker image
+        id: docker
         if: runner.os == 'Linux'
         working-directory: packages/client
         shell: bash
@@ -1081,6 +1082,12 @@ jobs:
           # release and not just the tag — this job failing skips Publish
           # release, and the release then sits as a draft nobody can install.
           # Layer cache makes a second attempt cheap.
+          # The digest is written out so the image can be attested by it
+          # (GRYT-760). GRYT-723 attested the installers on the release and left
+          # this, which is the version of the client anybody self-hosting the
+          # web build actually runs.
+          METADATA="${RUNNER_TEMP}/buildx-metadata.json"
+
           pushed=""
           for attempt in 1 2 3 4 5; do
             if docker buildx build \
@@ -1088,6 +1095,7 @@ jobs:
               --cache-from type=registry,ref=${IMAGE}:buildcache \
               --cache-to type=registry,ref=${IMAGE}:buildcache,mode=max \
               "${ARGS[@]}" \
+              --metadata-file "$METADATA" \
               --push \
               .
             then
@@ -1103,6 +1111,26 @@ jobs:
             echo "Could not build and push the image after 5 attempts." >&2
             exit 1
           fi
+
+          DIGEST="$(jq -r '."containerimage.digest" // empty' "$METADATA")"
+          if [[ -z "$DIGEST" ]]; then
+            echo "::error::buildx wrote no containerimage.digest — nothing to attest."
+            exit 1
+          fi
+
+          echo "Image digest: $DIGEST"
+          echo "image_digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Attest the client image
+        if: runner.os == 'Linux'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.DOCKER_IMAGE }}
+          subject-digest: ${{ steps.docker.outputs.image_digest }}
+          # Stored alongside the image in GHCR as well as in the log, so
+          # `gh attestation verify oci://...` works without knowing which
+          # repository built it.
+          push-to-registry: true
 
       - name: Package and publish Electron app
         if: runner.os != 'macOS'
@@ -1416,6 +1444,13 @@ jobs:
             "" \
             '```' \
             "gh attestation verify <file> --repo $OWNER/$REPO" \
+            '```' \
+            "" \
+            "So is the web client image, which is what you get if you host Gryt" \
+            "yourself rather than installing the app:" \
+            "" \
+            '```' \
+            "gh attestation verify oci://$DOCKER_IMAGE:$VERSION --repo $OWNER/$REPO" \
             '```' \
             >> notes.md
 

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -51,6 +51,13 @@ on:
 permissions:
   contents: write
   packages: write
+  # Both for `actions/attest-build-provenance`, which signs a statement about
+  # this build into sigstore's public transparency log (GRYT-760, after
+  # GRYT-723 did the same for the client). `id-token` is how the runner proves
+  # to sigstore which workflow it is, and `attestations` is what lets it store
+  # the result against this repository.
+  id-token: write
+  attestations: write
 
 concurrency:
   # Shared with release-client.yml on purpose. Both workflows commit to the same
@@ -445,6 +452,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Build and push server Docker image
+        id: docker
         if: github.event.inputs.push_docker == 'true'
         working-directory: packages/server
         shell: bash
@@ -480,12 +488,19 @@ jobs:
           # push is usually GitHub's secondary rate limit, and this job failing
           # costs the whole release rather than the one tag that was refused.
           # See v1.5.0-beta.1, where the client image went up half published.
+          # The digest is written out so the image can be attested by it
+          # (GRYT-760). `subject-path` is for files; a registry image is named
+          # by its digest, and this build does not go through
+          # `docker/build-push-action`, which would have emitted one.
+          METADATA="${RUNNER_TEMP}/buildx-metadata.json"
+
           pushed=""
           for attempt in 1 2 3 4 5; do
             if docker buildx build \
               --platform linux/amd64,linux/arm64 \
               --build-arg VERSION="$VERSION" \
               "${ARGS[@]}" \
+              --metadata-file "$METADATA" \
               --push \
               .
             then
@@ -501,6 +516,32 @@ jobs:
             echo "Could not build and push the image after 5 attempts." >&2
             exit 1
           fi
+
+          DIGEST="$(jq -r '."containerimage.digest" // empty' "$METADATA")"
+          if [[ -z "$DIGEST" ]]; then
+            echo "::error::buildx wrote no containerimage.digest — nothing to attest."
+            exit 1
+          fi
+
+          echo "Image digest: $DIGEST"
+          echo "image_digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      # Says, in a log run by somebody who is not us, that this image came out
+      # of this workflow at this commit. An operator can check it before pulling
+      # something onto a machine they run:
+      #
+      #   gh attestation verify oci://ghcr.io/gryt-chat/server:1.6.4 \
+      #     --repo Gryt-chat/gryt
+      - name: Attest the server image
+        if: github.event.inputs.push_docker == 'true'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.SERVER_IMAGE }}
+          subject-digest: ${{ steps.docker.outputs.image_digest }}
+          # Stored alongside the image in GHCR as well as in the log, so
+          # `gh attestation verify oci://...` works without knowing which
+          # repository built it.
+          push-to-registry: true
 
       - name: Build Windows self-hosted server bundle
         if: github.event.inputs.build_windows == 'true'
@@ -637,6 +678,8 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           BUILD_WINDOWS: ${{ github.event.inputs.build_windows }}
           BUILD_LINUX: ${{ github.event.inputs.build_linux }}
+          PUSH_DOCKER: ${{ github.event.inputs.push_docker }}
+          SERVER_IMAGE: ${{ env.SERVER_IMAGE }}
         shell: bash
         run: |
           set -euo pipefail
@@ -701,6 +744,48 @@ jobs:
           fi
 
           node .github/scripts/release-notes.mjs "${ARGS[@]}" > "${RUNNER_TEMP}/release-notes.md"
+
+          # How to check what you just downloaded, or what you are about to pull
+          # onto a machine you run (GRYT-760).
+          #
+          # `printf` with one argument per line rather than a heredoc.
+          # Everything here is indented to sit inside a YAML block scalar, and a
+          # heredoc terminator has to start at column zero — an indented one is
+          # not a terminator, the block runs to end of file, and the word itself
+          # lands in the release notes. That is not hypothetical; it happened
+          # while writing the client's half of this.
+          {
+            printf '%s\n' \
+              "" \
+              "---" \
+              "" \
+              "### Checking this release" \
+              "" \
+              "\`SHA256SUMS.txt\` has a hash for every file here." \
+              "" \
+              '```' \
+              "sha256sum --check --ignore-missing SHA256SUMS.txt" \
+              '```' \
+              "" \
+              "Every file is attested as well, so you can check it came out of this" \
+              "repository rather than only that it matches a hash we published" \
+              "ourselves." \
+              "" \
+              '```' \
+              "gh attestation verify <file> --repo ${RELEASE_OWNER}/gryt" \
+              '```'
+
+            if [[ "$PUSH_DOCKER" == "true" ]]; then
+              printf '%s\n' \
+                "" \
+                "So is the image:" \
+                "" \
+                '```' \
+                "gh attestation verify oci://${SERVER_IMAGE}:${VERSION} --repo ${RELEASE_OWNER}/gryt" \
+                '```'
+            fi
+          } >> "${RUNNER_TEMP}/release-notes.md"
+
           cat "${RUNNER_TEMP}/release-notes.md"
 
       - name: Commit monorepo release state
@@ -830,6 +915,32 @@ jobs:
             ASSETS+=("packages/server/dist-selfhosted/gryt-server-linux-x64-v${VERSION}.zip")
           fi
 
+          # Something to check a download against (GRYT-760, after GRYT-723 did
+          # the same for the client). A self-hosted bundle is a file somebody
+          # downloads and runs on a machine they own, so it gets what the
+          # desktop app gets.
+          #
+          # The assets are staged into one directory first, because the sums
+          # have to name the files the way somebody who downloaded them has
+          # them — bare, in whatever folder they landed in. Written with the
+          # paths they have here, `sha256sum --check` would look for
+          # `packages/server/dist-selfhosted/` and find nothing.
+          STAGE="${RUNNER_TEMP}/assets"
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE"
+          cp -- "${ASSETS[@]}" "$STAGE/"
+
+          # `--` and a glob rather than `ls`, so a filename with a space in it
+          # stays one argument. Globs come out sorted, which keeps the file
+          # stable between runs.
+          ( cd "$STAGE" && sha256sum -- * > "${RUNNER_TEMP}/SHA256SUMS.txt" )
+          cp "${RUNNER_TEMP}/SHA256SUMS.txt" "$STAGE/"
+
+          echo "Sums:"
+          sed 's/^/  /' "${RUNNER_TEMP}/SHA256SUMS.txt"
+
+          ASSETS+=("${RUNNER_TEMP}/SHA256SUMS.txt")
+
           FLAGS=()
           if [[ "$CHANNEL" == "beta" ]]; then
             FLAGS+=(--prerelease)
@@ -843,6 +954,15 @@ jobs:
             --notes-file "${RUNNER_TEMP}/release-notes.md" \
             "${FLAGS[@]}" \
             "${ASSETS[@]}"
+
+      # Attesting the sums file covers `manifest.json` transitively: it is a
+      # line in it, so a statement about the sums is a statement about it.
+      - name: Attest the self-hosted bundles
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            packages/server/dist-selfhosted/*.zip
+            ${{ runner.temp }}/SHA256SUMS.txt
 
       - name: Notify Discord
         shell: bash


### PR DESCRIPTION
GRYT-723 put sums and an attestation on the desktop installers. Three shipped
artifacts were left: the self-hosted server bundles, the server image, and the
client image.

The bundles are files somebody downloads and runs on a machine they own, so they
get exactly what the desktop app gets — a `SHA256SUMS.txt` on the release and an
attestation per file. Attesting the sums covers `manifest.json` transitively,
since it is a line in it.

The two images are named by digest rather than by path, so they take
`subject-digest`. Neither build goes through `docker/build-push-action`, which
would have emitted one, so both now pass `--metadata-file` and read
`containerimage.digest` out of it. `push-to-registry: true` stores the
attestation next to the image in GHCR, so `gh attestation verify oci://…` works
without knowing which repository built it.

The client image is in here rather than in its own change because it is the same
three lines, and leaving one of three images unattested is the shape of gap this
task exists to close. It is also the version of the client anybody self-hosting
the web build actually runs.

## What to look at

**`--repo Gryt-chat/gryt`, including for the server.** The server release lives
in `Gryt-chat/server`, but the workflow that builds it runs here, and an
attestation names the repository that made it. Anybody who assumes otherwise
gets a verification failure that reads like a bad artifact. The release notes
say it, and so does [docs#85](https://github.com/Gryt-chat/docs/pull/85).

**The digest step fails the release when `containerimage.digest` is missing.**
Deliberate: silently skipping the attestation leaves an image published and
unattested, which is worse than a failed release, and the image is already
pushed by that point either way. If you would rather it warned, that is a
one-line change.

**`release-server.yml` is CRLF.** Rewriting it through anything that normalises
line endings turns a 120-line diff into a 1960-line one nobody can review. The
diff here is 121 added lines and nothing else; worth confirming that is what you
see.

## Found by running the shell rather than reading it

The sums have to name files the way somebody who downloaded them has them. The
assets sit at `packages/server/dist-selfhosted/…` on the runner and `sha256sum`
writes whatever path it is given, so a downloader running `sha256sum --check` in
the folder they saved to would get "no such file" for every line. The assets are
staged into one directory and summed there. Checked end to end against real
files, including the check side.

`printf` with one argument per line for the notes, not a heredoc — everything is
indented to sit inside a YAML block scalar and a heredoc terminator has to start
at column zero, so an indented one is not a terminator: the block runs to end of
file and the word itself lands in the release notes. That happened while writing
GRYT-723; the comment now says so in both files.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>