### PR TITLE
Stamp every draft with the commit that wrote it (GRYT-780)

### DIFF
--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -190,6 +190,37 @@ const RUNUSER = (() => {
   return null
 })()
 
+/**
+ * The commit this drafter is running from, short.
+ *
+ * `ExecStartPre` pulls the checkout before every run and is allowed to fail —
+ * a network blip should not cost a release its note. The cost is that a
+ * checkout which quietly stops updating writes notes judged by rules that are
+ * no longer the rules, and nothing about the note says so. Three times in
+ * three days: a read-only filesystem, DNS, and a local edit the pull was right
+ * to refuse, which left it eleven commits behind.
+ *
+ * Worked out once per run and put on every draft, so "was this written by the
+ * rules that are on main?" is answerable from the review page rather than from
+ * the journal.
+ *
+ * Undefined rather than a guess when git cannot answer. A tarball with no
+ * `.git` is a legitimate way to run this, and refusing to draft over a missing
+ * label would trade a note for nothing.
+ */
+export function drafterRevision() {
+  try {
+    return sh('git', ['-C', REPO, 'rev-parse', '--short', 'HEAD'], { stdio: 'pipe' }) || undefined
+  } catch {
+    return undefined
+  }
+}
+
+/* Once per process. The checkout cannot move under a run: `ExecStartPre` has
+   already finished by the time this file is read, and a run that took six
+   hours still wrote every one of its notes from this commit. */
+const REVISION = drafterRevision()
+
 function sh(cmd, args, opts = {}) {
   const [run, argv] = owner && RUNUSER
     ? [RUNUSER, ['-u', owner.name, '--', 'env', `HOME=${owner.home}`, cmd, ...args]]
@@ -2182,6 +2213,7 @@ async function main() {
           since: prev.version,
           commits: count,
           model: OLLAMA_MODEL,
+          revision: REVISION,
           /* Which parts of Gryt moved, in the order the manifest lists them.
              Straight off the diff, so there is nothing here for a model to get
              wrong, and the page can answer "is this just the app?" without the

--- a/ops/internal/changelog-notes.test.mjs
+++ b/ops/internal/changelog-notes.test.mjs
@@ -14,11 +14,12 @@
  */
 
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { askWithRetry, borrowedHeading, neverReachedTheModel, refusalBlock, styleProblems } from "./changelog-notes.mjs";
+import { askWithRetry, borrowedHeading, drafterRevision, neverReachedTheModel, refusalBlock, styleProblems } from "./changelog-notes.mjs";
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const style = readFileSync(join(REPO, "patch-notes-style.md"), "utf8");
@@ -355,5 +356,28 @@ assert.match(refused, /The recap files a proxy fix under Updates\./, "and carrie
 assert.equal(refusalBlock(undefined), "", "no refusal is no block");
 assert.equal(refusalBlock(null), "", "null is no block");
 assert.equal(refusalBlock("   "), "", "a refusal with nothing typed in it is no block");
+
+/* ── The commit the drafter is running from (GRYT-780) ────────────────── */
+
+// ExecStartPre pulls the checkout and is allowed to fail, so a run can write
+// notes against rules that are no longer the rules. Three times in three days.
+// The commit goes on every draft so that question is answerable from the
+// review page rather than from the journal.
+const gitSays = execFileSync("git", ["-C", REPO, "rev-parse", "--short", "HEAD"], {
+  encoding: "utf8",
+}).trim();
+
+assert.equal(
+  drafterRevision(),
+  gitSays,
+  "the drafter reports the commit it is actually running from",
+);
+
+// Not a placeholder, not an empty string: absent is what a tarball with no
+// .git should produce, and a draft is worth posting without the label.
+assert.ok(
+  drafterRevision() === undefined || /^[0-9a-f]{7,}$/.test(drafterRevision()),
+  "a revision is a commit or nothing at all",
+);
 
 console.log("changelog-notes checks: ok");


### PR DESCRIPTION
The consumer half. [reports#26](https://github.com/Gryt-chat/reports/pull/26) adds the field; **these merge in either order** because it's optional there.

## Why

`ExecStartPre` pulls the drafter's checkout before every run and is allowed to fail — deliberately, so a network blip doesn't cost a release its note. The cost is invisible staleness:

```
2026-08-27  error: cannot open '.git/FETCH_HEAD': Read-only file system
2026-08-28  fatal: ... Could not resolve host: github.com   (twice)
2026-08-31  /home/sivert/gryt has local changes outside packages/ — leaving it alone
```

The last left it **eleven commits behind**, and was a correct refusal — real deployment edits in `ops/deploy/compose/`.

On 30 August this cost an afternoon and a wrong hypothesis. Six drafts in the queue broke rules that were on `main` at the time; working out that an older copy had written them meant reading the journal, the unit file and the pull script. **The draft said nothing.** Now it does.

## What to look at

**Computed once per process, not per draft.** The checkout can't move under a run — `ExecStartPre` has finished by the time this file is read — so a six-hour run legitimately wrote all its notes from one commit. A per-draft call would be three hundred pointless `git` invocations saying the same thing.

**Module-level side effect.** `const REVISION = drafterRevision()` shells out at import. The file already does module-level work of this kind (`stat`/`getent` for the owner at line 169), so it fits, but it does mean `check-changelog-style.mjs` and the test suite each spend one `git rev-parse`. Worth a look if you'd rather it were lazy.

**Undefined rather than a guess** when git can't answer. A tarball with no `.git` is a legitimate way to run this, and refusing to draft over a missing label would trade a note for nothing.

## Checks

- `node ops/internal/changelog-notes.test.mjs` passes, including the GRYT-734/755/763/778/781 fixtures.
- New test asserts `drafterRevision()` equals what `git rev-parse --short HEAD` says in the checkout — so it proves the wiring, not just that a string comes back. **Verified it fails**: stubbing the helper to return `undefined` exits 1; restored, exits 0.
- `check-changelog-style.mjs` run in a scratch tree against `origin/main`'s notes — four hand-written notes clean, bad-draft fixtures still caught.

## What this doesn't do

**It doesn't stop the checkout going stale.** It makes it visible, which is worth having whichever way the real conflict is settled — the same directory is both the drafter's source and where the running deployment is configured, and those two jobs disagree. The options are teaching the pull to ignore `ops/deploy/compose/`, or moving the deployed overrides out of the tracked tree (`beta.local.yml` already sets that precedent). Both change deployment behaviour on the prod box, so they're your call rather than mine.

GRYT-780 stays open for that half.
