### PR TITLE
Name the SFU's settings in compose, and scrape metrics on their own port (GRYT-741, GRYT-769)

### DIFF
--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -73,6 +73,9 @@ services:
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       ICE_UDP_MUX_PORT: ${ICE_UDP_MUX_PORT:-4443}
       ICE_ADVERTISE_IP: ${ICE_ADVERTISE_IP:-}
+      DISABLE_STUN: ${DISABLE_STUN:-false}
+      SFU_REQUIRE_CLIENT_TOKEN: ${SFU_REQUIRE_CLIENT_TOKEN:-}
+      SFU_METRICS_PORT: ${SFU_METRICS_PORT:-9091}
     networks:
       - gryt-beta
     restart: unless-stopped
@@ -120,6 +123,7 @@ services:
       SERVER_DESCRIPTION: ${SERVER_DESCRIPTION:-A Gryt voice chat server (beta)}
       SERVER_PASSWORD: ${SERVER_PASSWORD:-}
       MDNS_INTERFACE: ${MDNS_INTERFACE:-}
+      METRICS_PORT: ${METRICS_PORT:-9091}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3667,https://app.gryt.chat,https://beta.gryt.chat}
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env}
       SFU_WS_HOST: ws://sfu:${SFU_PORT:-5015}

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -68,6 +68,8 @@ services:
       ICE_UDP_MUX_PORT: ${ICE_UDP_MUX_PORT:-3478}
       ICE_ADVERTISE_IP: ${ICE_ADVERTISE_IP:-}
       DISABLE_STUN: ${DISABLE_STUN:-false}
+      SFU_REQUIRE_CLIENT_TOKEN: ${SFU_REQUIRE_CLIENT_TOKEN:-}
+      SFU_METRICS_PORT: ${SFU_METRICS_PORT:-9091}
       MAX_PEERS: ${MAX_PEERS:-}
     networks:
       - gryt-prod
@@ -108,6 +110,7 @@ services:
       SERVER_DESCRIPTION: ${SERVER_DESCRIPTION:-A Gryt voice chat server}
       SERVER_PASSWORD: ${SERVER_PASSWORD:-}
       MDNS_INTERFACE: ${MDNS_INTERFACE:-}
+      METRICS_PORT: ${METRICS_PORT:-9091}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,https://app.gryt.chat}
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env}
       SFU_WS_HOST: ws://sfu:${SFU_PORT:-5005}
@@ -408,12 +411,16 @@ services:
         global:
           scrape_interval: 15s
         scrape_configs:
+          # 9091, not 5000. Metrics moved off the port the world talks to, so
+          # that a deployment behind a reverse proxy or a tunnel does not serve
+          # its Prometheus register to strangers. Reached over the Compose
+          # network, so the port is deliberately not published.
           - job_name: gryt-server
             static_configs:
-              - targets: ["server:5000"]
+              - targets: ["server:${METRICS_PORT:-9091}"]
           - job_name: gryt-sfu
             static_configs:
-              - targets: ["sfu:5005"]
+              - targets: ["sfu:${SFU_METRICS_PORT:-9091}"]
         CFG
         exec /bin/prometheus --config.file=/tmp/prometheus.yml
     networks:


### PR DESCRIPTION
Pairs with [server#108](https://github.com/Gryt-chat/server/pull/108) and [sfu#28](https://github.com/Gryt-chat/sfu/pull/28), both merged. **Deploy this one first** — it only sets variables an older build ignores, whereas landing the code first leaves Prometheus scraping a port with nothing on it.

## Three variables that did nothing

Each was found the same way: by setting it and watching nothing happen. A container gets the environment the `environment:` block builds, not the file `--env-file` points at.

| Variable | Was named in |
|---|---|
| `DISABLE_STUN` | `prod.yml` only, never `beta.yml` (GRYT-769) |
| `SFU_REQUIRE_CLIENT_TOKEN` | neither |
| `METRICS_PORT` / `SFU_METRICS_PORT` | new, needed for the port move |

## Metrics move off the public port

Both scrape targets become `:9091` on the Compose network. The published-port lists are **deliberately untouched** — not publishing that port is the entire mechanism, so a reverse proxy or tunnel in front of the stack cannot pass `/metrics` through.

## What to look at

- **`SFU_REQUIRE_CLIENT_TOKEN` now defaults to empty**, which the SFU reads as unset and therefore *requires* tokens. That is the intended default after sfu#27. It only matters during a staged upgrade, where an operator sets it false deliberately.
- The scrape config is generated inline in `prod.yml` via a heredoc; I changed the two `targets` lines and nothing structural, but heredocs inside compose are easy to break subtly.

## How this happened, since it is worth not repeating

All three variables were applied by hand on the prod box during this morning's rollout and never reached the repository. That left every other deployment without them, and left the box's own checkout carrying uncommitted edits — which blocked `gryt-pull-superproject` for eleven commits before another agent noticed. The edits are reverted on the box now and come back through this PR instead.

The underlying problem is structural: `/home/sivert/gryt` is both the deploy source and a live config directory, so any hand-edit silently stops it updating. Worth either teaching the pull to ignore `ops/deploy/compose/`, or moving deployed overrides out of the tracked tree. Not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)