### PR TITLE
Refuse a paragraph lifted from another release's note (GRYT-787)

### DIFF
--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -553,6 +553,37 @@ function workedExample(repo) {
     .trim()
 }
 
+/* Every hand-written note in full, newest last.
+ *
+ * `workedExample` returns only the newest, and the contamination guard has
+ * been checking against that one alone. On 2026-08-31 a draft for 1.6.38
+ * opened with 1.6.0's first paragraph word for word — "one sharp edge",
+ * "lived in one browser on one machine", roles and owning a server — for a
+ * release whose three commits are about avatar storage and websocket pings.
+ * 1.6.0 is not the newest note, so nothing looked at it. Twice: it came back
+ * unchanged after being refused for exactly that.
+ *
+ * These are not in the prompt. The model has them anyway — the changelog is a
+ * public page — which is the argument for checking against all of them rather
+ * than only the one the prompt happens to show.
+ */
+function examplesInFull(repo) {
+  const dir = join(repo, 'packages/site/content/changelog')
+  if (!existsSync(dir)) return []
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.mdx'))
+    .sort()
+    .map((f) => {
+      const raw = readFileSync(join(dir, f), 'utf8')
+      const body = raw.split('---').slice(2).join('---').trim()
+      return {
+        version: f.replace(/\.mdx$/, ''),
+        text: body.replace(/^<(Image|Clip)[^>]*\/>\s*$/gm, '').replace(/\n{3,}/g, '\n\n').trim(),
+      }
+    })
+    .filter((e) => e.text)
+}
+
 /* Every commit in the range, in one numbered list.
    Numbered because the coverage rule below has to name the one that went
    missing, and "the third commit under the app" is not something a refusal can
@@ -1212,22 +1243,87 @@ export function borrowedHeading(entry, styleText) {
   return null
 }
 
-export function contamination(entry, exampleText, commitText) {
-  if (!exampleText) return null
+/* A paragraph taken out of a note about a different release.
+ *
+ * `contamination` is tuned for wholesale retelling — the draft that scored 59
+ * against a correct one's 8 — and a single borrowed paragraph goes straight
+ * under it. On 2026-08-31 a draft for 1.6.38 opened with 1.6.0's first
+ * paragraph, about guest identity, roles and owning a server, for a release
+ * whose three commits are avatar storage and websocket pings. It scored 11 on
+ * the word count and sailed through, twice, the second time after being
+ * refused for exactly that.
+ *
+ * Measured rather than guessed. Against the four notes written by hand, that
+ * paragraph scores 0.625; the worst any honest draft in the same batch scores
+ * against any of their paragraphs is 0.313. 0.45 sits between with room on
+ * both sides.
+ *
+ * Only paragraphs of twelve content words or more. Two short sentences about
+ * the same feature legitimately share most of their words, and a rule that
+ * fires on those is a rule that gets turned off.
+ *
+ * Not run over the hand-written notes themselves, for the obvious reason.
+ */
+export function liftedParagraph(entry, examples) {
+  const notes = Array.isArray(examples) ? examples.filter((e) => e && e.text) : []
+  if (!notes.length) return null
+
+  const paragraphs = [...(entry.intro ?? []), ...(entry.sections ?? []).flatMap((s) => s.body ?? [])]
+  for (const note of notes) {
+    /* Headings and list items are short and formulaic; a heading matching a
+       heading is what `borrowedHeading` is for and it says something else. */
+    const theirs = note.text
+      .split(/\n\n+/)
+      .map((t) => t.trim())
+      .filter((t) => t && !/^[#!\-<|]/.test(t) && contentWords(t).size >= 12)
+    for (const mine of paragraphs) {
+      if (contentWords(mine).size < 12) continue
+      for (const other of theirs) {
+        if (overlap(mine, other) >= 0.45) {
+          return `a paragraph is taken from the ${note.version} note: "${mine.slice(0, 70)}"`
+        }
+      }
+    }
+  }
+  return null
+}
+
+export function contamination(entry, examples, commitText) {
+  if (!examples) return null
+  /* A string is one note, an array is all of them. Kept accepting a string so
+     the older callers and their tests still mean what they meant. */
+  const notes = typeof examples === 'string'
+    ? [{ version: 'the example', text: examples }]
+    : examples.filter((e) => e && e.text)
+  if (!notes.length) return null
+
   const words = (t) => new Set((t.toLowerCase().match(/[a-z][a-z-]{4,}/g) ?? []))
   const inCommits = words(commitText)
-  const distinctive = [...words(exampleText)].filter(
-    (w) => !inCommits.has(w) && !COMMON.has(w),
-  )
   const draft = words(JSON.stringify(entry))
-  const borrowed = distinctive.filter((w) => draft.has(w))
+
+  /* Each note on its own rather than all of them pooled. Pooled, the set of
+     words that are "in some hand-written note and not in this range" is large
+     enough that an honest draft collects a score from four notes at once and
+     the number stops meaning what it means against one. This way a hit still
+     says the same thing it always did: this draft is retelling *that* note. */
+  let worst = null
+  for (const note of notes) {
+    const distinctive = [...words(note.text)].filter(
+      (w) => !inCommits.has(w) && !COMMON.has(w),
+    )
+    const shared = distinctive.filter((w) => draft.has(w))
+    if (!worst || shared.length > worst.borrowed.length) {
+      worst = { version: note.version, borrowed: shared }
+    }
+  }
+  const borrowed = worst.borrowed
   /* A handful is coincidence. A pile of it is the example being retold. The
      contaminated 1.6.43 draft scored 59 against a correct one's 8, so there is
      a lot of room between them; the ordinary English filtered out by COMMON is
      what keeps a short commit range from making that gap look narrower than it
      is. */
   return borrowed.length > 20
-    ? `looks copied from the example (${borrowed.length} of its words, none in the commits: ${borrowed.slice(0, 6).join(', ')})`
+    ? `looks copied from ${worst.version} (${borrowed.length} of its words, none in the commits: ${borrowed.slice(0, 6).join(', ')})`
     : null
 }
 
@@ -1393,17 +1489,30 @@ export function claimsSecurityIn(text) {
    the American ones. A hard problem rather than a soft one: it is not a matter
    of taste, and it reaches the page. Only the pairs a release note actually
    reaches for; this is not a dictionary. */
+/* The suffix is open on purpose.
+ *
+ * Each of these listed the forms somebody had seen — customiz(e|ed|es|ing) —
+ * which meant the word had to end there. "customizable" walked through a
+ * clean run on 2026-08-31 because -able was not one of the four. So does
+ * "organizational", "minimizer", "recognizable". The stems below do not occur
+ * in British English at all, so anything built on one is wrong whatever the
+ * ending, and listing endings is a game that only ever loses. */
 const AMERICAN = [
   [/\bcolors?\b/i, 'colour'],
-  [/\bminimiz(e|ed|es|ing)\b/i, 'minimise'],
-  [/\brecogniz(e|ed|es|ing)\b/i, 'recognise'],
+  [/\bminimiz[a-z]*\b/i, 'minimise'],
+  [/\brecogniz[a-z]*\b/i, 'recognise'],
   [/\bbehaviors?\b/i, 'behaviour'],
-  [/\borganiz(e|ed|es|ing|ation)\b/i, 'organise'],
-  [/\bcustomiz(e|ed|es|ing)\b/i, 'customise'],
-  [/\binitializ(e|ed|es|ing)\b/i, 'initialise'],
-  [/\banaly(z|zed|zes|zing)\b/i, 'analyse'],
+  [/\borganiz[a-z]*\b/i, 'organise'],
+  [/\bcustomiz[a-z]*\b/i, 'customise'],
+  [/\binitializ[a-z]*\b/i, 'initialise'],
+  [/\bnormaliz[a-z]*\b/i, 'normalise'],
+  [/\boptimiz[a-z]*\b/i, 'optimise'],
+  [/\bprioritiz[a-z]*\b/i, 'prioritise'],
+  [/\bsynchroniz[a-z]*\b/i, 'synchronise'],
+  [/\banaly[sz]?z[a-z]*\b/i, 'analyse'],
   [/\bcanceled\b/i, 'cancelled'],
   [/\bcentered?\b/i, 'centred'],
+  [/\bfavorites?\b/i, 'favourite'],
 ]
 
 const FILLER = [
@@ -2108,7 +2217,8 @@ async function main() {
         const shape =
           validate(draft) ??
           borrowedHeading(draft, style) ??
-          contamination(draft, workedExample(REPO), commitText)
+          contamination(draft, examplesInFull(REPO), commitText) ??
+          liftedParagraph(draft, examplesInFull(REPO))
         /* A draft of the wrong shape, or one retelling the example, is not a
            draft. Nothing below is worth reading about it. */
         if (shape) return [hard(shape)]

--- a/ops/internal/changelog-notes.test.mjs
+++ b/ops/internal/changelog-notes.test.mjs
@@ -19,7 +19,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { askWithRetry, borrowedHeading, drafterRevision, neverReachedTheModel, refusalBlock, styleProblems } from "./changelog-notes.mjs";
+import { askWithRetry, borrowedHeading, drafterRevision, liftedParagraph, neverReachedTheModel, refusalBlock, styleProblems } from "./changelog-notes.mjs";
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const style = readFileSync(join(REPO, "patch-notes-style.md"), "utf8");
@@ -379,5 +379,91 @@ assert.ok(
   drafterRevision() === undefined || /^[0-9a-f]{7,}$/.test(drafterRevision()),
   "a revision is a commit or nothing at all",
 );
+
+/* ── A paragraph taken from another release's note (GRYT-787) ─────────── */
+
+// The real one: a draft for 1.6.38 opened with 1.6.0's first paragraph, about
+// guest identity and owning a server, for a release whose commits are avatar
+// storage and websocket pings. It scored 11 on contamination's word count —
+// well under the 20 that catches wholesale retelling — and reached the queue
+// twice, the second time after being refused for exactly that.
+const oneSixZero = {
+  version: "1.6.0",
+  text: [
+    "Using Gryt without an account has always had one sharp edge: whatever you were on",
+    "a server lived in one browser on one machine. Clear your site data and it was gone,",
+    "along with any roles you had and any server you owned. This release takes that apart.",
+  ].join(" "),
+};
+
+const lifted = {
+  headline: "Your avatar follows you between devices",
+  intro: [
+    "Using Gryt without an account has always had one sharp edge: whatever you were on a server lived in one browser on one machine. Clear your site data and it was gone, along with any roles you had and any server you owned. This release takes that apart.",
+  ],
+  sections: [{ heading: "The look is stored beside the nickname", body: ["The server keeps the short string the editor produced."] }],
+  recap: [{ group: "Avatars and images", items: ["A designed owl follows you between devices"] }],
+  omitted: [],
+};
+
+assert.match(
+  liftedParagraph(lifted, [oneSixZero]) ?? "",
+  /taken from the 1\.6\.0 note/,
+  "a paragraph copied out of another release's note is caught, and named",
+);
+
+// The measurement that set the threshold: 0.625 for the copied paragraph
+// against 0.313 for the worst honest draft in the same batch. A note that
+// merely shares a subject with an older one has to pass.
+assert.equal(
+  liftedParagraph(
+    {
+      ...lifted,
+      intro: [
+        "A designed owl used to be a picture, so it stayed on the machine that made it and never followed anybody anywhere.",
+      ],
+    },
+    [oneSixZero],
+  ),
+  null,
+  "writing about the same subject in your own words is not lifting",
+);
+
+assert.equal(liftedParagraph(lifted, []), null, "no notes to compare against is not a finding");
+
+// Short paragraphs are skipped: two brief sentences about one feature share
+// most of their words honestly.
+assert.equal(
+  liftedParagraph({ ...lifted, intro: ["Clear your site data and it was gone."] }, [oneSixZero]),
+  null,
+  "a short paragraph is not enough to call it lifted",
+);
+
+/* ── The spelling list stops guessing at suffixes (GRYT-787) ──────────── */
+
+// "customizable" passed a clean run on 2026-08-31 because the pattern was
+// customiz(e|ed|es|ing) and -able was not one of the four.
+const withWord = (word) => ({
+  headline: "A release",
+  intro: [`The editor is ${word} in every way that matters to somebody setting one up.`],
+  sections: [{ heading: "The editor changed", body: ["It did."] }],
+  recap: [],
+  omitted: [],
+});
+const parts = [{ component: "The app", commits: [{ subject: "x", body: "y" }] }];
+
+for (const word of ["customizable", "organizational", "minimizer", "recognizable"]) {
+  assert.ok(
+    said(styleProblems(withWord(word), parts), /American spelling/),
+    `"${word}" is caught whatever its ending`,
+  );
+}
+
+for (const word of ["customisable", "recognisable", "colourful"]) {
+  assert.ok(
+    !said(styleProblems(withWord(word), parts), /American spelling/),
+    `"${word}" is British and must pass`,
+  );
+}
 
 console.log("changelog-notes checks: ok");


### PR DESCRIPTION
Two holes found reviewing the 31 August batch. Both mechanical, both with measured thresholds.

## 1. A paragraph out of a note about a different release

The draft for 1.6.38 opened with **1.6.0's first paragraph, word for word**:

> Using Gryt without an account has always had one sharp edge: whatever you were on a server lived in one browser on one machine. Clear your site data and it was gone, along with any roles you had and any server you owned.

1.6.0 is the guest identity release. 1.6.38's three commits are avatar storage and websocket pings. **It reached the queue twice** — the second time after being refused for exactly that, with the reason in the prompt. That's what tells you it wants a rule rather than a better prompt.

`contamination` missed it twice over, for two separate reasons:

- it compares against `workedExample`, which is only the **newest** hand-written note, and 1.6.0 isn't the newest;
- its threshold is tuned for wholesale retelling — the draft that scored 59 against a correct one's 8 — and one borrowed paragraph scores **11**.

## What to look at

**Why every note is checked separately rather than pooled.** Pooled, the set of words that are "in some hand-written note and not in this range" gets large enough that an honest draft collects a score from four notes at once, and 20 stops meaning what it meant against one. Checked separately, a hit says what it always said.

**The threshold is measured.** The lifted paragraph scores **0.625**; the worst any honest draft in the same batch scores against any hand-written paragraph is **0.313** (1.6.42). 0.45 sits between with about 1.4× either way. Twelve content words minimum, because two short sentences about one feature legitimately share most of their words.

**There's a warning in this codebase I took seriously.** `check-changelog-style.mjs` records that putting the *writing skills* through this guard made all three hand-written notes score as copied, on "voice", "reading", "person" — because a skill about writing and a note about a chat app are both English. So I measured against every draft in the batch and both published notes before believing it. All clean.

**The notes aren't in the prompt** — only their headlines are. The model has them because the changelog is a public page. That's the argument for guarding all of them rather than only the one the prompt shows, and it's worth knowing if the prompt ever changes.

## 2. `customizable`

`customiz(e|ed|es|ing)` requires the word to end there, so `customizable` passed a clean run on 1.6.36. So would `organizational`, `minimizer`, `recognizable`. The stems don't occur in British English at all, so the suffix is open now, plus four more stems that could plausibly turn up. Listing endings is a game that only ever loses.

## Checks

- `node ops/internal/changelog-notes.test.mjs` passes, including every existing fixture.
- **Both rules mutation-tested**: an unreachable overlap threshold fails the suite; reverting the suffixes to the old closed list fails it too. Restored, green.
- `check-changelog-style.mjs` in a scratch tree against `origin/main`'s notes — four hand-written notes clean, all bad-draft fixtures still caught.
- Ran both rules over all seven drafts in the queue plus the two published notes: `liftedParagraph` fires on 1.6.38 and nothing else; the spelling rule fires on 1.6.36's `customizable`.

Closes GRYT-787.
