### PR TITLE
Tag the client repo when a client release goes out (GRYT-851)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -674,6 +674,49 @@ jobs:
             git push origin "v$VERSION"
           fi
 
+      # The superproject carries the release; this only makes the submodule's own
+      # history say which of its commits shipped.
+      #
+      # Without it `git describe` inside packages/client answers v1.3.1, which is
+      # what the tag list has said since August while ten minor versions went
+      # out. It is a stale answer that looks authoritative, and it is the first
+      # thing anybody reaches for when working out what a release contained.
+      #
+      # No GitHub Release here, unlike the server. The artifact belongs to the
+      # superproject — a second release in the client repo would be two things
+      # both claiming to be the release, with only one of them holding the
+      # installers.
+      - name: Tag client repo
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="v${{ steps.version.outputs.version }}"
+
+          # Same idempotency as the superproject tag above and `Tag server repo`
+          # in release-server.yml: a re-dispatch that already got this far finds
+          # its own tag and must not fail on it, and a tag naming a different
+          # commit is somebody else's and must not be moved. GRYT-300.
+          HEAD_SHA="$(git -C packages/client rev-parse HEAD)"
+          REMOTE_SHA="$(git -C packages/client ls-remote origin "refs/tags/${TAG}" | awk '{ print $1 }')"
+
+          if [[ -n "$REMOTE_SHA" ]]; then
+            if [[ "$REMOTE_SHA" == "$HEAD_SHA" ]]; then
+              echo "${TAG} is already on the client remote at ${HEAD_SHA} — nothing to do."
+              exit 0
+            fi
+
+            echo "${TAG} already exists in the client repo at ${REMOTE_SHA}," >&2
+            echo "but this release built ${HEAD_SHA}." >&2
+            echo "" >&2
+            echo "Refusing to move a published tag. Either delete the remote tag" >&2
+            echo "and dispatch again, or release a new version." >&2
+            exit 1
+          fi
+
+          git -C packages/client tag -f "$TAG" "$HEAD_SHA"
+          git -C packages/client push origin "$TAG"
+
       - name: Determine checkout ref
         id: ref
         shell: bash


### PR DESCRIPTION
`release-server.yml` has a `Tag server repo` step. `release-client.yml` has no equivalent — so the superproject gets a tag on every release and `Gryt-chat/client` has been stuck on **v1.3.1 since August**, through ten minor versions.

That is a trap rather than an untidiness. `git describe` inside `packages/client` answers v1.3.1, which looks authoritative and is four months stale. It caught me twice today, looking for the last client release before deciding what a release would contain.

## The step

Same shape as `Tag server repo`, including its idempotency: a re-dispatch that already got this far accepts its own tag rather than failing on "tag already exists", and a tag naming a *different* commit is refused rather than force-moved.

Credentials are already in place — `packages/client`'s remote is set with `RELEASE_PAT` at the top of the job, before anything is published.

**No GitHub Release in the client repo**, unlike the server. The artifact belongs to the superproject; a second release there would be two things claiming to be the release with only one holding the installers. This is a tag and nothing else.

## The backfill is not in here

146 superproject release tags have no counterpart in the client repo. I have the script and a clean dry run — 146 to create, 2 already correct, 0 conflicts, every client commit resolvable from the superproject gitlink at that tag. Pushing 146 tags to a shared repo in one go is Sivert's call, so it is waiting on that rather than riding along in a workflow PR.

## Checked

YAML parses, the step lands between `Commit release metadata and tag` and `Determine checkout ref`, no tabs. `release-client.yml` is LF (unlike `release-server.yml`, which is CRLF) and stayed LF.

Not exercised: the step itself only runs on a real release dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)