### PR TITLE
Put the status page config in the repository (GRYT-888)

### DIFF
--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -8,11 +8,16 @@ This folder contains **internal** infrastructure used to run:
 - `feedback.gryt.chat` (Fider feature requests board)
 - `reports.gryt.chat` (bug reports and feedback from inside the apps, and the inbox at `/admin`)
 - `community.gryt.chat` (the one Gryt server we run — see [`community/`](community/))
+- `status.gryt.chat` (the public status page — see [`status/`](status/))
 
 The first five run together from `docker-compose.yml` here, on the Docker host at home.
 `community.gryt.chat` is its own stack on an isolated VM under Astro, with its own
 Cloudflare tunnel rather than the one on this host. Written up in
 [`community/README.md`](community/README.md).
+
+`status.gryt.chat` is on the Gigahost VPS, and not at home on purpose: everything it
+watches is served from home, so a status page next to those services goes dark with them.
+Written up in [`status/README.md`](status/README.md).
 
 It’s **not** intended for self-hosters. Self-hosting docs live under `ops/deploy/*` (Docker Compose) and `ops/helm/*` (Kubernetes).
 

--- a/ops/internal/status/README.md
+++ b/ops/internal/status/README.md
@@ -1,0 +1,83 @@
+# ops/internal/status
+
+The public status page at [status.gryt.chat](https://status.gryt.chat). It runs
+[Gatus](https://github.com/TwiN/gatus) and watches Gryt from the outside.
+
+## Why it isn't on the Docker host at home
+
+Everything it watches is served from home through a Cloudflare tunnel. A status
+page sitting next to those services would go dark at the same moment they do,
+which is the one moment anybody looks at it. So it runs on the Gigahost VPS
+instead, on its own Cloudflare tunnel, and it checks the public hostnames rather
+than internal ports. What the page reports is what a user gets, tunnel and CDN
+included.
+
+## Every check asserts on the body
+
+A status code can't tell a working service from an error page standing where the
+service used to be. Anything answering on the hostname returns a code, and so
+does an edge that puts its own page up when the origin is gone. So each check
+also names something only the real service serves: a title, an issuer, a JSON
+field.
+
+It wasn't always like that. Until 2026-09-03 most checks were `[STATUS] < 400`
+and nothing else, so a page that wasn't the service passed.
+
+If you add an endpoint, give it a body condition. To check the condition does
+any work, break it on purpose and confirm the endpoint goes red.
+
+## What it deliberately doesn't watch
+
+Only hosts under `gryt.chat`. Nothing personal, nothing on another domain.
+
+The demo server is for store review. This page is for people using Gryt.
+
+The community server belongs here once it has a DNS record. It's the default
+server in the client and it's named on the site, so it's the one server a user
+has a reason to see the state of. Tracked as GRYT-873.
+
+## Deploying
+
+It lives at `/opt/gryt-status` on the VPS. Copy this folder there and bring it
+up:
+
+```bash
+scp -r ops/internal/status/* vps:/opt/gryt-status/
+ssh vps 'cd /opt/gryt-status && docker compose up -d'
+```
+
+Gatus reads the config at start, so a change needs a restart:
+
+```bash
+ssh vps 'cd /opt/gryt-status && docker compose restart'
+```
+
+## Validate before you deploy
+
+A bad config stops the container, and the page goes down with it. Run the config
+in a throwaway container first and read what it says:
+
+```bash
+ssh vps 'timeout 25 docker run --rm --pull=never \
+  -v /opt/gryt-status/config/config.yaml.new:/config/config.yaml:ro \
+  -v /tmp/gatus-validate:/data \
+  twinproduction/gatus:v5.36.0 2>&1 | grep -E "Validated|success="'
+```
+
+It prints how many endpoints parsed, then runs every check once, so a typo in a
+body condition shows up as `success=false` before it reaches the live page.
+
+Don't grep that output for the word `errors`. Every passing line ends in
+`errors=0`.
+
+## Reading it
+
+The page is at status.gryt.chat. The JSON behind it is at
+`/api/v1/endpoints/statuses`, which is easier to read from a terminal:
+
+```bash
+curl -s https://status.gryt.chat/api/v1/endpoints/statuses | jq -r '.[] | "\(.group) \(.name) \(.results[-1].success)"'
+```
+
+History is SQLite in the `gatus-data` volume, so it survives a restart but not a
+`compose down -v`.

--- a/ops/internal/status/config/config.yaml
+++ b/ops/internal/status/config/config.yaml
@@ -1,0 +1,119 @@
+# Gryt public status page.
+#
+# Runs on the VPS on purpose: everything it watches is served from home through
+# a Cloudflare tunnel, so a status page hosted alongside those services would go
+# dark exactly when somebody needs it.
+#
+# Checks hit the public hostnames rather than internal ports, so what this page
+# reports is what a user actually experiences, tunnel and CDN included.
+#
+# Every check asserts on the response body, not only on the status code. A
+# status code alone cannot tell a working service from an error page standing
+# where the service used to be — anything that answers on the hostname passes a
+# code check, including whatever the edge substitutes when the origin is gone.
+# The body assertions below name something only the real service serves.
+
+storage:
+  type: sqlite
+  path: /data/data.db
+
+ui:
+  title: "Gryt Status"
+  header: "Gryt Status"
+  description: "Live status of the Gryt services you can reach from the internet."
+  link: "https://gryt.chat"
+endpoints:
+  # ── Signing in ──────────────────────────────────────────────────
+  # The discovery document, not the login page: it is what every client
+  # fetches before it can authenticate, so if this is down nobody signs in.
+  - name: "Accounts (Keycloak)"
+    group: "Signing in"
+    url: "https://auth.gryt.chat/realms/gryt/.well-known/openid-configuration"
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].issuer == https://auth.gryt.chat/realms/gryt"
+      - "[CERTIFICATE_EXPIRATION] > 240h"
+
+  # The certificate authority. Joining any server needs a certificate from it,
+  # so this being down looks like "I can log in but cannot join anything".
+  - name: "Identity certificates"
+    group: "Signing in"
+    url: "https://id.gryt.chat/health"
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].status == ok"
+
+  # ── Apps ────────────────────────────────────────────────────────
+  - name: "Web client"
+    group: "Apps"
+    url: "https://app.gryt.chat/"
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] == pat(*<title>Gryt</title>*)"
+      - "[CERTIFICATE_EXPIRATION] > 240h"
+
+  - name: "Beta web client"
+    group: "Apps"
+    url: "https://beta.gryt.chat/"
+    interval: 120s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] == pat(*<title>Gryt</title>*)"
+
+  # The CLI installer. Piped straight into sh, so a wrong body here is worse
+  # than a missing one.
+  - name: "CLI installer"
+    group: "Apps"
+    url: "https://get.gryt.chat/"
+    interval: 120s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] == pat(*Installs the Gryt CLI*)"
+
+  # ── Sites ───────────────────────────────────────────────────────
+  - name: "Homepage"
+    group: "Sites"
+    url: "https://gryt.chat/"
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] == pat(*Voice, Text & Video Chat*)"
+      - "[CERTIFICATE_EXPIRATION] > 240h"
+
+  # Root 307s to /docs, so check where it lands rather than the redirect.
+  - name: "Documentation"
+    group: "Sites"
+    url: "https://docs.gryt.chat/docs"
+    interval: 120s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] == pat(*Gryt Documentation*)"
+
+  - name: "Feature requests"
+    group: "Sites"
+    url: "https://feedback.gryt.chat/"
+    interval: 120s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] == pat(*<title>Gryt Chat</title>*)"
+
+  - name: "Component library"
+    group: "Sites"
+    url: "https://ui.gryt.chat/"
+    interval: 300s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] == pat(*the component library behind Gryt*)"
+
+  # In-app bug reports and feedback post here. Down means reports are lost
+  # silently, which nobody notices from inside the app.
+  - name: "Bug report intake"
+    group: "Sites"
+    url: "https://reports.gryt.chat/"
+    interval: 120s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].ok == true"

--- a/ops/internal/status/docker-compose.yml
+++ b/ops/internal/status/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  gatus:
+    image: twinproduction/gatus:v5.36.0
+    container_name: gryt-status
+    restart: unless-stopped
+    # Loopback only. The Cloudflare tunnel reaches it from this host; nothing
+    # else should. It also keeps it clear of the 1024:65000 DNAT that forwards
+    # this box's public ports to the WireGuard peer at home.
+    ports:
+      - "127.0.0.1:3001:8080"
+    volumes:
+      - ./config:/config:ro
+      - gatus-data:/data
+    environment:
+      GATUS_CONFIG_PATH: /config
+    healthcheck:
+      test: ["CMD", "/gatus", "--help"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  gatus-data:


### PR DESCRIPTION
The Gatus config behind [status.gryt.chat](https://status.gryt.chat) lived at `/opt/gryt-status` on the Gigahost VPS and nowhere else. No history, no review, no copy. Rebuilding the box would have lost it, and a bad edit had nothing to diff against.

It got rewritten on 2026-09-03 to assert on response bodies rather than status codes, which is exactly the kind of change that should have been a diff somebody could read. The only record was a dated backup file next to it.

## Nothing changes about what the page does

`config/config.yaml` and `docker-compose.yml` come across byte for byte from the running box. Verified with `diff` after copying, both identical. This is a copy into version control, not an edit.

## What to look at

The README is the substance. It covers why the page runs on the VPS rather than on the Docker host at home, the rule that every check asserts on the body and how to confirm a new condition does any work, what the page deliberately does not watch, and how to validate a config in a throwaway container before it reaches the live page.

Deploying is `scp` plus `docker compose up -d`, which is manual but at least starts from a reviewed file rather than from somebody editing in place. If that should be a script or a workflow instead, say so and I'll open a follow-up.

## Context

`status/` sits next to `community/`, which follows the same shape: its own stack, on its own box, with its own Cloudflare tunnel and its own README. `ops/internal/README.md` now lists both.

Two things the README records that were decided today: the page names no host outside `gryt.chat`, and it does not watch the demo server, which exists for store review rather than for people using Gryt. The community server goes on the page once it has a DNS record, which is GRYT-873.

🤖 Generated with [Claude Code](https://claude.com/claude-code)