### PR TITLE
Pass the Windows signing configuration to the packaging step (GRYT-848)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1143,6 +1143,16 @@ jobs:
           CHANNEL: ${{ env.CHANNEL }}
           RELEASE_TYPE: ${{ env.RELEASE_TYPE }}
           VERSION: ${{ env.VERSION }}
+          # Windows signing. Empty until a certificate exists, and empty is
+          # fine: scripts/sign-windows.cjs signs nothing without them and
+          # warns that Smart App Control will block the result.
+          #
+          # Whichever CA is bought also needs its own credentials here, next
+          # to these. They differ per CA and the signing tools read them from
+          # the environment themselves, so nothing is passed through Gryt's
+          # code. See the hook for the two likely commands. GRYT-848.
+          GRYT_WIN_SIGN_TOOL: ${{ secrets.WINDOWS_SIGN_TOOL }}
+          GRYT_WIN_SIGN_ARGS: ${{ secrets.WINDOWS_SIGN_ARGS }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
The other half of Gryt-chat/client#337, which added the Windows sign hook. Neither is much use alone.

Two environment variables on the step that packages Windows and Linux, so that turning signing on later is a matter of setting repository secrets rather than editing this workflow again.

**Both are empty today, and empty is the working state.** The hook signs nothing without them and prints a warning that Smart App Control will block what it just built — which it does, because Gryt has never signed a Windows build. Confirmed by reading the published `Gryt-Chat-1.9.1-win-x64.exe`: its certificate table is offset 0, size 0.

## What to look at

Whichever certificate authority is bought needs **its own credentials alongside these**. Those differ per CA, and every one of these signing tools reads them from the environment itself, so nothing passes through Gryt's code. The two likely commands are written down in the hook rather than here.

`WINDOWS_SIGN_TOOL` and `WINDOWS_SIGN_ARGS` are the only new secret names. Neither is really secret — they're the command and its arguments — but keeping one mechanism seemed better than splitting across `vars` and `secrets` for two values.

Nothing about the current release changes until those secrets exist. The YAML parses and the file is LF, so no line-ending surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
