### PR TITLE
Read the reason a draft was refused, and say it (GRYT-781)

### DIFF
--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -913,8 +913,48 @@ function prompt(release, changes, style) {
  * is what let 1.5.5 reach 30,130 tokens against a window of 24,576 with its
  * body cap working exactly as written.
  */
-function promptFor(release, changes, style) {
-  const skeleton = prompt(release, changes, style)
+/**
+ * What a person said when they refused the last draft of this release.
+ *
+ * Kept apart from `retryPrompt`, which carries the rules a draft broke inside
+ * one run. This is a different thing and reads differently: a person read a
+ * finished note, said what was wrong with it in their own words, and asked for
+ * another. Pasting it in among "Previously twice" would file a judgement as a
+ * lint.
+ *
+ * Only the reason, never the refused draft. `retryPrompt` hands back the
+ * previous answer because it wants the good parts kept; this does not, because
+ * the draft it refers to was written from the same commits and starting again
+ * from those is the point. Showing it would invite a light edit of a note
+ * somebody already turned down.
+ */
+export function refusalBlock(refusal) {
+  const reason = String(refusal ?? '').trim()
+  if (!reason) return ''
+  return [
+    '',
+    '─────────────────────────────────────────────────────────────────────',
+    'YOUR LAST NOTE FOR THIS RELEASE WAS READ BY A PERSON AND REFUSED',
+    '',
+    'They said:',
+    '',
+    `  ${reason}`,
+    '',
+    'Write this release again from the commits above, with that fixed. It is',
+    'the only feedback you have and it is worth more than a guess at what',
+    'else might be wrong: change what they named and leave the rest of your',
+    'judgement alone.',
+    '',
+  ].join('\n')
+}
+
+function promptFor(release, changes, style, refusal) {
+  /* Added before the allowance is worked out, not after, so the commit block
+     is asked to fit in what is left rather than in the whole window. It is a
+     few hundred characters against twenty-four thousand tokens, but the whole
+     of one release was a silent overflow and the way to not repeat that is to
+     let nothing sit outside the arithmetic. */
+  const skeleton = prompt(release, changes, style) + refusalBlock(refusal)
   const room = (OLLAMA_NUM_CTX - ANSWER_RESERVE) * 4
   const allowance = Math.max(0, Math.floor((room - (skeleton.length - COMMITS.length)) * COMMIT_SHARE))
 
@@ -1899,6 +1939,26 @@ async function alreadyDrafted() {
   return { unreachable: last }
 }
 
+/**
+ * Why each version's last draft was refused, if reports can say.
+ *
+ * Absent on an older reports, which answers 404 for an endpoint it has never
+ * heard of. That is not a failure: a draft written without the feedback is the
+ * behaviour of every run before this existed, and refusing to draft because a
+ * nicety is missing would trade a note for nothing. Same for a timeout.
+ */
+async function priorFeedback() {
+  try {
+    const { feedback } = await reports('/v1/changelog/feedback')
+    return feedback && typeof feedback === 'object' ? feedback : {}
+  } catch (err) {
+    if (!/reports 404/.test(err.message)) {
+      log(`! could not read what was refused (${err.message}) — drafting without it`)
+    }
+    return {}
+  }
+}
+
 async function postDraft(entry) {
   const query = REDRAFT === entry.version ? '?force=1' : ''
   return reports(`/v1/changelog${query}`, {
@@ -1957,6 +2017,10 @@ async function main() {
     log(`drafting ${REDRAFT} again, replacing the draft reports already has`)
   }
 
+  const refused = DRY_RUN || DUMP ? {} : await priorFeedback()
+  const refusedCount = Object.keys(refused).length
+  if (refusedCount) log(`${refusedCount} release(s) carry a reason they were refused`)
+
   let wrote = 0
   for (const channel of CHANNELS) {
     const inChannel = all.filter((r) => r.channel === channel)
@@ -1982,7 +2046,10 @@ async function main() {
       if (!count) { log(`${release.version}: nothing user-visible since ${prev.version}, skipping`); continue }
 
       log(`${release.version}: ${count} commits since ${prev.version}`)
-      const text = promptFor(release, changes, style)
+      if (refused[release.version]) {
+        log(`  refused before: ${refused[release.version].slice(0, 100)}`)
+      }
+      const text = promptFor(release, changes, style, refused[release.version])
 
       /* Say how big the prompt is, every time.
          The whole of this release was one silent overflow: num_ctx defaulted

--- a/ops/internal/changelog-notes.test.mjs
+++ b/ops/internal/changelog-notes.test.mjs
@@ -18,7 +18,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { askWithRetry, borrowedHeading, neverReachedTheModel, styleProblems } from "./changelog-notes.mjs";
+import { askWithRetry, borrowedHeading, neverReachedTheModel, refusalBlock, styleProblems } from "./changelog-notes.mjs";
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const style = readFileSync(join(REPO, "patch-notes-style.md"), "utf8");
@@ -337,5 +337,23 @@ assert.ok(
   ),
   "a caveat repeated on purpose is not a copied paragraph",
 );
+
+/* ── The reason a person refused the last draft (GRYT-781) ────────────── */
+
+// Rejecting a draft has always meant "write it again". Until this it did not
+// mean "and here is what was wrong": the reason sat in reports and reached
+// nobody, so 1.6.41 was refused for its recap group and came back with the
+// same group, and "The fixes are subtle but important" was refused on one
+// release and reappeared verbatim on the next.
+const refused = refusalBlock("The recap files a proxy fix under Updates.");
+assert.match(refused, /REFUSED/, "the block says the last note was refused");
+assert.match(refused, /The recap files a proxy fix under Updates\./, "and carries the reason verbatim");
+
+// A version nobody has refused adds nothing at all. The block is concatenated
+// onto every prompt, so an empty one has to be genuinely empty rather than a
+// heading with nothing under it.
+assert.equal(refusalBlock(undefined), "", "no refusal is no block");
+assert.equal(refusalBlock(null), "", "null is no block");
+assert.equal(refusalBlock("   "), "", "a refusal with nothing typed in it is no block");
 
 console.log("changelog-notes checks: ok");


### PR DESCRIPTION
The consumer half of GRYT-781. The other half is [reports#25](https://github.com/Gryt-chat/reports/pull/25), which exposes the endpoint. **These can merge in either order** — this tolerates a 404.

## Why

Rejecting a drafted note is how you ask for another one. The reason has never travelled: it goes into `changelog_drafts.note`, is rendered in `/admin/plain/changelog`, and is read by nothing else. Each redraft is an independent redraw of the same commit range.

**Thirty-three reasons written across three review rounds on 30–31 August, none of which the model saw.** Which faults recur says exactly this:

- `1.6.41` refused for filing a proxy fix under the `Updates` recap group → redraft has `Updates`, unchanged.
- `"The fixes are subtle but important"` refused on `1.6.43` → came back verbatim on `1.6.38`.
- `1.6.34` refused for leaving out push-to-talk → **came back fixed**, because coverage is mechanical and reaches the model through `retryPrompt`.

The mechanical half of the loop closes. The human half doesn't.

## What to look at

**Why it isn't just another `retryPrompt` reason.** `retryPrompt` carries rules a draft broke inside one run — "Previously twice", a heading repeating the headline. This is a person who read a finished note and said what was wrong in their own words. Pasting one in among the other would file a judgement as a lint, so it gets its own block and its own framing.

**It deliberately does *not* hand back the refused draft**, which is the opposite of what `retryPrompt` does. `retryPrompt` shows the previous answer because it wants the good parts kept and the named thing fixed. Here the refused draft came from the same commits and starting again from those is the point — showing it invites a light edit of something a person already turned down. I'd argue about this one if you disagree.

**Budget.** The block is concatenated onto the skeleton *before* the commit allowance is computed, so the commit block is asked to fit in what's left rather than in the whole window. A few hundred characters against 24,576 tokens is nothing, but a whole release once went out as a silent context overflow, and the fix for that class is to leave nothing outside the arithmetic.

**A missing endpoint is not a failure.** An older reports answers 404 and the run drafts without feedback — which is what every run did before this existed. Refusing to draft over a missing nicety would trade a note for nothing. A 404 is silent; anything else is logged once.

## Checks

- `node ops/internal/changelog-notes.test.mjs` passes, including the GRYT-734, 763, 778 and 779 fixtures.
- Four new cases: the block carries the reason verbatim and says it was refused; `undefined`, `null` and whitespace all produce the empty string. That last group matters because the block is concatenated onto *every* prompt — an "empty" one that was a heading with nothing under it would go out on every release.
- **Verified the tests can fail**: removed the empty guard and the suite exits 1; restored, exits 0.
- `check-changelog-style.mjs` run in a scratch tree against `origin/main`'s notes — all four hand-written notes clean, all bad-draft fixtures still caught.

## After both merge

The thirty-three reasons already sitting in reports become input on the next tick, with no backfill needed — they are keyed by version and the drafter asks per version.

Closes GRYT-781.
