### PR TITLE
Start the Snap Store publish from the release itself

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -33,6 +33,9 @@ on:
 permissions:
   contents: write
   packages: write
+  # For the `gh workflow run` at the end of publish-release, which starts
+  # publish-snap.yml. Dispatching a workflow is an Actions write.
+  actions: write
   # Both for `actions/attest-build-provenance`, which signs a statement about
   # this build into sigstore's public transparency log (GRYT-723). `id-token`
   # is how the runner proves to sigstore which workflow it is, and
@@ -1598,6 +1601,44 @@ jobs:
 
           gh release edit "v$VERSION" --repo "$OWNER/$REPO" --draft=false
           echo "Published v$VERSION."
+
+      # publish-snap.yml listens for `release: published`, and that event does
+      # not fire when the release was created with GITHUB_TOKEN — which is what
+      # the step above uses. So it never started on its own, and every stable
+      # release since it was split out has needed somebody to dispatch it by
+      # hand afterwards. It had two runs in total by v1.9.19, both manual.
+      #
+      # `workflow_dispatch` is one of the two events GitHub exempts from that
+      # rule, so dispatching it here does start a run.
+      #
+      # Dispatched rather than made a job of this workflow. Release Client
+      # shares its concurrency group with Release Server, a job holds that group
+      # until it finishes, and sitting in the group waiting out a Snap Store
+      # review is the exact thing the snap was split out to stop doing.
+      #
+      # Stable only, which is publish-snap.yml's own rule but not one it can
+      # apply here: it treats any dispatch as deliberate and skips its beta
+      # check, so the channel gate has to be on this side.
+      #
+      # `continue-on-error` because the Store is not part of the release's
+      # availability contract. Everything a person can install has already
+      # shipped by this point, so a failure to even start the upload must not
+      # turn a finished release red.
+      - name: Start the Snap Store publish
+        if: needs.prepare-release.outputs.channel == 'latest'
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh workflow run publish-snap.yml \
+            --repo "$OWNER/$REPO" \
+            --ref main \
+            -f tag="v$VERSION"
+
+          echo "Dispatched publish-snap.yml for v$VERSION."
 
       # Moved here from the Linux build leg. Announcing from there fired while
       # macOS was still signing, so #releases advertised a build that Mac users


### PR DESCRIPTION
The snap needed a manual dispatch after v1.9.19, same as after v1.9.17. This stops that.

## Why it never fired

`publish-snap.yml` triggers on `release: published`. GitHub doesn't raise that event when the release was created with `GITHUB_TOKEN`, and the publish step uses `github.token`. So the trigger has never once fired on its own — the workflow has two runs total, and I dispatched both by hand.

`workflow_dispatch` is one of only two events GitHub exempts from that rule (`repository_dispatch` is the other), so dispatching it from the release job does start a run.

## Why a dispatch and not a job

Making it a job of Release Client would undo the reason it was split out. This workflow shares its concurrency group with Release Server, and a job holds that group until it finishes. On 2026-08-25 a server release sat pending while a client release waited out a Snap Store review — that's in the comment at the top of `publish-snap.yml`. A dispatch holds nothing.

## Stable only

`publish-snap.yml` skips its beta check whenever the event is a dispatch, on the reasonable assumption that a human dispatching it means it. That assumption stops holding once a workflow dispatches it automatically, so the channel gate sits on this side instead: `needs.prepare-release.outputs.channel == 'latest'`.

I chose not to tighten the `if:` in `publish-snap.yml` to look at the tag instead. That would also work, but it would take away the manual escape hatch for pushing a beta on purpose, and `latest/beta` being closed in the Store already makes that fail on its own terms.

## What to look at

`actions: write` on the workflow-level `permissions` block. `publish-release` has no block of its own so it inherits, but that's worth confirming rather than taking from me — without it the dispatch 403s.

The step is `continue-on-error: true`, matching the snap job's own stance: by the time it runs, every installable artifact has shipped, so failing to start an upload shouldn't turn a finished release red.

## What I checked

The YAML parses, and the step lands between "Publish the release" and "Notify Discord" in `publish-release`.

`channel` is validated upstream to be exactly `latest` or `beta`, so the gate can't fall through on an unexpected value — and it fails closed if it somehow did.

Not run. It only proves itself on the next stable client release, and I'd rather not cut one to test it. If it doesn't fire, the fallback is what we've been doing anyway: dispatch `publish-snap.yml` with the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
