### PR TITLE
Stop cutting the changelog drafter off mid-release (GRYT-763)

### DIFF
--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -54,7 +54,10 @@
 //                          reads what is written there.
 //   OLLAMA_URL             Default http://127.0.0.1:11434
 //   OLLAMA_MODEL           Default llama3.1:8b
-//   OLLAMA_TIMEOUT_MS      Default 180000
+//   OLLAMA_TIMEOUT_MS      Default 3600000
+//   OLLAMA_RETRY_DELAY_MS  How long to wait before the one retry of a
+//                          request that never reached the model. Default
+//                          60000.
 //   OLLAMA_NUM_CTX         The context window to ask Ollama for. Default
 //                          32768. Not optional in practice: Ollama's own
 //                          default is 4096 and this prompt is past that, so
@@ -1036,6 +1039,47 @@ async function ask(text) {
   }
 }
 
+/* Read when it is used rather than at load, unlike the other settings here.
+   A minute of real sleeping in a test is a test nobody runs, and the file is
+   imported once per process, so a module-level const cannot be turned down
+   afterwards. */
+const retryDelayMs = () => Number(process.env.OLLAMA_RETRY_DELAY_MS ?? 60_000)
+
+/* Whether the request never reached the model at all.
+   Undici throws a bare `TypeError: fetch failed` for this, which is the same
+   shape whether the host is down, the connection dropped, or — the case that
+   actually happens here — no response headers arrived within five minutes.
+   That five minutes is undici's own `headersTimeout`, not OLLAMA_TIMEOUT_MS,
+   and the comment above `ask` is right that streaming avoids it for
+   generation: Ollama sends headers before the first token. It does not send
+   them while the request is queued behind somebody else's, and this box shares
+   its model.
+   An error that came back *from* the model — a non-2xx, or an `error` field in
+   the stream — is not this. Those mean the model answered, and answered badly,
+   and asking again unchanged is not going to help. */
+export function neverReachedTheModel(err) {
+  return err instanceof TypeError && /fetch failed/i.test(err.message ?? '')
+}
+
+/* One retry, because losing the release costs an hour and the retry costs a
+   minute.
+   Before this, a thrown error broke out of the attempt loop and `continue`d to
+   the next release, so a five-minute queue meant that release got no note for
+   the whole cycle. On 2026-08-30 that skipped 1.6.43 outright. Once, not in a
+   loop: if the model is genuinely unreachable, the next timer run is a better
+   place to find that out than a retry spiral inside one. */
+export async function askWithRetry(text) {
+  try {
+    return await ask(text)
+  } catch (err) {
+    if (!neverReachedTheModel(err)) throw err
+    const delay = retryDelayMs()
+    log(`  · ${err.message} — never reached the model, retrying once in ${Math.round(delay / 1000)}s`)
+    await new Promise((resolve) => setTimeout(resolve, delay))
+    return ask(text)
+  }
+}
+
 /* Words that belong to the material shown to the model and to nothing in this
    release.
    The example is there to show the shape, and a model that has just read a
@@ -1963,7 +2007,7 @@ async function main() {
       const history = []
       for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
         try {
-          entry = await ask(
+          entry = await askWithRetry(
             attempt === 1 ? text : text + retryPrompt(entry, problems.map((p) => p.text)),
           )
         } catch (err) {

--- a/ops/internal/changelog-notes.test.mjs
+++ b/ops/internal/changelog-notes.test.mjs
@@ -18,7 +18,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { borrowedHeading, styleProblems } from "./changelog-notes.mjs";
+import { askWithRetry, borrowedHeading, neverReachedTheModel, styleProblems } from "./changelog-notes.mjs";
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const style = readFileSync(join(REPO, "patch-notes-style.md"), "utf8");
@@ -206,5 +206,65 @@ assert.ok(
   ),
   "British spelling must pass",
 );
+
+/* ── One retry when the request never reached the model (GRYT-763) ────── */
+
+// Undici throws a bare TypeError for a request that got no reply, including
+// the five-minute headersTimeout that skipped 1.6.43 on 2026-08-30. An error
+// the model sent back is a different thing and must not be retried: asking the
+// same question again unchanged will get the same answer.
+assert.equal(neverReachedTheModel(new TypeError("fetch failed")), true, "a transport failure is one");
+assert.equal(neverReachedTheModel(new Error("ollama 500 boom")), false, "a status from the model is not");
+assert.equal(
+  neverReachedTheModel(Object.assign(new Error("aborted"), { name: "AbortError" })),
+  false,
+  "our own OLLAMA_TIMEOUT_MS abort is not — the model had its time and used it",
+);
+
+// Nothing here should sleep for the real minute.
+process.env.OLLAMA_RETRY_DELAY_MS = "0";
+
+const answering = () => ({
+  ok: true,
+  body: (async function* () {
+    yield Buffer.from(`${JSON.stringify({ message: { content: '{"ok":true}' } })}\n`);
+  })(),
+});
+
+const realFetch = globalThis.fetch;
+const countingFetch = (behaviour) => {
+  const state = { calls: 0 };
+  globalThis.fetch = async () => {
+    state.calls += 1;
+    return behaviour(state.calls);
+  };
+  return state;
+};
+
+try {
+  // Fails once, then answers. Two calls, and the answer comes back.
+  let state = countingFetch((n) => {
+    if (n === 1) throw new TypeError("fetch failed");
+    return answering();
+  });
+  assert.deepEqual(await askWithRetry("hello"), { ok: true }, "the retry's answer is returned");
+  assert.equal(state.calls, 2, "one retry, so two calls");
+
+  // Fails twice. One retry, not a spiral: the next timer run is a better place
+  // to discover the model is gone.
+  state = countingFetch(() => {
+    throw new TypeError("fetch failed");
+  });
+  await assert.rejects(askWithRetry("hello"), TypeError, "the transport error is rethrown");
+  assert.equal(state.calls, 2, "it gives up after one retry");
+
+  // A model-side error is passed straight out, untouched.
+  state = countingFetch(() => ({ ok: false, status: 500, text: async () => "boom" }));
+  await assert.rejects(askWithRetry("hello"), /ollama 500/, "a model error is rethrown as it was");
+  assert.equal(state.calls, 1, "and is not retried");
+} finally {
+  globalThis.fetch = realFetch;
+  delete process.env.OLLAMA_RETRY_DELAY_MS;
+}
 
 console.log("changelog-notes checks: ok");

--- a/ops/internal/systemd/gryt-changelog-notes.service
+++ b/ops/internal/systemd/gryt-changelog-notes.service
@@ -48,7 +48,20 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
 
-# A 32b model on CPU is minutes per release, and a first run with a backlog is
-# several of them in a row. Longer than the timer interval on purpose; systemd
-# leaves a running oneshot alone when the timer next fires.
-TimeoutStartSec=7200
+# Longer than the timer interval on purpose; systemd leaves a running oneshot
+# alone when the timer next fires.
+#
+# This was 7200, written when nobody had timed the model and the guess was
+# "minutes per release". Measured on dev.lan on 2026-08-30, 1.6.39 took 1h54m:
+# roughly forty minutes per attempt, and up to three attempts. So one release
+# could consume the whole window, and three runs in a row died at exactly two
+# hours — 1.6.51 was cut off mid-draft after two attempts. Finished releases
+# survive, because each is posted before the next one starts; the one in flight
+# does not.
+#
+# Six hours fits three or four releases, which is what a backlog run needs.
+# Still bounded rather than infinite: every model call carries its own
+# AbortController on OLLAMA_TIMEOUT_MS, so a genuinely stuck run is not what
+# this is protecting against — it is the backstop for something nothing else
+# anticipated.
+TimeoutStartSec=21600


### PR DESCRIPTION
Two timeouts, both written before anybody had timed the model, both cutting the drafter off mid-work. Found while getting the timer running again after it had been stopped since 29 August.

## 1. Every run was killed at exactly two hours

```
15:07:05  Starting…
17:07:06  start operation timed out. Terminating.  → Failed with result 'timeout'
17:07:06  Starting…
19:07:07  start operation timed out. Terminating.  → Failed with result 'timeout'
```

`TimeoutStartSec=7200`, explained in the unit as "longer than the timer interval" on the assumption a release takes "minutes". **1.6.39 took 1h54m** — attempt 1 at 17:41, attempt 2 at 18:20, accepted at 19:01. Roughly forty minutes per attempt, up to three attempts, so one release can eat the whole window. `1.6.51` was cut off mid-draft after two attempts.

Finished releases were never at risk; each is posted before the next starts. The one in flight was thrown away every two hours, and the unit reported `failed` each time.

Six hours fits three or four releases. Still bounded rather than infinite — every model call carries its own `AbortController` on `OLLAMA_TIMEOUT_MS`, so this is only the backstop.

## 2. A dropped request cost the release its note

```
15:27:13  prompt 39.0 kB, about 9989 tokens of 24576
15:32:13  ! model failed: fetch failed
```

**Exactly 300 seconds** — undici's `headersTimeout`, not `OLLAMA_TIMEOUT_MS`. The comment above `ask()` is right that streaming avoids that for generation, because Ollama sends headers before the first token. It does not send them while the request is queued behind another one, and that box shares its model. In the attempt loop a thrown error did `break` and then `continue`, so `1.6.43` was skipped outright.

## What to look at

**Why a retry and not a bigger timeout.** Raising `headersTimeout` needs an undici `Agent`, and this file deliberately has no dependencies outside `node:` builtins — `changelog-style.yml` has no install step precisely so it fails if that stops being true. A retry needs nothing.

**What is deliberately not retried**, and this is the part I'd check hardest:

- a non-2xx, or an `error` field in the stream — the model answered, and answered badly. Asking again unchanged gets the same answer.
- our own `AbortError` — it had its time and used it.

Only a bare `TypeError: fetch failed` counts, which is what undici throws when nothing came back.

**Once, not in a loop.** If the model is genuinely unreachable, the next timer run is a better place to discover that than a spiral inside this one.

**One thing changed shape**: the retry delay is read at call time rather than as a module-level const, unlike every other setting in the file. Without that a test either sleeps for a real minute or cannot reach the value, because the module is imported once per process. Reasoning is in a comment at the definition.

## Checks

- `node ops/internal/changelog-notes.test.mjs` — passes, including the existing GRYT-734 fixtures. New cases: the predicate against all three error shapes, one retry then success, giving up after one retry, and a model error passing straight through untouched.
- **Verified the tests can fail.** Replaced `if (!neverReachedTheModel(err)) throw err` with a bare `throw err` and the suite exits 1; restored, exits 0.
- `check-changelog-style.mjs` run against the patched drafter in a scratch tree, with `packages/site/content/changelog` populated from `origin/main` rather than from a working copy. All four hand-written notes pass, all the bad drafts still caught.

## Deploying

Needs root on dev.lan, so it is yours:

```
git pull && sudo systemctl daemon-reload
```

The unit file is copied into `/etc/systemd/system`, not symlinked, so it needs recopying — step in `ops/internal/README.md`. The running job keeps the old timeout until it ends.

Closes GRYT-763.
