### PR TITLE
Keep container logs after the container is gone

### DIFF
--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -1,5 +1,26 @@
 name: gryt-beta
 
+# Logs that survive the container.
+#
+# The default json-file driver keeps its files under the container, so `docker
+# compose up -d` on a new image takes the old container's entire history with
+# it. On 2026-09-06 a voice drop on pp could not be diagnosed for exactly that
+# reason: the server had been up for seventeen hours through the incident, was
+# recreated ten minutes later by a routine deploy, and every line it had written
+# went with it.
+#
+# journald keeps them in the system journal instead, where they outlive the
+# container and are searchable by time across every service at once. `docker
+# logs` still works — the driver supports reading back.
+#
+# Applied to the long-lived services only. The init containers run once and say
+# nothing worth keeping, and MinIO is noisy enough to be worth leaving where it
+# is.
+x-logging: &gryt-logging
+  driver: journald
+  options:
+    tag: "{{.Name}}"
+
 services:
   # ── Object Storage ───────────────────────────────────────────────────────
   minio:
@@ -65,6 +86,7 @@ services:
   sfu:
     image: ghcr.io/gryt-chat/sfu:${SFU_VERSION:-latest-beta}
     container_name: gryt-beta-sfu
+    logging: *gryt-logging
     ports:
       - "${SFU_PORT:-5015}:5005"
       - "${ICE_UDP_MUX_PORT:-4443}:${ICE_UDP_MUX_PORT:-4443}/udp"
@@ -101,6 +123,7 @@ services:
   server:
     image: ghcr.io/gryt-chat/server:${SERVER_VERSION:-latest-beta}
     container_name: gryt-beta-server
+    logging: *gryt-logging
     network_mode: host
     extra_hosts:
       - "sfu:127.0.0.1"
@@ -196,6 +219,7 @@ services:
   image-worker:
     image: ghcr.io/gryt-chat/image-worker:${IMAGE_WORKER_VERSION:-latest-beta}
     container_name: gryt-beta-image-worker
+    logging: *gryt-logging
     # The server runs with host networking, so it cannot reach this container
     # by service name — it has to come in through a published port. Bound to
     # loopback: this is a health endpoint for the server beside it, not
@@ -244,6 +268,7 @@ services:
   client:
     image: ghcr.io/gryt-chat/client:${CLIENT_VERSION:-latest-beta}
     container_name: gryt-beta-client
+    logging: *gryt-logging
     profiles: ["web"]
     ports:
       - "${CLIENT_PORT:-3667}:80"

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -1,5 +1,26 @@
 name: gryt-prod
 
+# Logs that survive the container.
+#
+# The default json-file driver keeps its files under the container, so `docker
+# compose up -d` on a new image takes the old container's entire history with
+# it. On 2026-09-06 a voice drop on pp could not be diagnosed for exactly that
+# reason: the server had been up for seventeen hours through the incident, was
+# recreated ten minutes later by a routine deploy, and every line it had written
+# went with it.
+#
+# journald keeps them in the system journal instead, where they outlive the
+# container and are searchable by time across every service at once. `docker
+# logs` still works — the driver supports reading back.
+#
+# Applied to the long-lived services only. The init containers run once and say
+# nothing worth keeping, and MinIO is noisy enough to be worth leaving where it
+# is.
+x-logging: &gryt-logging
+  driver: journald
+  options:
+    tag: "{{.Name}}"
+
 services:
   # ── Object Storage ───────────────────────────────────────────────────────
   minio:
@@ -59,6 +80,7 @@ services:
   sfu:
     image: ghcr.io/gryt-chat/sfu:${SFU_VERSION:-latest}
     container_name: gryt-prod-sfu
+    logging: *gryt-logging
     ports:
       - "${SFU_PORT:-5005}:5005"
       - "${ICE_UDP_MUX_PORT:-3478}:${ICE_UDP_MUX_PORT:-3478}/udp"
@@ -94,6 +116,7 @@ services:
   server:
     image: ghcr.io/gryt-chat/server:${SERVER_VERSION:-latest}
     container_name: gryt-prod-server
+    logging: *gryt-logging
     network_mode: host
     extra_hosts:
       - "sfu:127.0.0.1"
@@ -181,6 +204,7 @@ services:
   image-worker:
     image: ghcr.io/gryt-chat/image-worker:${IMAGE_WORKER_VERSION:-latest}
     container_name: gryt-prod-image-worker
+    logging: *gryt-logging
     # The server runs with host networking, so it cannot reach this container
     # by service name — it has to come in through a published port. Bound to
     # loopback: this is a health endpoint for the server beside it, not
@@ -350,6 +374,7 @@ services:
   client:
     image: ghcr.io/gryt-chat/client:${CLIENT_VERSION:-latest}
     container_name: gryt-prod-client
+    logging: *gryt-logging
     profiles: ["web"]
     ports:
       - "${CLIENT_PORT:-3666}:80"


### PR DESCRIPTION
The reason the pp voice drop could not be diagnosed, fixed.

## What happened

`json-file` keeps its logs under the container. `docker compose up -d` on a new image creates a *new* container, and the old one's entire history goes with it.

On 2026-09-06 that erased the only evidence of a real incident. pp had been up **seventeen hours straight** through the drop (`execDuration=17h5m`), a routine deploy recreated it ten minutes later, and the line that would have settled the cause — `[Voice:Step 1] REFUSED ... reason=` — went with it. The difference between "the channel was missing" and "the check failed" was in that line, and it is not recoverable.

## The change

`sfu`, `server`, `image-worker` and `client` on both stacks log to `journald`. The lines outlive the container, and the journal can be searched by time across every service at once — which is what you want when the question is "what else happened at 11:42?".

`docker logs` still works; the journald driver reads back.

Init containers and MinIO stay on `json-file`: the init containers run once and say nothing worth keeping, MinIO is noisy enough to leave alone.

## One step this does not do, and it matters

**The journal is capped at 4G and is already at 3.0G.** systemd's default `SystemMaxUse` is `min(10% of filesystem, 4G)`, and the 4G cap binds on a 490G disk. Adding container logs on top of 3G of existing journal will just evict older entries faster — trading one lost-log problem for another.

Raise it before or soon after merging. There's 272G free, so this is cheap:

```bash
sudo mkdir -p /etc/systemd/journald.conf.d
printf '[Journal]\nSystemMaxUse=20G\n' | sudo tee /etc/systemd/journald.conf.d/gryt.conf
sudo systemctl restart systemd-journald
```

I could not do it myself: `sudo` needs a password there, and I don't handle those.

## What to look at

**Whether journald is the right destination at all.** It is searchable across services and survives recreation, which is exactly the gap. The alternative — a bind-mounted file per service — keeps things separate but loses the cross-service timeline, which was the thing I actually wanted when investigating this.

**The service list.** I left MinIO and the init containers out deliberately; say if you would rather it were uniform.

## What I checked

Both files parse, and the anchor resolves to the same block on all four services in each:

```
prod: logging on -> ['client', 'image-worker', 'server', 'sfu']
beta: logging on -> ['client', 'image-worker', 'server', 'sfu']
```

**Not applied to `server-pp` or `server-nt`.** Those live in `pp.yml` and `nt.yml`, which are on the box and not in this repo — so the very server this incident happened on is not covered by this PR. Same two lines are needed there:

```yaml
    logging:
      driver: journald
      options:
        tag: "{{.Name}}"
```

Worth deciding whether those files should be tracked, since right now the prod stack is partly in git and partly not.

Takes effect per container as each is next recreated. Nothing needs restarting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
