### PR TITLE
Read the SFU peer count from a port that exists

### DIFF
--- a/ops/internal/refresh-web-client.sh
+++ b/ops/internal/refresh-web-client.sh
@@ -87,17 +87,40 @@ label() {
 # How many people are in voice on this stack, or empty if it cannot be
 # determined.
 #
-# Read off the SFU's own Prometheus gauge through whichever host port that
-# stack publishes 5005 on, so it works for prod and beta without either being
-# named here.
+# Read off the SFU's own Prometheus gauge, from inside the container.
+#
+# This used to ask host port 5005, which is the SFU's *signalling* port. The
+# metrics listener is a second one on SFU_METRICS_PORT, and the SFU logs
+# "container-only; do not publish this port" when it starts it — so there was
+# never a published port to reach it on. The curl came back empty, awk found no
+# gauge and exited 1, and every run since has logged
+#
+#   [prod/sfu] new image, but the peer count could not be read — deferring
+#
+# which reads like a busy channel and is not. It deferred on every tick, so the
+# SFU was never updated at all: on 2026-09-06 prod was still running a
+# 2026-09-02 image with a newer one pulled and waiting, and beta the same. The
+# failure is a safe one, which is exactly why it went unnoticed — no call was
+# ever cut, and no SFU was ever updated either.
+#
+# `docker exec` rather than a published port, because not publishing it is
+# deliberate and opening it would be the wrong fix. The port is read off the
+# container's own environment, so prod and beta still need no naming here.
+#
+# wget or curl: the image has one of them, and which is not worth pinning a
+# base image over.
 sfu_peers() {
-  local container="$1" hostport
-  hostport=$(docker port "$container" 5005/tcp 2>/dev/null | head -1) || return 0
-  [[ -z "$hostport" ]] && return 0
-  # docker reports the wildcard bind; ask the loopback address instead.
-  hostport=${hostport/0.0.0.0/127.0.0.1}
-  hostport=${hostport/\[::\]/127.0.0.1}
-  curl -sf --max-time 5 "http://${hostport}/metrics" 2>/dev/null \
+  local container="$1" port
+  port=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$container" 2>/dev/null \
+    | sed -n 's/^SFU_METRICS_PORT=//p' | head -1)
+
+  # Unset means an SFU old enough not to have the setting; 0 means metrics are
+  # recorded and served nowhere, which that build says outright at boot. Either
+  # way the count cannot be read, and the caller defers rather than guessing.
+  [[ -z "$port" || "$port" == "0" ]] && return 0
+
+  docker exec "$container" sh -c \
+    "wget -qO- http://127.0.0.1:${port}/metrics 2>/dev/null || curl -sf --max-time 5 http://127.0.0.1:${port}/metrics" 2>/dev/null \
     | awk '/^gryt_sfu_peers_active /{print $2; found=1} END{if(!found) exit 1}'
 }
 


### PR DESCRIPTION
Found while investigating an unrelated voice drop on pp. It is **not** the cause of that — it is a separate bug that has been quietly running for days.

## The SFU has never been auto-updated

The busy gate asks host port 5005 for the SFU's metrics. 5005 is the *signalling* port. The metrics listener is a second one on `SFU_METRICS_PORT`, and the SFU logs this when it starts it:

```
📊 Metrics on %d (container-only; do not publish this port)
```

There was never a published port to reach it on. So `curl` came back empty, `awk` found no gauge and exited 1, and the caller reads an unreadable count as a reason to defer.

Every tick since has logged:

```
[prod/sfu] new image, but the peer count could not be read — deferring
[beta/sfu] new image, but the peer count could not be read — deferring
```

which reads like a busy channel and is not. On 2026-09-06 `gryt-prod-sfu` was running an image started **2026-09-02** with a newer one already pulled and waiting. Beta the same.

**The failure is a safe one, which is exactly why nobody noticed.** No call was ever cut. No SFU was ever updated either.

## The fix

Read the gauge from inside the container, on the port taken from the container's own environment — so prod and beta still need no naming here.

Publishing the metrics port was the other option and the wrong one: not publishing it is deliberate, and the SFU says so at boot.

## What to look at

**`docker exec` in a timer-driven script.** It costs a process per SFU per ten minutes. That seemed better than the alternatives, but it is the judgement call.

**`wget` then `curl`.** The image has one of them; I did not want to pin a base image over which. If you would rather it were definite, `wget` alone works on the current image.

**The defer path is unchanged.** Unset `SFU_METRICS_PORT` (an older SFU) and `0` (metrics recorded but served nowhere, which that build states at boot) both still return nothing, so the caller still defers rather than guessing.

## What I checked

Ran the new function against both live SFUs on the box:

```
gryt-prod-sfu -> peers=[0]
gryt-beta-sfu -> peers=[0]
gryt-nope     -> unreadable
```

`bash -n` clean.

**Worth knowing before you merge:** both SFUs currently report 0 peers, so the first tick after this lands will actually recreate them — the update that has been deferred since 2 September. That is the intended behaviour and it is gated on nobody being in voice, but it is a real restart rather than a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
