### PR TITLE
Name the services in the internal start command (GRYT-161)

### DIFF
--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -16,13 +16,26 @@ Cloudflare tunnel rather than the one on this host. Written up in
 
 It’s **not** intended for self-hosters. Self-hosting docs live under `ops/deploy/*` (Docker Compose) and `ops/helm/*` (Kubernetes).
 
-## Start (site + docs)
+## Start
 
 From the repo root:
 
 ```bash
 cp ops/internal/.env.example ops/internal/.env
-docker compose --env-file ops/internal/.env -f ops/internal/docker-compose.yml up -d --build
+docker compose --env-file ops/internal/.env -f ops/internal/docker-compose.yml up -d --build docs site ui
+```
+
+**Name the services.** Without them that command is a bare `up -d` over the whole file, so it
+also recreates `fider`, `fider-db` and `reports`. Those three own `gryt-fider-pg-data` and
+`gryt-reports-data`. Recreating a database because you wanted to rebuild the docs is not a
+trade anybody would make on purpose, and on `dev.lan` it is somebody else's feature board and
+everyone's bug reports. The refresh scripts below take the same care for the same reason;
+this is the manual version of it.
+
+Fider and reports are started the same way, one at a time, when they actually need it:
+
+```bash
+docker compose --env-file ops/internal/.env -f ops/internal/docker-compose.yml up -d --no-deps reports
 ```
 
 ## Ports


### PR DESCRIPTION
The documented way to start `ops/internal` was a bare `up -d --build` over the whole compose file:

```
docker compose --env-file ops/internal/.env -f ops/internal/docker-compose.yml up -d --build
```

That file holds six services, and three of them are not the ones you were trying to start. `fider`, `fider-db` and `reports` own `gryt-fider-pg-data` and `gryt-reports-data`, so the command for rebuilding the docs also recreated somebody's feature board and everyone's bug reports.

The heading said **Start (site + docs)** while the command started all six. That mismatch is most of why it read as safe.

## The rest of the file already had this right

`refresh-sites.sh` is documented as never running a bare `up -d`, because "Fider and its Postgres are in the same compose file, and a timer has no business recreating a database". `refresh-web-client.sh` is described the same way — `--no-deps`, one service named. The manual start command was the only thing in the document that disagreed with the document, and with CLAUDE.md's rule for `dev.lan`.

## Change

Names `docs site ui` in the start command, says why in two sentences, and adds the single-service form for bringing up `fider` or `reports` deliberately.

Checked the rest of the file: line 456 already names services (`up -d --no-deps site reports`), and the other `up -d` mentions are prose about the scripts. This was the only offender.

Documentation only — no compose or script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
