### PR TITLE
Add packages/core

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -193,6 +193,18 @@ git push                        # then the gitlink
 
 Reverse that order and the superproject points at a commit that doesn't exist on the remote.
 
+**`packages/core` is `@gryt/core`, the logic the client and the phone share.** Before
+writing something on one side, check whether the other already does it: the goal is that
+the two apps don't diverge in method or choice. Something belongs in that package if it
+compiles with no DOM and no React Native, and both apps would otherwise need a copy. Its
+tsconfig leaves `DOM` out of `lib` so the first half of that fails loudly rather than
+quietly.
+
+**Both apps pin the same version of every `@gryt/*` package.** `@gryt/voice` is at `0.4.4`
+in the client and `^0.3.2` in mobile, which is what this is meant to stop: a shared package
+on two versions is two implementations again. If one app needs a version the other can't
+take yet, that's the thing to fix.
+
 ## Package manager
 
 Use **yarn, never npm**. `packages/client` and `packages/server` both ship `yarn.lock` and

--- a/.gitmodules
+++ b/.gitmodules
@@ -54,3 +54,7 @@
 	path = packages/crypto
 	url = https://github.com/Gryt-chat/crypto.git
 	branch = main
+[submodule "packages/core"]
+	path = packages/core
+	url = https://github.com/Gryt-chat/core.git
+	branch = main


### PR DESCRIPTION
`@gryt/core` as the fifteenth submodule, pointing at `c4d0013` on its main.

## What it is

The logic the client and the phone share. The first version replaces two copies
each of the reports payload and the link preview provider table — the second of
which I created earlier today, which is what prompted the whole thing.

Something belongs in it if it compiles with no DOM and no React Native, and both
apps would otherwise need a copy. The package's tsconfig leaves `DOM` out of
`lib`, so the first half is a build error rather than a judgement call.

## The CLAUDE.md addition

Two rules, in the Submodules section:

- what belongs in the package, so the next person doesn't have to infer it
- **both apps pin the same version of every `@gryt/*` package** — `@gryt/voice`
  is at `0.4.4` in the client and `^0.3.2` in mobile, and a shared package on
  two versions is two implementations again

If you'd rather CLAUDE.md stayed shorter, that half is a clean revert; the rules
are also in my memory for this repo.

## Nothing consumes it yet

In order from here:

1. **Publish 0.1.0** — needs you. `@gryt/core` isn't on npm, and trusted
   publishing has to be configured against a package that already exists. So it
   wants either the trusted-publisher setup on npmjs.com or one manual
   `npm publish`. The release workflow is dispatch-only and self-sufficient
   after that.
2. Client and mobile drop their copies and import it, pinned to the same version.

Step 2 is where the duplication actually goes away. Until then this is a
submodule nothing imports, which is deliberate — the alternative was landing the
package and the two app rewrites in one unreviewable change.
