### PR TITLE
Say which build is waiting and how many are in voice

### DIFF
--- a/ops/internal/refresh-web-client.sh
+++ b/ops/internal/refresh-web-client.sh
@@ -103,6 +103,11 @@ label() {
 # failure is a safe one, which is exactly why it went unnoticed — no call was
 # ever cut, and no SFU was ever updated either.
 #
+# That line is also why the gate below now names both images and the count. It
+# repeated every ten minutes for four days and told nobody which build was
+# waiting or how many were supposedly in voice, so there was nothing in it to
+# read as broken.
+#
 # `docker exec` rather than a published port, because not publishing it is
 # deliberate and opening it would be the wrong fix. The port is read off the
 # container's own environment, so prod and beta still need no naming here.
@@ -225,18 +230,24 @@ refresh_container() {
   #
   # An unreadable peer count defers too. Being unable to tell is not the same as
   # nobody being there, and the cost of guessing wrong is somebody's call.
+  # Every line here names both images and the peer count, so the log answers
+  # "why is the SFU still on last week's build" without anybody having to go
+  # and ask the container. The old lines said "new image" and left which one,
+  # and how many were in voice, to the imagination — and the one that mattered
+  # said only "could not be read", which is how it repeated for four days
+  # without anybody reading it as broken.
   if [[ "$service" == "sfu" && -n "$pulled_id" && "$pulled_id" != "$image_before" ]]; then
-    local peers
+    local peers move="${image_before:0:19} -> ${pulled_id:0:19}"
     peers=$(sfu_peers "$container") || peers=""
     if [[ -z "$peers" ]]; then
-      log "[$tag] new image, but the peer count could not be read — deferring"
+      log "[$tag] update available ($move), peer count unreadable — deferring"
       return 0
     fi
     if [[ "${peers%%.*}" -gt 0 ]]; then
-      log "[$tag] new image, but ${peers%%.*} in voice — deferring"
+      log "[$tag] update available ($move), ${peers%%.*} in voice — deferring"
       return 0
     fi
-    log "[$tag] new image and nobody in voice — recreating"
+    log "[$tag] update available ($move), 0 in voice — updating"
   fi
 
   # `--no-deps` because the client's `depends_on` reaches the server, and the


### PR DESCRIPTION
This was meant to be part of #192 but landed on the branch after it merged, so it never reached main. Same idea, on its own.

The deferral line said only:

```
[prod/sfu] new image, but the peer count could not be read — deferring
```

It repeated every ten minutes for four days without naming the build that was waiting or the count it couldn't read. There was nothing in it to recognise as broken — which is why nobody did.

All three outcomes now say both:

```
[prod/sfu] update available (sha256:aaa -> sha256:bbb), 0 in voice — updating
[prod/sfu] update available (sha256:aaa -> sha256:bbb), 3 in voice — deferring
[prod/sfu] update available (sha256:aaa -> sha256:bbb), peer count unreadable — deferring
```

"update available" rather than "new image", because the line is answering *why the SFU is still on last week's build* and that reads better as the question it answers.

## What I checked

`bash -n` clean, and I ran the three branches against sample ids to confirm the formatting.

Cherry-picked onto current main, so it sits on top of the probe fix rather than duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
