### PR TITLE
Comments: default to none, two lines when needed (GRYT-899)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -330,9 +330,41 @@ a person will read it, it goes through both skills before you hand it over.
 Run them on the copy **before you commit**, not as a later pass. The draft is what ships.
 
 **The one exception is code comments**, along with log lines, test names, and variable and
-function names. Those want to be plain and direct, a copy skill spends a turn on prose
-nobody browses, and the comments in this repository are load-bearing and long on purpose.
-Leave them alone.
+function names. Those want to be plain and direct, and a copy skill spends a turn on prose
+nobody browses. Don't run the skills over them. The rule below applies instead.
+
+## Comments
+
+**Default to none. Two lines when you need one. Longer only to stop a specific mistake,
+and then say which mistake.**
+
+This reverses what this file used to say. It claimed the comments here were load-bearing
+and long on purpose, and that was true of some of them and became an excuse for the rest.
+The result is code you have to read around.
+
+Delete on sight:
+
+- **Narration.** A comment that says what the next line says. `// increment the counter`.
+- **History.** What this used to be, who changed it, which task it came from. That is what
+  `git log` is. A comment that starts "this used to" is telling you about a file that no
+  longer exists.
+- **Justification nobody asked for.** Three paragraphs on why a sensible choice was
+  sensible. If it is the obvious thing, it needs no defence.
+- **Restated types.** `/** The user's name. */` above `name: string`.
+
+Keep, and let it run past two lines if it has to:
+
+- **A trap.** Something that looks wrong and is not, or looks fine and is not. `btoa` being
+  unsafe above `0x7f` on Hermes is the example that keeps earning its place — it is why
+  `@gryt/crypto` has one base64 implementation rather than the browser's.
+- **A constraint from outside.** A protocol, a wire format, an engine bug, an order that
+  matters. `check-subpaths.mjs` enumerating modules by hand rather than reading the
+  directory is worth one line, because otherwise a new module is silently unchecked.
+- **A decision that will otherwise be re-litigated.** Not the history of it — the
+  conclusion, once, where the code is.
+
+The test: **would somebody make a mistake without it?** Not "is this interesting", not "did
+this take a while to work out". If nothing breaks when the comment is gone, it goes.
 
 This used to carve out PR bodies, commit messages and task descriptions as "in between",
 on the argument that they are work records rather than product surface. That carve-out is


### PR DESCRIPTION
This file said the comments here were **load-bearing and long on purpose**. That was true of some of them and became an excuse for the rest, and the result is code you have to read around.

New rule: **default to none, two lines when one is needed, longer only to stop a specific mistake — and then say which mistake.**

## What goes

Narration, history, unrequested justification, restated types. `git log` already holds the history, and a comment opening "this used to" is describing a file that no longer exists.

## What stays, and may run long

**Traps.** Something that looks wrong and is not, or looks fine and is not.

The standing example is `btoa` being unsafe above `0x7f` on Hermes. That comment in `@gryt/crypto/src/base64.ts` is why the package has one base64 implementation rather than the browser's — and during the GRYT-898 work today it is what settled which of two copies to keep. Without it there was no basis to prefer either.

Also: constraints from outside (a protocol, a wire format, an engine bug, an order that has to hold), and a decision that would otherwise be argued again — the conclusion, once, not its history.

## The test

**Would somebody make a mistake without it?** Not "is this interesting", not "did this take a while to work out".

## Worth saying

This reverses a documented decision rather than filling a gap, so it should be a deliberate change rather than a quiet one. A handful of long comments did real work today — `roleOrder.ts` explaining that ranks had not gone away, only the number on screen; mobile's `address.ts` naming its own duplication as GRYT-406; the release workflows explaining that two dispatches at once put a version on npm with no commit behind it. The rule is written to keep that kind and cut the rest, rather than to cap everything at two lines regardless.

[GRYT-899](https://tasks.sivert.io) is the cleanup pass this implies — thirteen submodules plus the superproject, a repository at a time, and it wants somebody reading rather than a regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)