### PR TITLE
Stop naming a private tracker in a public repository (GRYT-889)

### DIFF
--- a/.claude/skills/changelog-notes/SKILL.md
+++ b/.claude/skills/changelog-notes/SKILL.md
@@ -96,9 +96,9 @@ Merge branch · Bump … · Build N, because …
 
 ### Why, as opposed to what
 
-The commits carry `GRYT-` numbers. Those lead to the tasks at
-[tasks.sivert.io](https://tasks.sivert.io), which is where the reason lives. Use
-the range for what changed and the task for why it was worth doing.
+The commits carry `GRYT-` numbers. Those lead to the tasks in Vikunja, which is
+where the reason lives. Use the range for what changed and the task for why it
+was worth doing.
 
 A commit with no body gives you a subject and nothing else. It doesn't give you a
 symptom, a cause, or who it affected. Three drafts were thrown away for inventing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ current client.
 Branch naming is `claude/<id>-<slug>`, matching the existing `copilot/*` branches:
 
 ```
-claude/GRYT-118-invite-expiry     # Vikunja task at tasks.sivert.io
+claude/GRYT-118-invite-expiry     # Vikunja task
 claude/gh-42-invite-expiry        # GitHub issue
 claude/docs-ai-policy-typo        # no ticket — use a descriptive slug
 ```
@@ -116,8 +116,8 @@ AI involvement with `git log`. Stripping the trailer breaks a promise Gryt made 
 
 ## Task tracking
 
-Tasks live in Vikunja at [tasks.sivert.io](https://tasks.sivert.io), project `GRYT`. The
-kanban board is the state: **To-Do → Doing → Review → Done**.
+Tasks live in Vikunja, project `GRYT`. Sivert has the address; it is not written down in
+a public repository. The kanban board is the state: **To-Do → Doing → Review → Done**.
 
 | When | What happens | Who does it |
 |------|--------------|-------------|

--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -110,7 +110,7 @@ services:
       # Every interface, not just loopback. The tunnel reaches this over the
       # network as dev.lan:5010, and the server defaults to 127.0.0.1 — so
       # without this it answers the healthcheck (which curls localhost on the
-      # same box) while the tunnel gets nothing, and beta.sivert.io serves a
+      # same box) while the tunnel gets nothing, and the beta hostname serves a
       # 502 next to a container `docker ps` calls healthy. Prod has always had
       # it; server-nt got it in #56; this one was missed.
       HOST: "0.0.0.0"

--- a/ops/internal/.env.example
+++ b/ops/internal/.env.example
@@ -101,8 +101,9 @@ GRYT_SMTP_PASS=replace-me
 # Fider SMTP options
 FIDER_EMAIL_SMTP_ENABLE_STARTTLS=true
 
-# Filing a report as a task on the board (GRYT-534). A write credential.
-REPORTS_VIKUNJA_URL=https://tasks.sivert.io
+# Filing a report as a task on the board (GRYT-534). A write credential, and
+# the board's own address. Both are needed before the button is offered.
+REPORTS_VIKUNJA_URL=
 REPORTS_VIKUNJA_TOKEN=
 REPORTS_VIKUNJA_PROJECT=2
 

--- a/ops/internal/docker-compose.yml
+++ b/ops/internal/docker-compose.yml
@@ -132,8 +132,9 @@ services:
       REPORTS_DISCORD_WEBHOOK_URL: "${REPORTS_DISCORD_WEBHOOK_URL:-}"
       # Filing a report as a task on the board (GRYT-534). A write credential,
       # so it is empty here and set in .env; without it the button is not
-      # offered rather than offered and broken.
-      REPORTS_VIKUNJA_URL: "${REPORTS_VIKUNJA_URL:-https://tasks.sivert.io}"
+      # offered rather than offered and broken. The address has no default
+      # either — a built-in one files onto whoever's board was compiled in.
+      REPORTS_VIKUNJA_URL: "${REPORTS_VIKUNJA_URL:-}"
       REPORTS_VIKUNJA_TOKEN: "${REPORTS_VIKUNJA_TOKEN:-}"
       REPORTS_VIKUNJA_PROJECT: "${REPORTS_VIKUNJA_PROJECT:-2}"
       # The weekly digest (GRYT-537). SMTP is the GRYT_SMTP_* set the rest of


### PR DESCRIPTION
Every Gryt repository is public except `.github-private`. `sivert.io` is a personal domain, and it appeared in six places in the superproject.

## The one that did something

`ops/internal/docker-compose.yml` defaulted `REPORTS_VIKUNJA_URL` to `https://tasks.sivert.io` when the variable was unset. The reports service carried the same fallback in its own source, fixed in [Gryt-chat/reports#30](https://github.com/Gryt-chat/reports/pull/30), opened alongside this.

Neither ever filed anything by accident: the board needs a token as well, and the token is not in either repository. The default was inert. It was still the wrong shape, and it published the address.

## The rest is prose

`CLAUDE.md` and `.claude/skills/changelog-notes/SKILL.md` now name Vikunja without naming the host. Contributors without access were already told to use `gh-<n>`, so nothing depended on the URL being written down.

`ops/deploy/compose/beta.yml` had `beta.sivert.io` in a comment about a server binding loopback and answering its own healthcheck while the tunnel serves a 502. It reads the same as "the beta hostname".

## What to look at

`REPORTS_VIKUNJA_URL: "${REPORTS_VIKUNJA_URL:-}"` is the only line that changes behaviour, and only for a deployment that sets a token but not a URL. `ops/internal/.env` on dev sets both explicitly, so the running service is unaffected. Confirmed the pair of PRs is consistent: with reports#30 merged, an empty URL means the Create task button is not offered, rather than the task being filed somewhere unexpected.

This PR does not move the reports gitlink. That follows once reports#30 merges.

## Also done outside the repo

`status.gryt.chat` had a check pointing at `sfu.sivert.io`. Removed the same day, along with the demo-server check, which is a store-review server rather than something a user of Gryt Chat has a reason to see. Scanned the live public sites afterwards — gryt.chat, docs, app, get, status, feedback and ui all return zero mentions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)