### PR TITLE
Take the changelog file out of compose (GRYT-863)

### DIFF
--- a/.claude/skills/changelog-notes/SKILL.md
+++ b/.claude/skills/changelog-notes/SKILL.md
@@ -27,8 +27,13 @@ gh api --paginate -q '.[] | select(.draft|not) | [.tag_name, .prerelease] | @tsv
 ```
 
 ```bash
-ls packages/site/content/changelog/
+git -C packages/site ls-tree --name-only origin/main content/changelog/
 ```
+
+**Against `origin/main`, not the working checkout.** The superproject's copy of a submodule
+is routinely parked on somebody else's branch. On 2026-09-02 a plain `ls` of that directory
+showed three notes when there were four, and the missing one got overwritten by a new file
+with the same name.
 
 Stable releases are the ones that need a note. A beta only earns one when it has
 something above **Under the hood**, and it covers the whole `1.4.0` line rather

--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -112,19 +112,3 @@ REPORTS_VIKUNJA_PROJECT=2
 REPORTS_DIGEST_ENABLED=true
 REPORTS_DIGEST_DAY=1
 REPORTS_DIGEST_HOUR=9
-
-# Reading a drafted release note before it is published (GRYT-635).
-#
-# A drafter on this box used to post a note after a release, and reports held it
-# until somebody read it at /admin/changelog. The drafter is gone (GRYT-861) and
-# notes are written by hand, so nothing posts here any more. The routes stay
-# until the four published notes still living only in changelog.json are MDX in
-# the site (GRYT-863). Without this key they do not exist at all.
-#
-# Not one of the app keys above: those ship inside a public binary, and this one
-# writes to a page.
-REPORTS_CHANGELOG_KEY=replace-me
-
-# Where changelog.json is written and served from. The reports service mounts
-# this writable and the site mounts it read-only, so there is one writer.
-GRYT_CHANGELOG_DIR=/var/lib/gryt-changelog

--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -374,7 +374,16 @@ sudo rm -f /etc/default/gryt-changelog-notes /usr/local/lib/gryt/changelog-notes
 sudo systemctl daemon-reload
 ```
 
-Leave `/var/lib/gryt-changelog/changelog.json` alone for now. Four published
-notes are still only in that file, and the changelog page still fetches it at
-runtime. They become MDX first; the mounts, the reports routes and
-`REPORTS_CHANGELOG_KEY` come out after that, under GRYT-863.
+The notes that lived only in `/var/lib/gryt-changelog/changelog.json` are MDX in
+`packages/site` now, nothing fetches the file and nothing writes it, so the
+mounts and `REPORTS_CHANGELOG_KEY` are gone from the compose file too. Once
+site#78 and reports#28 are deployed, the directory on the box can go:
+
+```bash
+sudo rm -rf /var/lib/gryt-changelog
+```
+
+The `changelog_drafts` table inside the reports database is deliberately still
+there. It holds three unread drafts nobody will miss, and dropping a table in
+the database with every report ever sent is worth doing on purpose rather than
+as a line in a removal.

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -16,25 +16,6 @@ services:
       - "${INTERNAL_SITE_HTTP_PORT:-9472}:80"
     volumes:
       - ./downloads:/usr/share/nginx/html/downloads:ro
-      # Release notes, which the changelog page fetches at runtime. Mounted
-      # rather than built in so a note is live without rebuilding the site.
-      #
-      # Read-only here and writable in the reports service below, which is the
-      # only thing that writes this file.
-      #
-      # Frozen since GRYT-861. A drafter on this box used to post notes to
-      # reports, and notes are written by hand now, so nothing adds to the file
-      # any more. Four published notes are still only in it, which is why the
-      # mount is still here; it comes out with GRYT-863, once they are MDX.
-      #
-      # Its own path, not /changelog.json at the root: the site router owns
-      # /changelog, and a real file under a path the router also claims is a
-      # collision waiting to be discovered by somebody else.
-      #
-      # A missing source directory makes Docker create one, which is harmless
-      # here — the page treats an absent file the same as an empty one and
-      # renders the hand-written notes on their own.
-      - ${GRYT_CHANGELOG_DIR:-/var/lib/gryt-changelog}:/usr/share/nginx/html/release-notes:ro
     restart: unless-stopped
 
   # Component library docs (ui.gryt.chat). Built from packages/ui, which is a
@@ -178,21 +159,8 @@ services:
       REPORTS_OIDC_REDIRECT_URI: "${REPORTS_OIDC_REDIRECT_URI:-}"
       REPORTS_BOOTSTRAP_ADMIN: "${REPORTS_BOOTSTRAP_ADMIN:-}"
       REPORTS_SESSION_SECRET: "${REPORTS_SESSION_SECRET:-}"
-      # Reading a drafted release note before it is published (GRYT-635).
-      #
-      # A drafter on this box used to post notes here rather than writing the
-      # file the site reads, so nothing a model wrote was public until somebody
-      # had read it. The drafter is gone (GRYT-861) and nothing posts any more.
-      # The routes stay until the four published notes still living only in
-      # changelog.json are MDX in the site (GRYT-863). Empty here and set in
-      # .env; without
-      # it those routes do not exist.
-      REPORTS_CHANGELOG_KEY: "${REPORTS_CHANGELOG_KEY:-}"
-      REPORTS_CHANGELOG_FILE: /release-notes/changelog.json
     volumes:
       - gryt-reports-data:/data
-      # The same directory the site mounts read-only above. One writer.
-      - ${GRYT_CHANGELOG_DIR:-/var/lib/gryt-changelog}:/release-notes
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
`/var/lib/gryt-changelog` was bind-mounted into two containers so a drafter on
this box could write a note and the site could fetch it. Both halves are gone:
site#78 compiles every note in and stops fetching, reports#28 removes the routes
that wrote the file.

So the two mounts go, along with `REPORTS_CHANGELOG_KEY`, `REPORTS_CHANGELOG_FILE`
and `GRYT_CHANGELOG_DIR`. `docker compose config` still parses.

The README says how to remove the directory on the box, and why the
`changelog_drafts` table inside the reports database is deliberately left where
it is.

Also carries the fix to the changelog-notes skill from earlier on this branch:
it said to list the site's content directory, which reads the superproject's
checkout of a submodule and is how a hand-written 1.7.0 note nearly got
overwritten.

**Merge after site#78 and reports#28.** Removing the mount while either still
expects it leaves a container writing into its own filesystem instead of the
shared directory, which is harmless and pointless.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
