### PR TITLE
Sweep every submodule in .gitmodules, not a list kept by hand

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,7 +1,7 @@
 # Working rules for Gryt
 
 Gryt is a WebRTC voice chat platform maintained by one person. It's a superproject with
-thirteen git submodules under `packages/`. Read these rules before making changes.
+fifteen git submodules under `packages/`. Read these rules before making changes.
 
 ## Review-required paths
 
@@ -126,10 +126,16 @@ a public repository. The kanban board is the state: **To-Do → Doing → Review
 | PR merged | Move to **Done** *and* set the task's done flag | CI |
 
 CI covers the last two through `.github/workflows/vikunja-task-done.yml`, which calls a
-reusable workflow in `Gryt-chat/.github`. Every repo has it — the superproject and all ten
-submodules — so you don't normally need to touch a task after opening the PR. There is no
-longer an exception to work around: `ui` was the last one missing it and GRYT-143 landed
-that on 2026-08-11.
+reusable workflow in `Gryt-chat/.github`. Every repo has it — the superproject and all
+fifteen submodules — so you don't normally need to touch a task after opening the PR.
+
+This paragraph said "all ten submodules" and named `ui` as the last one missing it,
+fixed by GRYT-143 on 2026-08-11. That stopped being true when submodules were added
+afterwards and nobody came back here: `core` had neither this workflow nor
+`bump-gitlink.yml` from the day it was created until 2026-09-04, so its tasks never
+moved and its gitlink never did either. A new submodule needs the three shared
+workflows copied into it: this one, `bump-gitlink.yml` and `discord-ci-notify.yml`.
+None of them arrive on their own.
 
 Moving a task is not exposed by the Vikunja MCP server, so use the REST API directly:
 

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -173,67 +173,32 @@ jobs:
             git add "$path"
           }
 
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "client" ]]; then
-            update_submodule "packages/client" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
+          # Derived from $SUBMODULES rather than written out, because this was
+          # the last hand-kept copy of the list and it had already drifted. The
+          # comment above records the same mistake twice, on mobile and then
+          # reports, against the two copies that were consolidated then. This
+          # was the third, and packages/core was its third drift: added as a
+          # submodule, never added here, so its gitlink sat at 0dec296 through
+          # five releases while the sweep ran green every hour and said nothing.
+          #
+          # The short name a dispatch selects is the path's last segment, which
+          # is what every one of those blocks used.
+          MATCHED=0
 
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "server" ]]; then
-            update_submodule "packages/server" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
+          for path in $SUBMODULES; do
+            name="${path##*/}"
 
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "sfu" ]]; then
-            update_submodule "packages/sfu" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
+            if [[ "$SELECTED" == "all" || "$SELECTED" == "$name" ]]; then
+              MATCHED=1
+              update_submodule "$path" "$DEFAULT_SUBMODULE_BRANCH"
+            fi
+          done
 
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "image-worker" ]]; then
-            update_submodule "packages/image-worker" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
-
-          # docs, site and auth were missing here, so their pointers only ever
-          # moved when someone did it by hand. That is why docs and site had to
-          # be bumped manually during the llms.txt work.
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "docs" ]]; then
-            update_submodule "packages/docs" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
-
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "site" ]]; then
-            update_submodule "packages/site" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
-
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "auth" ]]; then
-            update_submodule "packages/auth" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
-
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "ui" ]]; then
-            update_submodule "packages/ui" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
-
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "cli" ]]; then
-            update_submodule "packages/cli" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
-
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "voice" ]]; then
-            update_submodule "packages/voice" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
-
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "mobile" ]]; then
-            update_submodule "packages/mobile" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
-
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "bot" ]]; then
-            update_submodule "packages/bot" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
-
-          # Added with the submodule itself rather than after the first stale
-          # pointer, which is how docs, site and auth ended up in the comment
-          # above. A submodule missing from this list is one whose gitlink only
-          # ever moves by hand, and nothing reports that it has stopped.
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "reports" ]]; then
-            update_submodule "packages/reports" "$DEFAULT_SUBMODULE_BRANCH"
-          fi
-
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "crypto" ]]; then
-            update_submodule "packages/crypto" "$DEFAULT_SUBMODULE_BRANCH"
+          # A dispatch naming something that is not a submodule used to do
+          # nothing at all and report success, because no block matched it.
+          if [[ "$MATCHED" == "0" ]]; then
+            echo "::error::No submodule matched '$SELECTED'. Known: $SUBMODULES"
+            exit 1
           fi
 
       - name: Commit changes


### PR DESCRIPTION
`packages/core` was added as a submodule and never added to the sweep's update
list. Its gitlink still points at `0dec296` — *"Put the README in the house style
(#2)"* — through the permissions matrix, the name pool, the member grouping, the
76 provider logos and five npm releases.

The hourly sweep ran green the entire time. It had nothing to skip.

## The list was hand-kept, again

The comment above that block already records this happening twice, on `mobile`
and then `reports`, and the fix then was to read the list out of `.gitmodules`
for the sync and commit steps. The dispatch list stayed written out by hand, so
it was a third copy — and core is its third drift.

It is derived now. The short name a dispatch selects is the path's last segment,
which is what all fourteen blocks used, so the behaviour is the same minus the
drift.

One deliberate change: a dispatch naming something that is not a submodule used
to match no block, do nothing, and report success. It now fails and prints what
it knows about.

## Also in here

`.claude/CLAUDE.md` carried the same drift in two places — "thirteen git
submodules" where there are fifteen, and a claim that every repo has the Vikunja
workflow. Core had neither that nor `bump-gitlink.yml` from the day it was
created until today ([core#13](https://github.com/Gryt-chat/core/pull/13)), so
its tasks never moved and its gitlink never did either. Same finding, so it is
here rather than in its own PR.

## Verified

I cannot run the workflow, so: parsed the YAML, extracted the step and ran
`bash -n` over it, then simulated the loop against the real `.gitmodules`.

```
all    -> auth bot cli client core crypto docs image-worker mobile
          reports server sfu site ui voice   (15)
core   -> core
client -> client
nope   -> no match, now exits 1
```

## A correction

I wrote in core#13 that the sweep was "plainly not reaching this repository".
That was wrong — the sweep reaches it fine and always has. It simply never had
core in the list it iterates. `bump-gitlink.yml` was still worth adding there,
but this is the actual cause.

## What this does not do

It does not move core's gitlink. The next sweep or push will, once this is on
main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
