### PR TITLE
Keep the community server current, and stop checking a voice server nobody uses (GRYT-873)

### DIFF
--- a/ops/internal/community/README.md
+++ b/ops/internal/community/README.md
@@ -140,6 +140,28 @@ covers `*.gryt.chat` and stops there, so `sfu.community.gryt.chat` would need
 Advanced Certificate Manager and the failure is a TLS error at the edge that
 nothing in Gryt's logs mentions.
 
+## Staying current
+
+The VM was found on server 1.8.3 with 1.8.8 released, because `SERVER_VERSION`
+and friends in `.env` pinned exact tags and a pinned tag never moves. Same shape
+as GRYT-291, where app.gryt.chat served a build five versions behind the desktop
+app for weeks.
+
+Those three variables are `latest` now, and
+[`update.sh`](update.sh) pulls them from a ten-minute timer. It only ever pulls
+the tag a service is already configured for, so putting a version back in `.env`
+pins that service again and this stops moving it.
+
+It recreates a container only when the tag resolves to a different image. The
+first version of that check compared `docker inspect .Image` against
+`docker compose images -q`, which answer in different id formats, so nothing
+ever matched and every service was recreated every ten minutes. Run it twice in
+a row when changing it — the second run has to say `already on`.
+
+The SFU is left alone while anybody is in voice, since recreating it drops every
+call on it. Nobody is expected to use voice on this server, but expected is not
+the same as never.
+
 ## Backups
 
 `backup.sh` runs nightly through the systemd units in `systemd/`, writes to

--- a/ops/internal/community/systemd/gryt-community-update.service
+++ b/ops/internal/community/systemd/gryt-community-update.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Pull the images community.gryt.chat is configured for
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/opt/gryt-community/.env
+ExecStart=/opt/gryt-community/update.sh

--- a/ops/internal/community/systemd/gryt-community-update.timer
+++ b/ops/internal/community/systemd/gryt-community-update.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Keep community.gryt.chat on the last released images
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=10min
+Persistent=true
+RandomizedDelaySec=120
+
+[Install]
+WantedBy=timers.target

--- a/ops/internal/community/update.sh
+++ b/ops/internal/community/update.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Keep community.gryt.chat on the images the last release published.
+#
+# The VM was found on server 1.8.3 while 1.8.7 was out. Nothing on the box ever
+# pulled, because SERVER_VERSION and friends in .env pinned exact tags and a
+# pinned tag never moves. Same shape as GRYT-291, where app.gryt.chat served a
+# build five versions behind the desktop app for weeks.
+#
+# So the versions are `latest` now and this pulls them. The trade is the one
+# refresh-web-client.sh made on dev on 2026-08-21: rolling forward on a timer
+# is a decision, and so is leaving a public server behind, and the second one
+# is the decision that keeps producing bugs nobody can reproduce.
+#
+# To pin again, put a version back in .env and `docker compose up -d`. This
+# script only ever pulls the tag a service is already configured for, so a
+# pinned service stops moving the moment you pin it.
+#
+# Run from the systemd timer beside this script. Safe to run by hand.
+
+set -euo pipefail
+
+DIR="${GRYT_COMMUNITY_DIR:-/opt/gryt-community}"
+SERVICES="${GRYT_COMMUNITY_SERVICES:-server sfu image-worker}"
+MIN_FREE_GB="${GRYT_MIN_FREE_GB:-3}"
+
+log() { printf '%s  %s\n' "$(date -Is)" "$*"; }
+
+cd "$DIR"
+
+free_gb=$(df -BG --output=avail . | tail -1 | tr -dc '0-9')
+if (( free_gb < MIN_FREE_GB )); then
+  log "only ${free_gb}G free, need ${MIN_FREE_GB}G — not pulling"
+  exit 0
+fi
+
+for service in $SERVICES; do
+  container="gryt-community-${service}"
+
+  before=$(docker inspect --format '{{.Image}}' "$container" 2>/dev/null || true)
+  if [[ -z "$before" ]]; then
+    log "[$service] no container named $container — skipped"
+    continue
+  fi
+
+  # Recreating the SFU drops every call on it, so leave it alone while anybody
+  # is connected and take it on a later tick. Voice is not expected on this
+  # server, but "not expected" is not "never", and a dropped call to save ten
+  # minutes is a bad trade.
+  if [[ "$service" == "sfu" ]]; then
+    peers=$(curl -sf --max-time 5 http://127.0.0.1:5025/metrics 2>/dev/null \
+      | awk '/^gryt_sfu_peers_active /{print $2}' || true)
+    if [[ -n "$peers" && "$peers" != "0" ]]; then
+      log "[$service] $peers in voice — leaving it, will try again next tick"
+      continue
+    fi
+  fi
+
+  if ! docker compose pull "$service" >/dev/null 2>&1; then
+    log "[$service] pull failed — leaving the running container alone"
+    continue
+  fi
+
+  # Compare like with like. `before` is the image the running container was
+  # created from, so `after` has to be the image that container's own tag
+  # resolves to now, read the same way. `docker compose images -q` answers in a
+  # different id format, so it never matched and every service was recreated on
+  # every tick — the ten-minute churn refresh-web-client.sh warns about, found
+  # by running this twice in a row and watching it recreate a second time.
+  ref=$(docker inspect --format '{{.Config.Image}}' "$container" 2>/dev/null || true)
+  after=$(docker image inspect --format '{{.Id}}' "$ref" 2>/dev/null || true)
+  if [[ -z "$after" || "$before" == "$after" ]]; then
+    log "[$service] already on ${ref:-?}"
+    continue
+  fi
+
+  docker compose up -d --no-deps "$service" >/dev/null 2>&1
+  log "[$service] recreated on $ref (${before:7:12} -> ${after:7:12})"
+done

--- a/ops/internal/status/config/config.yaml
+++ b/ops/internal/status/config/config.yaml
@@ -49,6 +49,9 @@ endpoints:
   # The default server in the client and the one named on the site, so it is
   # the only server a user has a reason to see the state of.
   #
+  # Its SFU is not checked. Voice is not expected on this server, and a red
+  # light for something nobody uses trains people to ignore the page.
+  #
   # No serverId assertion: /info reports it as null on this deployment, so the
   # name is what distinguishes the real service from anything else answering
   # on the hostname.
@@ -59,17 +62,6 @@ endpoints:
     conditions:
       - "[STATUS] == 200"
       - "[BODY].name == Gryt Chat (OFFICIAL)"
-
-  # Voice for that server. /health is the only path here that answers plain
-  # HTTP; everything else expects a WebSocket upgrade and answers 400 by design.
-  - name: "Community voice (SFU)"
-    group: "Talking"
-    url: "https://community-sfu.gryt.chat/health"
-    interval: 60s
-    conditions:
-      - "[STATUS] == 200"
-      - "[BODY].status == healthy"
-      - "[BODY].service == sfu"
 
   # ── Apps ────────────────────────────────────────────────────────
   - name: "Web client"


### PR DESCRIPTION
This was the second commit on the branch behind #177. That PR merged while the commit was still being written, so the work is live on the boxes and was missing from the repository. Same content, rebased onto main.

## Nothing on the VM ever pulled

It was on server 1.8.3 with 1.8.8 released, and SFU 1.0.61 with 1.0.63 out. `SERVER_VERSION`, `SFU_VERSION` and `IMAGE_WORKER_VERSION` in `.env` pinned exact tags, and a pinned tag never moves. That is GRYT-291 again, where app.gryt.chat served a build five versions behind the desktop app for weeks because nothing pulled it either.

Those three are `latest` now, and `update.sh` pulls them from a ten-minute timer, next to the backup timer already there. It only pulls the tag a service is already configured for, so putting a version back in `.env` pins that service and stops this moving it.

Already applied: 1.8.3 → 1.8.8, 1.0.61 → 1.0.63, image-worker → latest, all four containers healthy after.

## The bug worth reading

The first version of the "did the image move" check compared `docker inspect .Image` against `docker compose images -q`. Those answer in different id formats, so nothing ever matched and all three services were recreated on every run — on a ten-minute timer, a public server restarting six times an hour, forever.

Found by running it twice in a row and watching the second run recreate again, not by reading it. The README now says to do that when changing it: the second run has to say `already on`.

## Status page

No longer checks the community SFU. Voice is not part of what that server is for, and a red light for something nobody uses teaches people to ignore the page. The server itself is still checked, on its name.

## Verified

`update.sh`, both systemd units and the status config are byte-identical to what is running — checked with `diff` against the VM and the status host after rebasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)