### PR TITLE
Sign the macOS build with the keychain we already made (GRYT-903)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1286,8 +1286,30 @@ jobs:
         shell: bash
         env:
           DEBUG: electron-builder,electron-osx-sign,electron-notarize
-          CSC_LINK: ${{ secrets.MACOS_CERT_P12_BASE64 }}
-          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          # The keychain "Prepare macOS signing keychain" already built, rather
+          # than CSC_LINK and CSC_KEY_PASSWORD, which used to be here.
+          #
+          # With CSC_LINK set, electron-builder ignores that work and does its
+          # own: app-builder-lib's `createKeychain` makes a keychain with a
+          # random 32-byte password, imports the certificate, and then runs
+          #
+          #   security set-key-partition-list -S apple-tool:,apple: -s -k <p12 password>
+          #
+          # where `-k` is the *keychain's* password. It has been passing the
+          # certificate's for as long as the function has existed — 26.8.1, what
+          # we pin, and 26.15.3, the current release, are identical here.
+          #
+          # macOS did not check until 26.6. GitHub moved macos-latest from
+          # 26.5.2 to 26.6.2 on 2026-08-31, and v1.9.13 failed on
+          # `SecKeychainUnlock: The user name or passphrase you entered is not
+          # correct` with nothing in this repository changed and the signing
+          # secrets untouched since March. GRYT-903.
+          #
+          # `codeSigningInfo` in macPackager.js returns `{ keychainFile:
+          # process.env.CSC_KEYCHAIN }` whenever CSC_LINK is absent, and only
+          # calls `createKeychain` when it is present. So naming the keychain
+          # here is what keeps electron-builder out of the broken path.
+          CSC_KEYCHAIN: ${{ runner.temp }}/build.keychain-db
           APPLE_API_KEY: ${{ runner.temp }}/AuthKey.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -1310,9 +1332,17 @@ jobs:
           # rather than this one, and every shipped macOS build asked an empty
           # repository for updates. The other platforms always passed these,
           # which is why only macOS was broken.
+          # `forceCodeSigning` is the other half of dropping CSC_LINK. Without a
+          # certificate to import, electron-builder looks for an identity and,
+          # when it cannot find one, calls `reportError`, which *warns* and
+          # carries on — a green build that shipped an unsigned app, which
+          # Gatekeeper refuses and the updater cannot replace. `reportError`
+          # throws instead when this is set, so a keychain that did not work is
+          # a failed release rather than a bad one.
           npx electron-builder \
             --mac \
             --publish never \
+            -c.mac.forceCodeSigning=true \
             -c.extraMetadata.version="$VERSION" \
             -c.publish.provider=github \
             -c.publish.owner="$OWNER" \


### PR DESCRIPTION
The v1.9.13 release failed on macOS. Windows and Linux built, the cleanup job pulled the tag and the release, and nothing shipped — but `release.json` on main already reads 1.9.13.

```
security set-key-partition-list -S apple-tool:,apple: -s -k *** <keychain>
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

## It was the runner, not us

The signing secrets have not been touched since 2026-03-03, and the four releases on 2026-09-03 all packaged macOS fine.

| | macOS | Image | Runner | |
|---|---|---|---|---|
| 2026-09-03 | 26.5.2 | `macos-26-arm64` 20260728.0273.1 | 2.336.0 | passed |
| 2026-09-04 | 26.6.2 | `macos-26-arm64` 20260831.0337.3 | 2.337.0 | failed |

## The bug is upstream, and it is old

`app-builder-lib`'s `createKeychain` makes a keychain with a random 32-byte password, imports the certificate, and then runs:

```js
await exec("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile])
```

`password` there is the p12's. `-k` is the keychain's. It has been the wrong secret for as long as the function has existed — 26.8.1 (what we pin) and 26.15.3 (current) are byte-identical on that line, so upgrading electron-builder does nothing. macOS just did not verify it until 26.6.

## The fix

We already prepare a keychain correctly one step earlier: empty password throughout, cert imported, `set-key-partition-list` given the password that actually matches, made default. That step succeeded in the failed run and printed the identity it found:

```
1) 273797E21D4F1BD6C370BAC750FE756AC6657103 "Developer ID Application: SVEKT GULLSERG - HANSEN (8883W2XTQ8)"
```

Then the packaging step handed electron-builder `CSC_LINK` and it threw all that away and did its own. `codeSigningInfo` in `macPackager.js`:

```js
const cscLink = this.getCscLink()
if (cscLink == null || process.platform !== "darwin") return null
...
return Promise.resolve({ keychainFile: process.env.CSC_KEYCHAIN || null })
```

So `CSC_KEYCHAIN` instead of `CSC_LINK` + `CSC_KEY_PASSWORD` is what keeps it out of the broken path.

## What to look at

- **`forceCodeSigning`.** This is the part that changes behaviour rather than shape, and it is there because dropping `CSC_LINK` opens a worse failure than the one being fixed: with no certificate to import, an identity electron-builder cannot find goes through `reportError`, which warns and carries on. That is a green release shipping an unsigned app — refused by Gatekeeper, and not replaceable by the updater. With `mac.forceCodeSigning` it throws instead.
- **Whether the prepared keychain is enough for notarization too.** `afterSign: scripts/notarize.cjs` runs on the Apple API key and does not touch the keychain, so it should be unaffected, but this is the bit I have not been able to exercise without running a release.
- This cannot be tested short of dispatching a release. `macos-latest` is the image that broke, so the next run is the test.

## After merging

Re-run `Release Client` with **`bump=none`** so it ships 1.9.13 rather than skipping to 1.9.14 — `release.json` on main is already at 1.9.13 from the failed attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)