### PR TITLE
Take the AI sentence out of the store listings

### DIFF
--- a/marketing/listings/microsoft-store.en-US.md
+++ b/marketing/listings/microsoft-store.en-US.md
@@ -14,7 +14,7 @@ Voice goes over WebRTC through an SFU, so one server relays the audio and a call
 
 Messages are encrypted and the keys are yours. Your identity is a keypair the app makes and keeps on your device, not an account somebody else can lock you out of.
 
-The whole thing is open source under the AGPL: the desktop client, the server, the media server, the docs, and a written policy on how much of it was built with AI and how you can check that yourself with git log.
+The whole thing is open source under the AGPL: the desktop client, the server, the media server and the docs.
 
 Features
 - Text channels, roles and permissions that stay put

--- a/marketing/listings/microsoft-store.nb-NO.md
+++ b/marketing/listings/microsoft-store.nb-NO.md
@@ -15,7 +15,7 @@ Tale går over WebRTC gjennom en SFU, så én server sender lyden videre og en s
 
 Meldinger er krypterte og nøklene er dine. Identiteten din er et nøkkelpar appen lager og beholder på enheten din, ikke en konto noen andre kan låse deg ute av.
 
-Alt sammen er åpen kildekode under AGPL: klienten, serveren, medieserveren, dokumentasjonen, og en skriftlig policy på hvor mye av det som er bygget med KI og hvordan du selv sjekker det med git log.
+Alt sammen er åpen kildekode under AGPL: klienten, serveren, medieserveren og dokumentasjonen.
 
 Funksjoner
 - Tekstkanaler, roller og rettigheter som blir stående


### PR DESCRIPTION
Microsoft failed certification on **policy 11.16, Live Generative AI Content**, asking us to tick *"This product incorporates generative AI features"*.

The only thing a reviewer could have been reading is the last line of the description, which mentioned a written policy on how much of Gryt was built with AI. They took a note about how the code is written as a claim about what the app does.

## Gryt has no generative AI in it

Checked rather than assumed:

- No `openai`, `anthropic`, `llm`, `gpt`, `ollama`, `stable-diffusion`, `transformers` or `onnxruntime` in the client source or `package.json`
- No user-facing "AI" string in the app — the one hit is a dev-only chat fixture
- The demo harness is hardcoded: `fakeChat.ts` replays one-line scripts, `fakeParticipants.ts` invents people, and the fake screen share is `canvas.captureStream(30)` painting a frame counter. Nothing calls a model.
- The only machine-learning component is `@shiguredo/rnnoise-wasm`, which removes background noise from a microphone rather than creating anything

So the declaration stays unticked, and the checkbox in Partner Center was already in that state.

## Why the sentence goes rather than gets reworded

A store listing has to earn every line, and this one was spending its last on a development-process detail that reads to a certification tester as a product feature.

Nothing here is untrue by omission. The AI policy is still published at docs.gryt.chat/docs/guide/ai, it is still in the repository, and every commit still carries its `Co-Authored-By` trailer — so the promise that you can audit this with `git log` is exactly as auditable as it was. The listing simply stops repeating it.

The open-source half of the sentence stays, because that is a fact about the product and worth the line.

Same edit in both languages. The files are the source and the console is a paste of them, per the README next door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)