### PR TITLE
Build the MSIX every release, attach it to none of them (GRYT-850)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1172,10 +1172,18 @@ jobs:
           # the release in Gryt-chat/client, where this token cannot write, and
           # got a 403 that no retry was ever going to clear. That is what left
           # v1.5.9 a draft with no .snap on it.
+          # `--win nsis portable` rather than a bare `--win`, which would also
+          # build the appx and publish it. The MSIX is built in its own step
+          # below and kept off the release, because nobody can install it: it
+          # is unsigned, and `Add-AppxPackage -AllowUnsigned` refuses any
+          # package that activates an executable, which every packaged Electron
+          # app does. v1.9.5 put 254MB on the release page that fails for
+          # everyone who downloads it. See packages/client/scripts/sign-windows.cjs
+          # for the HRESULTs and GRYT-848 for the certificate.
           if [[ "$RUNNER_OS" == "Linux" ]]; then
             TARGETS="--linux AppImage deb snap"
           elif [[ "$RUNNER_OS" == "Windows" ]]; then
-            TARGETS="--win"
+            TARGETS="--win nsis portable"
           else
             echo "Unsupported runner OS: $RUNNER_OS"
             exit 1
@@ -1217,6 +1225,60 @@ jobs:
             echo "Could not package and publish after 3 attempts." >&2
             exit 1
           fi
+
+      # The MSIX, built every release and attached to none of them.
+      #
+      # Built, because a target nobody builds rots. This one went out in v1.9.5
+      # carrying electron-builder's own SampleAppx placeholder tiles, which
+      # happened because until then nothing had ever looked inside the package
+      # the release was producing. It is also the artefact a Store submission
+      # uploads, so there has to be one to fetch.
+      #
+      # Not published, because an unsigned MSIX cannot be installed by anybody.
+      # Not by double-clicking it, and not with `Add-AppxPackage -AllowUnsigned`
+      # either — that refuses any package activating an executable, and Gryt's
+      # manifest activates `app\Gryt Chat.exe` as a Windows.FullTrustApplication.
+      # Attaching it to the release meant 254MB that failed for everyone who
+      # downloaded it. GRYT-848 is the certificate; a Store submission needs a
+      # Partner Center identity instead, because Microsoft signs what it
+      # distributes.
+      #
+      # Its own step rather than another target on the run above, because
+      # `--publish always` publishes everything it builds and there is no
+      # per-target way to opt one artefact out that is worth the config. The
+      # cost is one more pack over the same win-unpacked tree, a few minutes.
+      - name: Package the MSIX
+        if: runner.os == 'Windows'
+        working-directory: packages/client
+        shell: bash
+        env:
+          VERSION: ${{ env.VERSION }}
+          # Same as the step above. Empty until a certificate exists, and the
+          # hook says out loud that the package it just made cannot be
+          # installed.
+          GRYT_WIN_SIGN_TOOL: ${{ secrets.WINDOWS_SIGN_TOOL }}
+          GRYT_WIN_SIGN_ARGS: ${{ secrets.WINDOWS_SIGN_ARGS }}
+        run: |
+          set -euo pipefail
+
+          npx electron-builder \
+            --win appx \
+            --publish never \
+            -c.extraMetadata.version="$VERSION"
+
+          ls -la release/*.appx
+
+      # Kept for a month rather than forever. Long enough to pull one for a
+      # Store submission or to check what the tiles look like, short enough that
+      # a quarter-gigabyte per release does not pile up.
+      - name: Upload the MSIX
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: msix-${{ env.VERSION }}
+          path: packages/client/release/*.appx
+          retention-days: 30
+          if-no-files-found: error
 
       - name: Package macOS app
         if: runner.os == 'macOS'


### PR DESCRIPTION
v1.9.5 put a 254MB `.appx` on the release page that nobody can install, and every release since would have done the same.

Verified against the real package on a Windows 11 machine with Developer Mode already on:

```
Publisher='CN=ms'
  0x80073D2B  its publisher is not in the unsigned namespace

Publisher='CN=Gryt Chat, OID.2.25.311729368913984317654407730594956997722=1'
  0x80073D2B  an unsigned package cannot include Executable activations
```

Fixing the publisher clears the first check and hits the second, and the second does not move. `Add-AppxPackage -AllowUnsigned` refuses any package that activates an executable, and Gryt's manifest activates `app\Gryt Chat.exe` as a `Windows.FullTrustApplication`. Client PR #351 wrote both HRESULTs into `sign-windows.cjs`.

## What changed

The Windows run is `--win nsis portable` instead of a bare `--win`. The appx gets its own step with `--publish never`, and `actions/upload-artifact@v4` keeps it for 30 days.

Still built rather than dropped from `win.target`, for two reasons. It is the artefact a Store submission uploads, so there has to be one to fetch. And a target nobody builds rots: this one shipped in v1.9.5 with electron-builder's SampleAppx placeholder tiles because until then nothing had ever looked inside the package the release was producing.

## What to look at

**The second electron-builder invocation.** It re-runs `beforeBuild`, which repacks `embedded-server.tar.gz`, and packs `win-unpacked` again. Locally that was a few minutes; on the runner it should be similar, and the Windows job was 7 minutes on the v1.9.5 run. If that is too much, the alternative is `-c.appx.publish=null` on the single run, which I did not use because I have not confirmed electron-builder honours a null per-target publish and a wrong guess there publishes the file again.

**Whether the appx run should be inside the retry loop.** The publish step retries three times because `DownloadNoRetry` has dropped the Electron download mid-build before. This step runs after Electron is already cached locally, so it should not hit that, and a failure here fails the release rather than the artefact. That is arguably the wrong tradeoff now that the MSIX is not a release asset — `continue-on-error: true` would let a broken MSIX stop being a broken release. I left it strict on the grounds that a silently skipped build is how this target rotted in the first place, but it is a judgement call.

**`if-no-files-found: error`.** Deliberate. A missing artefact should fail loudly rather than upload an empty bundle.

## Testing

YAML parses and the steps land in the right order in `build-electron`, between "Package and publish Electron app" and "Package macOS app". `npx electron-builder --win appx --publish never` is the exact command this runs and it succeeded locally on Windows three times today, producing a package with the correct tiles.

Not tested on a runner. The Windows job is the only place `makeappx.exe` and the split invocation meet, so the first real proof is the next release. Worth watching the "Package the MSIX" step on it.
