### PR TITLE
Upload the macOS channel file by pattern, not by name

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1394,7 +1394,13 @@ jobs:
             release/*.dmg
             release/*.zip
             release/*.blockmap
-            release/latest-mac.yml
+            # A glob, because the channel file is named after the channel:
+            # latest-mac.yml for a full build and slim-mac.yml for a slim one.
+            # Spelled out, it was a literal path rather than a pattern, so
+            # nullglob left it in the list when it did not exist and the upload
+            # failed with "no matches found". That is what kept macOS slim off
+            # v1.9.15 while every other leg published.
+            release/*-mac.yml
           )
           shopt -u nullglob
 


### PR DESCRIPTION
macOS slim was the one leg that failed on v1.9.15, and this is why:

```
release/latest-mac.yml
no matches found for `release/latest-mac.yml`
```

The upload step listed that path literally. A slim build writes `slim-mac.yml`,
and a literal path is not a pattern — so `nullglob`, which only drops globs, left
the missing file in the array and `gh release upload` stopped on it.

It failed at **step 32, the upload**. The app had already built, signed and
notarized, so this wasted the whole expensive part of a macOS leg to fall over on
a filename.

`release/*-mac.yml` matches both names and drops out cleanly if neither exists.

## Where that leaves v1.9.15

It published. Five of six legs were green and the slim artifacts are on the
release:

| | full | slim |
|---|---|---|
| Windows `.exe` | 125 MB | **92 MB** |
| Linux `.deb` | 134 MB | **86 MB** |
| AppImage | 147 MB | **109 MB** |

macOS has no slim build on this release. Nothing is broken by that — no mac slim
install exists to update — and `continue-on-error` on the slim legs did exactly
its job: the failure did not block a release the other five legs had earned.

That is also the argument for keeping the guard one more release rather than
removing it now, as the earlier PR suggested.

## Verified

Parsed the YAML, extracted the step and ran `bash -n` over it. I cannot test the
upload itself without a release, so the proof will be the next one carrying
`Gryt-Chat-<version>-mac-arm64-slim.dmg` and `slim-mac.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
