### PR TITLE
Draft the changelog with the Anthropic API (GRYT-861)

### DIFF
--- a/.github/workflows/changelog-style.yml
+++ b/.github/workflows/changelog-style.yml
@@ -24,6 +24,7 @@ on:
       - .github/scripts/check-changelog-style.mjs
       - .github/workflows/changelog-style.yml
       - ops/internal/changelog-notes.mjs
+      - ops/internal/changelog-notes.test.mjs
       # The prompt reads both of these in full, so removing or renaming one
       # changes what a draft is judged by.
       - ops/internal/writing/**
@@ -65,3 +66,9 @@ jobs:
       # stops being true, this failing is the right way to find out.
       - name: Check the style rules
         run: node .github/scripts/check-changelog-style.mjs
+
+      # The drafter's own checks. Same job because it is the same two things
+      # being protected and neither needs an install: the rules that decide
+      # whether a draft is kept, and the request that fetches one.
+      - name: Check the drafter
+        run: node ops/internal/changelog-notes.test.mjs

--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -413,9 +413,38 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now gryt-changelog-notes.timer
 ```
 
-Edit `/etc/default/gryt-changelog-notes` before the first run. `OLLAMA_URL` has
-no useful default — the model does not run on this box — and the port is not
-optional.
+Edit `/etc/default/gryt-changelog-notes` before the first run.
+
+### Which model writes it
+
+Two of them, and `ANTHROPIC_API_KEY` picks. With a key set, drafting goes to the
+Anthropic API. Without one it goes to Ollama, which is what everything below
+about `OLLAMA_NUM_CTX` and the card describes. `GRYT_CHANGELOG_PROVIDER`
+overrides the guess either way.
+
+Ollama drafted 105 notes and 4 of them were published. All 101 rejections had
+already passed every check in this script, so there was nothing left to tighten
+there.
+
+The API costs money per draft, which nothing else on this box does. Measured on
+the last three releases, a prompt is 13,000 to 15,000 tokens. The answer is a
+note of under a thousand plus whatever the model thinks first, and thinking is
+billed as output — so at Opus 5 rates an attempt is around 15 cents, with up to
+three attempts a release. Redrafting all 38 releases that have no note comes to
+something between five and fifteen dollars. It is billed to
+an API account and not to a Claude subscription; the reports service beside it
+already uses a key for triage, so it lands on the same bill.
+
+Two other things change with it. A release takes about forty minutes on
+qwen3:32b and seconds through the API. And `ANTHROPIC_NUM_CTX` defaults to
+200,000, past the largest range this has ever seen, so the commit block stops
+being trimmed: 1.5.5 is 164 commits and the Ollama budget drops some of them
+before the model reads a word.
+
+### On Ollama
+
+`OLLAMA_URL` has no useful default — the model does not run on this box — and
+the port is not optional.
 
 `OLLAMA_NUM_CTX` matters more than it looks, and it is a memory decision
 rather than a size one.
@@ -474,14 +503,15 @@ for working on the prompt without a reports instance to hand; nothing reads what
 it writes.
 
 A run with nothing to do costs one call to the releases API. A run with something
-to do is minutes: roughly eight per release on qwen3:32b, which is the model to
-use. `sudo journalctl -u gryt-changelog-notes -n 50` for what it did.
+to do takes seconds per release through the API, or roughly forty minutes on
+qwen3:32b. `sudo journalctl -u gryt-changelog-notes -n 50` for what it did.
 
 ### The backfill
 
-42 stable releases have shipped and three have notes written by hand, so the
-first real run has about 35 to draft, at roughly eight minutes each on
-qwen3:32b. Four and a half hours, which the machine spends on its own.
+42 stable releases have shipped and four have notes, so a full backfill is
+about 38 to draft. Through the API that is a few minutes and a few dollars. On
+qwen3:32b it is roughly forty minutes each, which the machine spends on its own
+overnight.
 
 **Use the largest model that fits on the card.** qwen3:14b is three minutes a
 release rather than eight and reads flatter for it: in one run it produced a

--- a/ops/internal/changelog-notes.mjs
+++ b/ops/internal/changelog-notes.mjs
@@ -52,6 +52,24 @@
 //   GRYT_CHANGELOG_DUMP    with --dump, where to write drafts for inspection.
 //                          Default ./changelog/drafts beside this file. Nothing
 //                          reads what is written there.
+//
+//   Which model writes the prose. ANTHROPIC_API_KEY picks the API; without
+//   one it is Ollama. GRYT_CHANGELOG_PROVIDER overrides that either way.
+//
+//   ANTHROPIC_API_KEY      the key to draft with. Setting it is what moves
+//                          drafting off Ollama, and it is the only setting
+//                          here that costs money to use.
+//   ANTHROPIC_MODEL        Default claude-opus-5
+//   ANTHROPIC_URL          Default https://api.anthropic.com
+//   ANTHROPIC_MAX_TOKENS   the cap on one answer, thinking included.
+//                          Default 32000.
+//   ANTHROPIC_TIMEOUT_MS   Default 600000
+//   ANTHROPIC_NUM_CTX      how much prompt to budget for, in tokens.
+//                          Default 200000. Well under the model's window,
+//                          and past the largest range this has ever seen.
+//   GRYT_CHANGELOG_PROVIDER  "anthropic" or "ollama". Worked out from
+//                          whether there is a key when this is unset.
+//
 //   OLLAMA_URL             Default http://127.0.0.1:11434
 //   OLLAMA_MODEL           Default llama3.1:8b
 //   OLLAMA_TIMEOUT_MS      Default 3600000
@@ -62,7 +80,7 @@
 //                          32768. Not optional in practice: Ollama's own
 //                          default is 4096 and this prompt is past that, so
 //                          leaving it unset silently drops part of the input.
-//                          See the comment on ask().
+//                          See the comment on askOllama().
 
 import { execFileSync } from 'node:child_process'
 import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs'
@@ -98,6 +116,62 @@ const OLLAMA_TIMEOUT_MS = Number(process.env.OLLAMA_TIMEOUT_MS ?? 3_600_000)
    tokens; 24576 covers it with the answer and costs 6 GiB, or 3 with a
    quantised cache. See ops/internal/README.md. */
 const OLLAMA_NUM_CTX = Number(process.env.OLLAMA_NUM_CTX ?? 24_576)
+
+/* ── Which model writes the prose ──────────────────────────────────────
+   Two providers, and the key picks between them: with ANTHROPIC_API_KEY set
+   the drafting goes to the Anthropic API, and without one it goes to Ollama.
+   That is the same rule the reports service uses to pick a triage model, so
+   there is one thing to learn here rather than two.
+
+   Why there is a choice at all. Ollama costs nothing to run and the notes it
+   wrote were not good enough to publish: 105 drafts, 4 published, and all
+   101 rejections had already passed every check further down this file. So
+   the checks were not the thing to fix.
+
+   The API costs money per draft, which nothing else on this box does. A
+   prompt measures 13,000 to 15,000 tokens and the answer is the note plus the
+   thinking in front of it, which bills as output — around 15 cents an attempt
+   at Opus 5 rates, up to three attempts a release. Nothing is spent until
+   somebody sets a key. */
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY ?? ''
+const PROVIDER = (process.env.GRYT_CHANGELOG_PROVIDER || (ANTHROPIC_API_KEY ? 'anthropic' : 'ollama')).toLowerCase()
+const ANTHROPIC_URL = (process.env.ANTHROPIC_URL ?? 'https://api.anthropic.com').replace(/\/$/, '')
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL ?? 'claude-opus-5'
+
+/* The cap on one answer, and it covers thinking as well as the note.
+   A finished note measured 200 to 830 tokens across the drafts on disk, so
+   the note itself is nowhere near this. Thinking is what the room is for:
+   the model reasons before it answers and those tokens count against this
+   number, so a cap sized to the note would truncate the answer that was
+   about to be written. Streamed either way, so a large cap costs nothing
+   when the answer is short. */
+const ANTHROPIC_MAX_TOKENS = Number(process.env.ANTHROPIC_MAX_TOKENS ?? 32_000)
+const ANTHROPIC_TIMEOUT_MS = Number(process.env.ANTHROPIC_TIMEOUT_MS ?? 600_000)
+
+/* How much prompt to budget for, and it is not the model's window.
+   The window is far larger than this. The number matters because it is what
+   the commit block is trimmed to fit, and the trimming is the thing that
+   was quietly losing releases: 1.5.5 is 164 commits and the Ollama budget
+   drops some of them before the model reads a word. 200,000 is past the
+   largest range this has ever produced, so nothing gets dropped, while
+   still being a bound rather than no bound at all. */
+const ANTHROPIC_NUM_CTX = Number(process.env.ANTHROPIC_NUM_CTX ?? 200_000)
+
+if (PROVIDER !== 'anthropic' && PROVIDER !== 'ollama') {
+  console.error(`[changelog] GRYT_CHANGELOG_PROVIDER is "${PROVIDER}"; it has to be "anthropic" or "ollama"`)
+  process.exit(1)
+}
+if (PROVIDER === 'anthropic' && !ANTHROPIC_API_KEY) {
+  console.error('[changelog] GRYT_CHANGELOG_PROVIDER=anthropic without ANTHROPIC_API_KEY set')
+  process.exit(1)
+}
+
+/* What the rest of the file asks for instead of the provider's own settings.
+   Recorded on every draft as well, so a note in reports says which model
+   wrote it and a bad run is attributable afterwards. */
+const MODEL = PROVIDER === 'anthropic' ? ANTHROPIC_MODEL : OLLAMA_MODEL
+const CONTEXT_TOKENS = PROVIDER === 'anthropic' ? ANTHROPIC_NUM_CTX : OLLAMA_NUM_CTX
+const CONTEXT_SETTING = PROVIDER === 'anthropic' ? 'ANTHROPIC_NUM_CTX' : 'OLLAMA_NUM_CTX'
 
 /* Four characters to the token. Rough, and on the safe side for English prose
    with code in it, which is what these prompts are. The same estimator is used
@@ -1017,7 +1091,7 @@ function promptFor(release, changes, style, refusal) {
      of one release was a silent overflow and the way to not repeat that is to
      let nothing sit outside the arithmetic. */
   const skeleton = prompt(release, changes, style) + refusalBlock(refusal)
-  const room = (OLLAMA_NUM_CTX - ANSWER_RESERVE) * 4
+  const room = (CONTEXT_TOKENS - ANSWER_RESERVE) * 4
   const allowance = Math.max(0, Math.floor((room - (skeleton.length - COMMITS.length)) * COMMIT_SHARE))
 
   /* Built and measured rather than predicted. The allowance is spent on
@@ -1083,7 +1157,131 @@ function retryPrompt(previous, problems) {
   ].join('\n')
 }
 
-async function ask(text) {
+/**
+ * The same schema, with every object closed to properties it did not name.
+ *
+ * Ollama takes SCHEMA as it stands. The Anthropic API's json_schema format
+ * wants `additionalProperties: false` on each object, and adding it to SCHEMA
+ * itself would change what Ollama is sent for no reason — so it is added here,
+ * on the way out, and the one definition upstream stays the definition.
+ */
+export function strictSchema(node) {
+  if (Array.isArray(node)) return node.map(strictSchema)
+  if (!node || typeof node !== 'object') return node
+  const out = {}
+  for (const [k, v] of Object.entries(node)) out[k] = strictSchema(v)
+  if (out.type === 'object' && out.properties) out.additionalProperties = false
+  return out
+}
+
+/**
+ * What the model actually wrote, out of a stream of server-sent events.
+ *
+ * Only `text_delta` is collected. With thinking on — which it is by default on
+ * this model — the answer arrives after a run of `thinking_delta`, and those
+ * are the reasoning rather than the note. Kept per block rather than as one
+ * string because a turn can carry more than one text block, and two JSON
+ * documents concatenated parse as neither.
+ */
+export function readAnthropicEvent(event, state) {
+  if (event.type === 'error') {
+    throw new Error(`anthropic: ${event.error?.type ?? 'error'}: ${event.error?.message ?? ''}`.trim())
+  }
+  if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+    const i = event.index ?? 0
+    state.blocks.set(i, (state.blocks.get(i) ?? '') + event.delta.text)
+  }
+  if (event.type === 'message_start') {
+    state.inputTokens = event.message?.usage?.input_tokens ?? 0
+  }
+  if (event.type === 'message_delta') {
+    state.stopReason = event.delta?.stop_reason ?? state.stopReason
+    state.outputTokens = event.usage?.output_tokens ?? state.outputTokens
+  }
+  return state
+}
+
+/* The state `readAnthropicEvent` fills in, so the test and the caller agree
+   on its shape. */
+export const emptyAnthropicState = () => ({
+  blocks: new Map(),
+  stopReason: null,
+  inputTokens: 0,
+  outputTokens: 0,
+})
+
+async function askAnthropic(text) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), ANTHROPIC_TIMEOUT_MS)
+  try {
+    /* Streamed for the same reason the Ollama call is: a non-streamed request
+       sends nothing until the whole answer exists, and Node's fetch gives up
+       waiting for response headers after five minutes. Thinking makes that a
+       real risk rather than a theoretical one, and it is what the SDK does for
+       a max_tokens this size anyway. */
+    const res = await fetch(`${ANTHROPIC_URL}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        /* Server-side fallback. If a safety classifier declines the request,
+           the API re-runs it on another model inside the same call instead of
+           handing back a refusal. Vanishingly unlikely for a prompt made of
+           git commits, and it costs nothing when it does not fire. */
+        'anthropic-beta': 'server-side-fallback-2026-07-01',
+      },
+      signal: controller.signal,
+      body: JSON.stringify({
+        model: ANTHROPIC_MODEL,
+        max_tokens: ANTHROPIC_MAX_TOKENS,
+        stream: true,
+        fallbacks: 'default',
+        /* The same fixed shape Ollama is asked for, by the same reasoning:
+           the site renders it with its own components, and a malformed answer
+           is detectable rather than merely ugly. */
+        output_config: { format: { type: 'json_schema', schema: strictSchema(SCHEMA) } },
+        messages: [{ role: 'user', content: text }],
+      }),
+    })
+    if (!res.ok) throw new Error(`anthropic ${res.status} ${await res.text().catch(() => '')}`.trim())
+
+    const state = emptyAnthropicState()
+    let buf = ''
+    for await (const chunk of res.body) {
+      buf += Buffer.from(chunk).toString('utf8')
+      /* One event per `data:` line, and the last line of a chunk is usually a
+         partial one — keep it for the next chunk rather than parsing it. */
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const line of lines) {
+        if (!line.startsWith('data:')) continue
+        let event
+        try { event = JSON.parse(line.slice(5).trim()) } catch { continue }
+        readAnthropicEvent(event, state)
+      }
+    }
+
+    log(`  ${state.inputTokens} tokens in, ${state.outputTokens} out`)
+    /* A refusal is a 200 with nothing usable in it, so it has to be checked
+       rather than caught. It means the fallback model declined as well; the
+       one before it would have been rescued silently. */
+    if (state.stopReason === 'refusal') throw new Error('anthropic: the request was declined')
+
+    const parts = [...state.blocks.values()]
+    /* Normally one block. Where there are two, joining them is right when the
+       JSON was split across them and wrong when each is its own document, and
+       there is no telling which from here — so try the join, then the pieces. */
+    for (const candidate of [parts.join(''), ...parts]) {
+      try { return JSON.parse(candidate) } catch { /* next */ }
+    }
+    throw new Error(`anthropic: no JSON in the answer (${parts.join('').slice(0, 200)})`)
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function askOllama(text) {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), OLLAMA_TIMEOUT_MS)
   try {
@@ -1140,6 +1338,10 @@ async function ask(text) {
     clearTimeout(timer)
   }
 }
+
+/* Which of the two gets asked. Chosen once at load, so a run cannot be half
+   one model and half the other. */
+const ask = (text) => (PROVIDER === 'anthropic' ? askAnthropic(text) : askOllama(text))
 
 /* Read when it is used rather than at load, unlike the other settings here.
    A minute of real sleeping in a test is a test nobody runs, and the file is
@@ -2276,16 +2478,16 @@ async function main() {
          before it is sent. Four characters to the token is rough and is on
          the safe side for English prose. */
       const estimate = TOKENS(text)
-      log(`  prompt ${(text.length / 1024).toFixed(1)} kB, about ${estimate} tokens of ${OLLAMA_NUM_CTX}`)
+      log(`  prompt ${(text.length / 1024).toFixed(1)} kB, about ${estimate} tokens of ${CONTEXT_TOKENS}`)
       /* Only when the budget failed to do its job.
          It used to warn at 85% of the window, which fires on every long range
          now that the commits are sized to fill what is left — the budget
          working is not news. What is news is a prompt past what was reserved
          for it, because that means something is in here the budget cannot
          see. */
-      if (estimate > OLLAMA_NUM_CTX - ANSWER_RESERVE) {
-        log(`  ! past the ${OLLAMA_NUM_CTX - ANSWER_RESERVE} tokens budgeted, so part of it may be dropped before the model reads it`)
-        log(`    raise OLLAMA_NUM_CTX, or lower GRYT_CHANGELOG_COMMIT_SHARE (${COMMIT_SHARE})`)
+      if (estimate > CONTEXT_TOKENS - ANSWER_RESERVE) {
+        log(`  ! past the ${CONTEXT_TOKENS - ANSWER_RESERVE} tokens budgeted, so part of it may be dropped before the model reads it`)
+        log(`    raise ${CONTEXT_SETTING}, or lower GRYT_CHANGELOG_COMMIT_SHARE (${COMMIT_SHARE})`)
       }
       if (DRY_RUN) { console.log(`\n───── prompt for ${release.version} ─────\n${text}\n`); continue }
 
@@ -2399,7 +2601,7 @@ async function main() {
         source: {
           since: prev.version,
           commits: count,
-          model: OLLAMA_MODEL,
+          model: MODEL,
           revision: REVISION,
           /* Which parts of Gryt moved, in the order the manifest lists them.
              Straight off the diff, so there is nothing here for a model to get

--- a/ops/internal/changelog-notes.test.mjs
+++ b/ops/internal/changelog-notes.test.mjs
@@ -19,7 +19,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { askWithRetry, borrowedHeading, drafterRevision, liftedParagraph, neverReachedTheModel, refusalBlock, styleProblems } from "./changelog-notes.mjs";
+import { askWithRetry, borrowedHeading, drafterRevision, emptyAnthropicState, liftedParagraph, neverReachedTheModel, readAnthropicEvent, refusalBlock, strictSchema, styleProblems } from "./changelog-notes.mjs";
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const style = readFileSync(join(REPO, "patch-notes-style.md"), "utf8");
@@ -465,5 +465,142 @@ for (const word of ["customisable", "recognisable", "colourful"]) {
     `"${word}" is British and must pass`,
   );
 }
+
+/* ── Drafting through the Anthropic API (GRYT-861) ────────────────────── */
+
+// The API's json_schema format wants every object closed. SCHEMA is not
+// written that way, because Ollama does not need it and there is one copy.
+const closed = strictSchema({
+  type: "object",
+  properties: {
+    headline: { type: "string" },
+    sections: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { heading: { type: "string" } },
+        required: ["heading"],
+      },
+    },
+  },
+  required: ["headline"],
+});
+
+assert.equal(closed.additionalProperties, false, "the top-level object is closed");
+assert.equal(
+  closed.properties.sections.items.additionalProperties,
+  false,
+  "an object nested inside an array is closed too",
+);
+assert.equal(
+  closed.properties.headline.additionalProperties,
+  undefined,
+  "a string is not an object and gets nothing added to it",
+);
+
+// The input is left alone, which is the whole reason this is a function and
+// not four characters added to SCHEMA.
+const before = { type: "object", properties: { a: { type: "string" } } };
+strictSchema(before);
+assert.equal(before.additionalProperties, undefined, "strictSchema does not edit what it was given");
+
+// Reading the stream. Thinking is on by default on this model, so the answer
+// arrives after a run of deltas that are the reasoning rather than the note —
+// collecting those too is a parse failure with the note sitting right there.
+const drive = (events) => {
+  const state = emptyAnthropicState();
+  for (const e of events) readAnthropicEvent(e, state);
+  return state;
+};
+
+const answered = drive([
+  { type: "message_start", message: { usage: { input_tokens: 16300 } } },
+  { type: "content_block_start", index: 0, content_block: { type: "thinking" } },
+  { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "The range has four commits" } },
+  { type: "content_block_start", index: 1, content_block: { type: "text" } },
+  { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: '{"headline":' } },
+  { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: '"A release"}' } },
+  { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 812 } },
+]);
+
+assert.deepEqual(
+  JSON.parse([...answered.blocks.values()].join("")),
+  { headline: "A release" },
+  "the text deltas are the note and the thinking deltas are not",
+);
+assert.equal(answered.stopReason, "end_turn");
+assert.equal(answered.inputTokens, 16300, "the prompt size comes off message_start");
+assert.equal(answered.outputTokens, 812, "the answer size comes off message_delta");
+
+// Two text blocks are kept apart. Joined they are one document; each on its
+// own is another, and the caller tries both rather than guessing here.
+const split = drive([
+  { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: '{"a":1}' } },
+  { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: '{"b":2}' } },
+]);
+assert.equal(split.blocks.size, 2, "one entry per content block");
+
+// An error arrives as an event on a 200 response, so it has to be thrown
+// rather than caught.
+assert.throws(
+  () => drive([{ type: "error", error: { type: "overloaded_error", message: "Overloaded" } }]),
+  /overloaded_error: Overloaded/,
+  "an error event stops the read",
+);
+
+// The request itself, against a server pretending to be the API.
+//
+// Everything above this is a pure function and none of it would have caught a
+// wrong header, a body the API refuses, or a stream split down the middle of a
+// `data:` line. Run in a child process because the provider is decided once
+// when the module loads, and this file has already loaded it as Ollama.
+const child = `
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+
+let seen = null;
+const server = createServer((req, res) => {
+  let body = "";
+  req.on("data", (c) => { body += c; });
+  req.on("end", () => {
+    seen = { url: req.url, headers: req.headers, body: JSON.parse(body) };
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    // Written in awkward pieces on purpose: one event split across two
+    // writes, and a chunk that ends mid-line.
+    res.write('event: message_start\\ndata: {"type":"message_start","message":{"usage":{"input_tokens":42}}}\\n\\n');
+    res.write('event: content_block_delta\\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\\\\"head');
+    res.write('line\\\\":\\\\"A release\\\\"}"}}\\n\\nevent: message_delta\\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}\\n\\n');
+    res.end('event: message_stop\\ndata: {"type":"message_stop"}\\n\\n');
+  });
+});
+await new Promise((r) => server.listen(0, "127.0.0.1", r));
+
+process.env.ANTHROPIC_URL = "http://127.0.0.1:" + server.address().port;
+process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+process.env.GRYT_CHANGELOG_PROVIDER = "anthropic";
+
+// Via the environment, not argv: the module treats argv[1] as "was I run\n// directly?" and would start a real drafting run if it saw its own path.
+const { askWithRetry } = await import(process.env.DRAFTER);
+const answer = await askWithRetry("write a note");
+server.close();
+
+assert.deepEqual(answer, { headline: "A release" }, "the note survives an awkwardly chunked stream");
+assert.equal(seen.url, "/v1/messages");
+assert.equal(seen.headers["x-api-key"], "sk-ant-test");
+assert.equal(seen.headers["anthropic-version"], "2023-06-01");
+assert.equal(seen.headers["anthropic-beta"], "server-side-fallback-2026-07-01");
+assert.equal(seen.body.stream, true, "streamed, or fetch gives up after five minutes");
+assert.equal(seen.body.model, "claude-opus-5");
+assert.equal(seen.body.fallbacks, "default");
+assert.equal(seen.body.output_config.format.type, "json_schema");
+assert.equal(seen.body.output_config.format.schema.additionalProperties, false, "the schema goes out closed");
+assert.equal(seen.body.messages[0].content, "write a note");
+assert.equal(seen.body.thinking, undefined, "omitted, which is adaptive on this model");
+`;
+
+execFileSync(process.execPath, ["--input-type=module", "-e", child], {
+  stdio: ["ignore", "ignore", "inherit"],
+  env: { ...process.env, DRAFTER: join(REPO, "ops/internal/changelog-notes.mjs") },
+});
 
 console.log("changelog-notes checks: ok");

--- a/ops/internal/systemd/gryt-changelog-notes.env.example
+++ b/ops/internal/systemd/gryt-changelog-notes.env.example
@@ -1,8 +1,49 @@
 # Per-machine settings for gryt-changelog-notes.service.
 # Install to /etc/default/gryt-changelog-notes.
 #
-# Unlike the other two units here, this one needs at least OLLAMA_URL: the
-# default is a local Ollama and the model does not run on this box.
+# Unlike the other two units here, this one needs somewhere to send a prompt.
+# Either a key below, or OLLAMA_URL further down: the Ollama default is a local
+# instance and the model does not run on this box.
+
+# ── Which model writes it ────────────────────────────────────────────────
+#
+# A key here moves drafting off Ollama and onto the Anthropic API, the same way
+# a key picks the triage model in the reports service next to this one.
+#
+# Why bother: Ollama drafted 105 notes and 4 were published. All 101 rejections
+# had already passed every check in the script, so the checks were not the thing
+# to fix.
+#
+# It costs money, which nothing else on this box does. A prompt measures 13,000
+# to 15,000 tokens, and the answer is a note of under a thousand plus whatever
+# the model thinks first — thinking is billed as output. At Opus 5 rates that is
+# around 15 cents an attempt, and up to three attempts a release. Billed to an
+# API account rather than to a Claude subscription.
+#ANTHROPIC_API_KEY=
+
+# Default claude-opus-5.
+#ANTHROPIC_MODEL=claude-opus-5
+
+# The cap on one answer, thinking included. A note is 200 to 830 tokens; the
+# room is for the reasoning that comes before it, which counts against the same
+# number. Streamed, so a large cap costs nothing when the answer is short.
+#ANTHROPIC_MAX_TOKENS=32000
+
+#ANTHROPIC_TIMEOUT_MS=600000
+
+# How much prompt to budget for, in tokens. Not the model's window, which is far
+# larger — this is what the commit block gets trimmed to fit, and 200,000 is past
+# the largest range this has ever produced, so nothing gets trimmed at all. The
+# Ollama budget does trim: 1.5.5 is 164 commits and some of them never reach the
+# model.
+#ANTHROPIC_NUM_CTX=200000
+
+# "anthropic" or "ollama", when you want to say rather than let the presence of
+# a key decide. Naming anthropic without a key is an error rather than a quiet
+# fall back to Ollama.
+#GRYT_CHANGELOG_PROVIDER=
+
+# ── On Ollama ────────────────────────────────────────────────────────────
 
 # The Ollama instance that writes the prose. No trailing slash, and the port is
 # not optional — Ollama's default is 11434 and nothing is listening on 80.

--- a/ops/internal/systemd/gryt-changelog-notes.service
+++ b/ops/internal/systemd/gryt-changelog-notes.service
@@ -17,10 +17,11 @@ ExecStartPre=-/usr/local/bin/gryt-pull-superproject
 # to be installed again.
 ExecStart=/usr/bin/env node /usr/local/lib/gryt/changelog-notes.mjs
 
-# Where OLLAMA_URL, OLLAMA_MODEL and the reports address and key live.
-# Required: the Ollama defaults point at a local instance and there is not one
-# on this box, and the script refuses to start without somewhere to post a
-# draft. See gryt-changelog-notes.env.example.
+# Where ANTHROPIC_API_KEY or the OLLAMA_* settings live, along with the reports
+# address and key. Required: without a key the drafting goes to Ollama, whose
+# default is a local instance and there is not one on this box, and the script
+# refuses to start without somewhere to post a draft. See
+# gryt-changelog-notes.env.example.
 EnvironmentFile=-/etc/default/gryt-changelog-notes
 
 # It works on a git checkout and talks to two hosts, one on the LAN and one on


### PR DESCRIPTION
Ollama drafted 105 notes over the life of this script and 4 were published.
All 101 rejections had already passed every check in the file, so tightening
the checks wasn't going to help.

ANTHROPIC_API_KEY now picks the provider, the same way a key picks the triage
model in the reports service next to this one. Without a key everything runs
on Ollama exactly as before. GRYT_CHANGELOG_PROVIDER says which one when the
guess is wrong, and naming anthropic without a key is an error rather than a
quiet fall back to Ollama.

Nothing else moves. Same prompt, same style checks, same three attempts with
the refusal handed back, same review gate at /admin/changelog.

Two things change as a side effect of the window. A release took about forty
minutes on qwen3:32b and takes seconds through the API. And the commit block
stops being trimmed: the budget is what the prompt gets cut down to fit, and
ANTHROPIC_NUM_CTX defaults to 200,000 against Ollama's 24,576, so a long range
arrives whole. 1.5.5 is 164 commits and some of them never reached the model.

It costs money, which nothing else on this box does. Measured on the last three
releases the prompt is 13,000 to 15,000 tokens. The answer is a note of under a
thousand plus the thinking in front of it, and thinking bills as output, so an
attempt is around 15 cents at Opus 5 rates. Redrafting all 38 releases that
have no note comes to somewhere between five and fifteen dollars. The billing
is an API account, separate from any Claude subscription.

What is not tested: there is no API key on this machine, so no request has
reached Anthropic. The request shape is checked against a local server
pretending to be the API, covering the URL, the three headers, stream, model,
fallbacks, the json_schema format and a stream split mid-line on purpose. The
SSE reader has its own tests for collecting text deltas while ignoring the
thinking deltas around them.

The drafter's test file now runs in CI. It never has, so everything in it was
only ever run by hand.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
