### PR TITLE
community.gryt.chat is live, and the README described a tunnel we did not build (GRYT-873)

### DIFF
--- a/ops/internal/community/README.md
+++ b/ops/internal/community/README.md
@@ -22,7 +22,8 @@ might get a shell on.
       │  DNAT udp/10000 -> 10.2.0.6, over WireGuard
       ▼
     VM gryt-community  (192.168.122.213 on virbr0, 10.2.0.6 on wg0)
-      └─ compose: server, sfu, minio, image-worker, cloudflared
+      ├─ cloudflared, as a systemd service on the VM
+      └─ compose: server, sfu, minio, image-worker
 ```
 
 Everything the VM sends leaves through the VPS (`AllowedIPs = 0.0.0.0/0`). That
@@ -35,14 +36,16 @@ because calls kept connecting on a candidate nobody had chosen.
 
 | | Where | Reachable from |
 |---|---|---|
-| Server HTTP | `server:5000` on the compose network | `community.gryt.chat`, via cloudflared |
-| SFU signalling | `sfu:5005` on the compose network | `community-sfu.gryt.chat`, via cloudflared |
+| Server HTTP | `127.0.0.1:5020` on the VM | `community.gryt.chat`, via cloudflared |
+| SFU signalling | `127.0.0.1:5025` on the VM | `community-sfu.gryt.chat`, via cloudflared |
 | SFU media | `0.0.0.0:10000/udp` on the VM | the VPS address, DNAT'd over WireGuard |
 | MinIO | compose network | nothing |
 | Metrics | compose network | nothing |
 
-`127.0.0.1:5020` and `127.0.0.1:5025` are also published on the VM. Those are
-for debugging from inside it; cloudflared reaches the services by name.
+`127.0.0.1:5020` and `127.0.0.1:5025` are how cloudflared reaches the two
+services. It runs as a systemd unit on the VM rather than in the compose
+project, so it is not on the compose network and cannot resolve `server` or
+`sfu`. Those two ports are load-bearing, not debug conveniences.
 
 ## Isolation
 
@@ -113,11 +116,24 @@ sudo install -d -o sivert -g sivert /opt/gryt-community
 # copy compose.yml, backup.sh and .env.example from this directory
 cp .env.example .env    # fill in every blank
 docker compose up -d
-docker compose --profile tunnel up -d    # once CLOUDFLARE_TUNNEL_TOKEN is set
 ```
 
-The tunnel's ingress in the Zero Trust dashboard points at `http://server:5000`
-and `http://sfu:5005`, since cloudflared runs on the compose network.
+Then the tunnel, following Cloudflare's own install steps from the Zero Trust
+dashboard. That installs cloudflared as a systemd unit reading
+`/etc/cloudflared/token`, which is what runs today.
+
+Its two published application routes point at `http://localhost:5020` and
+`http://localhost:5025`, because a systemd cloudflared is not on the compose
+network and `server` and `sfu` do not resolve there. Adding a route through the
+dashboard creates the DNS record as well, so there is nothing to add by hand.
+
+`compose.yml` still carries a `cloudflared` service behind a `tunnel` profile,
+from before. It is unused. Starting it with an empty `CLOUDFLARE_TUNNEL_TOKEN`
+gives a container that restarts forever with `"cloudflared tunnel run" requires
+the ID or name of the tunnel`, which is what an empty token looks like. To use
+it instead of the systemd unit, put the token in `.env`, `systemctl disable
+--now cloudflared`, and repoint both routes at `http://server:5000` and
+`http://sfu:5005`.
 
 `community-sfu.gryt.chat`, one label deep. Cloudflare's universal certificate
 covers `*.gryt.chat` and stops there, so `sfu.community.gryt.chat` would need

--- a/ops/internal/status/config/config.yaml
+++ b/ops/internal/status/config/config.yaml
@@ -45,6 +45,32 @@ endpoints:
       - "[STATUS] == 200"
       - "[BODY].status == ok"
 
+  # ── Talking ─────────────────────────────────────────────────────
+  # The default server in the client and the one named on the site, so it is
+  # the only server a user has a reason to see the state of.
+  #
+  # No serverId assertion: /info reports it as null on this deployment, so the
+  # name is what distinguishes the real service from anything else answering
+  # on the hostname.
+  - name: "Community server"
+    group: "Talking"
+    url: "https://community.gryt.chat/info"
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].name == Gryt Chat (OFFICIAL)"
+
+  # Voice for that server. /health is the only path here that answers plain
+  # HTTP; everything else expects a WebSocket upgrade and answers 400 by design.
+  - name: "Community voice (SFU)"
+    group: "Talking"
+    url: "https://community-sfu.gryt.chat/health"
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].status == healthy"
+      - "[BODY].service == sfu"
+
   # ── Apps ────────────────────────────────────────────────────────
   - name: "Web client"
     group: "Apps"


### PR DESCRIPTION
The community server had been running on its VM for days with nothing pointing at it. It is named in the Terms, the Privacy Policy and the Community Guidelines, and it is the default server in the client, so all of those described a service that did not resolve.

## It resolves now

- `community.gryt.chat/info` → 200, `{"name":"Gryt Chat (OFFICIAL)","members":"1","joinPolicy":"request"}`
- `community-sfu.gryt.chat/health` → 200
- A WebSocket upgrade against the SFU returns `101 Switching Protocols` through the tunnel
- HSTS already covers both, from the `includeSubDomains` set on the zone earlier today

## Two things the repository had wrong

**cloudflared runs as a systemd unit on the VM**, installed from Cloudflare's own dashboard steps, not as the compose service this README described. It is therefore not on the compose network, `server` and `sfu` do not resolve for it, and the published application routes point at `http://localhost:5020` and `http://localhost:5025`.

That inverts something the README stated: those two ports were described as debug conveniences reachable from inside the VM, with cloudflared reaching the services by name. They are the actual path.

**The `cloudflared` service behind the `tunnel` profile in `compose.yml` is unused.** Left in place rather than deleted, but the README now says so, describes what an empty token looks like if you start it by accident (a container restart-looping on `"cloudflared tunnel run" requires the ID or name of the tunnel`), and gives the three steps to switch back to it.

## Status page

Gains the two checks that were blocked on the DNS record. Both assert on the body, per the rule in `ops/internal/status/README.md`: the server on its name, because `/info` reports `serverId` as null on this deployment, and the SFU on `status` and `service`.

Validated in a throwaway container before deploying, and the committed config is byte-identical to what is running — verified with `diff`. The live page now shows 12 endpoints, all green.

## What to look at

Whether the systemd unit is the arrangement you want long term, or whether this should move to the compose service so `docker compose down` takes the tunnel with it. I documented what exists rather than changing working infrastructure. The README has the switch-back steps either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)