### PR TITLE
Refuse a paragraph the intro already said (GRYT-778)

### DIFF
--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -1478,6 +1478,33 @@ export function styleProblems(entry, parts) {
     problems.push(soft('every recap line is one of the section headings again'))
   }
 
+  /* A body paragraph that is already in the intro.
+
+     1.6.42 opened its only section with a word-for-word copy of its own intro
+     paragraph, and 1.6.41 did the same with two words changed. It reads as a
+     note twice as long as it is, and the second copy is always the one that
+     could have said something new.
+
+     `overlap` is content-word based, so a verbatim copy scores 1.0 and a
+     reworded one still scores high. The threshold is measured rather than
+     guessed: across the four notes written by hand the highest any intro
+     paragraph scores against any body paragraph is 0.607 — 1.7.0 restating
+     that direct messages are not encrypted, which is repetition on purpose
+     and must stay allowed. 1.6.42's copy scored 0.810. 0.75 sits between
+     them with room either side.
+
+     Short paragraphs are skipped: two eight-word sentences about the same
+     feature will legitimately share most of their words. */
+  const paragraphs = entry.sections.flatMap((s) => s.body)
+  for (const intro of entry.intro) {
+    if (contentWords(intro).size < 12) continue
+    const copy = paragraphs.find((body) => overlap(intro, body) >= 0.75)
+    if (copy) {
+      problems.push(soft(`a paragraph repeats the intro: "${copy.slice(0, 60)}"`))
+      break
+    }
+  }
+
   /* Security is its own section when there is security in the release, and no
      section at all when there is not. The prompt used to say "always", which
      is a shape to fill rather than a fact to report. */

--- a/ops/internal/changelog-notes.test.mjs
+++ b/ops/internal/changelog-notes.test.mjs
@@ -267,4 +267,75 @@ try {
   delete process.env.OLLAMA_RETRY_DELAY_MS;
 }
 
+/* ── A body paragraph copied out of the intro (GRYT-778) ─────────────── */
+
+// 1.6.42 opened its only section with its own intro paragraph, two words
+// changed. The threshold is measured, not guessed: 0.607 is the highest any
+// hand-written note scores (1.7.0 restating that DMs are not encrypted, which
+// is deliberate), and that copy scored 0.810.
+const copied = {
+  headline: "Voice tiles take their colour from the owl on them",
+  intro: [
+    "Before this release there was a mismatch between how you saw your avatar and how everyone else saw it, because the app used two different ways to pick the colour of your tile.",
+  ],
+  sections: [
+    {
+      heading: "The tile and the owl agree now",
+      body: [
+        "Before this release there was a mismatch between how you saw your avatar and how everyone else saw it, because the app picked the colour of your tile two different ways.",
+        "Both now read the same nickname and the same worn look, so the tile is the colour of the owl sitting on it.",
+      ],
+    },
+  ],
+  recap: [{ group: "Avatars and images", items: ["Voice tiles take their colour from the owl on them"] }],
+  omitted: [],
+};
+
+assert.ok(
+  said(styleProblems(copied, withBody), /repeats the intro/),
+  "a section paragraph that restates the intro is caught",
+);
+
+// The same note with the second copy replaced by something that says
+// anything new must pass. This is the half that stops the rule being a
+// blanket ban on mentioning a subject twice.
+assert.ok(
+  !said(
+    styleProblems(
+      { ...copied, sections: [{ ...copied.sections[0], body: copied.sections[0].body.slice(1) }] },
+      withBody,
+    ),
+    /repeats the intro/,
+  ),
+  "a section that does not restate the intro passes",
+);
+
+// 1.7.0 repeats the not-encrypted warning between intro and body on purpose,
+// and scores 0.607. Deliberate repetition of a caveat has to stay allowed.
+assert.ok(
+  !said(
+    styleProblems(
+      {
+        headline: "You can message one person instead of a channel",
+        intro: [
+          "Direct messages are not encrypted yet. Whoever runs the server can read them, the same as any channel, and Gryt says so above the box you type into rather than letting a conversation that looks private stand in for a private one.",
+        ],
+        sections: [
+          {
+            heading: "What this does not do",
+            body: [
+              "Direct messages are not encrypted. They are stored on the server like any other message and whoever runs it can read them. The notice above the composer says so and links to the documentation.",
+            ],
+          },
+        ],
+        recap: [{ group: "Voice", items: ["Ring somebody from a direct message"] }],
+        omitted: [],
+      },
+      withBody,
+    ),
+    /repeats the intro/,
+  ),
+  "a caveat repeated on purpose is not a copied paragraph",
+);
+
 console.log("changelog-notes checks: ok");


### PR DESCRIPTION
Two checks were asked for. **One ships, one was written and thrown away** — the second half is the more useful finding.

## What ships: a body paragraph that repeats the intro

1.6.42 opened its only section with its own intro paragraph, two words changed. 1.6.41 did the same. Nothing compared the two halves of a note against each other, so both passed every check and reached the queue.

**The threshold is measured, not picked.** Across the four notes written by hand, the highest any intro paragraph scores against any body paragraph is **0.607** — 1.7.0 restating that direct messages are not encrypted, which is deliberate and has to stay allowed. 1.6.42's copy scored **0.810**. 0.75 sits between them with room either side.

`soft`, not `hard`: saying a thing twice makes a note worse, not wrong.

## What to look at

**The 1.7.0 case is pinned as passing.** There's a test asserting that a caveat repeated on purpose between intro and body is *not* flagged, so a later tightening of the number can't quietly ban it. That's the test I'd try to break.

**The short-paragraph guard.** Intros under 12 content words are skipped — two brief sentences about the same feature legitimately share most of their words. Worth checking that 12 isn't too low.

## What was thrown away, and why

Four of eight drafts filed a recap item under a group it has nothing to do with: a macOS app icon under `Hosting`, a proxy scheme fix under `Updates`, not retrying an identity renewal under `Security`.

I wrote the rule — a marker vocabulary per group, firing when an item matches nothing from its own group and something from another. It caught 1.6.41 and 1.6.43. It also failed the house notes:

```
✗ 1.4.0  [Voice]    "Tiles are tinted from the colour of your avatar…"
✗ 1.4.0  [Emoji]    "Clearing a server icon takes effect straight away…"
✗ 1.7.0  [Hosting]  "The emoji upload limit is the one you set"
✗ 1.7.0  [Security] "Animated server icons have a frame cap"
```

All four are filed correctly and each mentions another group's noun exactly once — as do both real misfiles. Requiring two markers spares the house notes and loses the bugs. **Which group an item belongs in is its subject, not its nouns**, and a bag of words cannot see the difference. Deleted rather than shipped, since a rule that refuses 1.4.0 and 1.7.0 is a rule that gets turned off.

**And a correction to the task**: it guessed the eight groups were missing a category for 1.6.33's clock item. They aren't. The prompt already permits a new label and names `Joining` as one the hand-written notes use, so the model had somewhere to put it and reached for `Updates` anyway. That's a judgement failure, not a gap in the list — which is also why the prompt already explaining `Updates` at length hasn't fixed it.

## Checks

- `node ops/internal/changelog-notes.test.mjs` passes, including the existing GRYT-734 and GRYT-763 fixtures.
- **Verified the new test can fail**: set the threshold to an unreachable value and the suite exits 1; restored, exits 0.
- `check-changelog-style.mjs` run in a scratch tree against `origin/main`'s notes rather than a working copy — all four hand-written notes clean, all bad-draft fixtures still caught.
- Fires on the real draft it was written for: 1.6.42 from the 2026-08-31 batch.

Closes GRYT-778.
