### PR TITLE
Catch a permission the server ships and the client has no words for (GRYT-932)

### DIFF
--- a/.github/scripts/check-permission-labels.mjs
+++ b/.github/scripts/check-permission-labels.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Fails when the server ships a permission the client has no words for.
+ *
+ * The server owns the list of permissions and sends it with the role editor
+ * payload. The client owns the labels and the one-line descriptions, on
+ * purpose — how a permission is worded is not the server's business. The
+ * seam between them is unchecked, and when it slips the role editor puts the
+ * permission in a group called "Newer than this client" and draws it as a bare
+ * id. It saves and applies correctly the whole time. It just reads as a client
+ * that is out of date.
+ *
+ * That has happened twice: `upload_avatar_image` in GRYT-866 and
+ * `set_activity` in GRYT-929, the second caught by hand rather than by
+ * anything running.
+ *
+ * Neither repository's CI can catch it, because neither can see the other.
+ * This one can. Same reasoning as check-avatar-parity.sh next door.
+ *
+ * Usage: check-permission-labels.mjs
+ *
+ * Reads the two source files in place. The caller is responsible for having
+ * packages/server and packages/client checked out at whatever refs it wants
+ * compared; this script has no opinion about that.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const ROOT =
+  process.env.GRYT_ROOT ??
+  resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const SERVER_FILE = `${ROOT}/packages/server/src/constants/permissions.ts`;
+const CLIENT_FILE = `${ROOT}/packages/client/src/packages/socket/src/lib/permissions.ts`;
+
+/**
+ * Both files are dense with comments, and the comments talk about permissions
+ * by name. Stripping them first is the difference between reading the code and
+ * reading the prose about the code.
+ *
+ * Crude on purpose: it does not understand a `//` inside a string literal.
+ * Neither file has one, and a parser that did would be a dependency.
+ */
+function withoutComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+function read(path, label) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    fail(`No ${label} at ${path} — is the submodule checked out?`);
+    process.exit(1);
+  }
+}
+
+const problems = [];
+function fail(message) {
+  problems.push(message);
+  console.error(`::error::${message}`);
+}
+
+/* ── the server's list ───────────────────────────────────────────────────── */
+
+const serverSource = withoutComments(read(SERVER_FILE, "server permission catalogue"));
+
+/*
+ * Anchored on the declaration rather than on "the first array in the file".
+ * The same file also holds MEMBER_PERMISSIONS and the backfill table, and
+ * picking one of those up would compare the client against a subset — which
+ * passes while saying nothing.
+ */
+const serverMatch = serverSource.match(
+  /export const PERMISSIONS\b[^=]*=\s*\[([\s\S]*?)\n\]/,
+);
+if (!serverMatch) {
+  fail(
+    `Could not find "export const PERMISSIONS = [" in ${SERVER_FILE} — ` +
+      "did the constant get renamed? This check reads the source as text, so a " +
+      "rename makes it silently compare nothing.",
+  );
+  process.exit(1);
+}
+
+const serverPermissions = [...serverMatch[1].matchAll(/"([a-z0-9_]+)"/g)].map((m) => m[1]);
+
+/* ── the client's labels ─────────────────────────────────────────────────── */
+
+const clientSource = withoutComments(read(CLIENT_FILE, "client permission labels"));
+
+/*
+ * Every entry the role editor can draw a name for. Matching on `id:` followed
+ * by `label:` rather than on bare strings keeps PERMISSIONS_BEFORE_CATALOGUE
+ * out of it — that list is a frozen record of an old release, not a set of
+ * things this editor has words for.
+ */
+const clientLabelled = [
+  ...clientSource.matchAll(/\{\s*id:\s*"([a-z0-9_]+)"\s*,\s*label:/g),
+].map((m) => m[1]);
+
+if (clientLabelled.length === 0) {
+  fail(
+    `Found no { id: "…", label: … } entries in ${CLIENT_FILE} — the shape of ` +
+      "PERMISSION_GROUPS has changed and this check needs rewriting. Reporting " +
+      "it rather than passing, because an empty list matches nothing and looks " +
+      "like agreement.",
+  );
+  process.exit(1);
+}
+
+/* ── compare, in both directions ─────────────────────────────────────────── */
+
+const labelled = new Set(clientLabelled);
+const shipped = new Set(serverPermissions);
+
+const unlabelled = serverPermissions.filter((p) => !labelled.has(p));
+const orphaned = clientLabelled.filter((p) => !shipped.has(p));
+
+console.log(`server ships ${serverPermissions.length} permissions`);
+console.log(`client labels ${clientLabelled.length}`);
+
+for (const permission of unlabelled) {
+  fail(
+    `${permission} is shipped by the server and has no label in the client — ` +
+      'it will render as a bare id under "Newer than this client".',
+  );
+}
+
+/*
+ * The other direction is worth failing on too. A label for a permission the
+ * server dropped is a switch the role editor offers and the server ignores,
+ * which is a worse lie than a missing switch.
+ */
+for (const permission of orphaned) {
+  fail(
+    `${permission} is labelled in the client and the server does not ship it — ` +
+      "the role editor offers a switch that does nothing.",
+  );
+}
+
+const duplicates = clientLabelled.filter((p, i) => clientLabelled.indexOf(p) !== i);
+for (const permission of new Set(duplicates)) {
+  fail(`${permission} is labelled twice in the client — it will draw in two groups.`);
+}
+
+if (problems.length > 0) {
+  console.error("");
+  console.error("The role editor and the server disagree about what exists.");
+  console.error(`Server: ${SERVER_FILE}`);
+  console.error(`Client: ${CLIENT_FILE}`);
+  process.exit(1);
+}
+
+console.log("");
+console.log("Every permission the server ships has words in the client.");

--- a/.github/workflows/discord-ci-notify.yml
+++ b/.github/workflows/discord-ci-notify.yml
@@ -13,6 +13,7 @@ on:
     workflows:
       - Avatar parity
       - Changelog style
+      - Permission labels
       - Release Client
       - Release Server
       - Sync Vikunja task

--- a/.github/workflows/permission-labels.yml
+++ b/.github/workflows/permission-labels.yml
@@ -1,0 +1,84 @@
+name: Permission labels
+
+# Checks that every permission the server ships has a label in the client's
+# role editor, and that the client has no labels for permissions the server
+# dropped.
+#
+# This lives in the superproject because nowhere else can see both sides. The
+# server owns the list and the client owns the wording — deliberately, since
+# how a permission reads is not the server's business — so each repository's
+# CI is green while the two have already drifted. When they have, the role
+# editor draws the permission as a bare id under "Newer than this client". It
+# saves correctly; it just reads as a client that is out of date. Twice now:
+# upload_avatar_image in GRYT-866 and set_activity in GRYT-929.
+
+on:
+  # Time-based for the same reason Avatar parity is. The commit that changes
+  # which two versions ship together is the gitlink bump from Update
+  # Submodules, and that commit carries [skip ci], so anything hung off `push`
+  # would skip exactly the commits worth checking.
+  schedule:
+    - cron: "41 6 * * *"
+
+  workflow_dispatch:
+
+  # So a change to the check is exercised by the PR that makes it, rather than
+  # first running at 06:41 the morning after it merges.
+  pull_request:
+    paths:
+      - .github/scripts/check-permission-labels.mjs
+      - .github/workflows/permission-labels.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: permission-labels-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Compare server permissions against client labels
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout monorepo
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Clone the two sides
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Cloned from the URL at main rather than resolved from the recorded
+          # gitlink, matching Avatar parity. What ships is each repository's
+          # own main; the gitlink is a snapshot of that, usually current and
+          # sometimes an hour behind.
+          #
+          # One file each, because that is all the check reads. Blobless plus a
+          # path-limited checkout fetches those two blobs and nothing else.
+          # Repo and path kept on one line each rather than in an
+          # associative array, so this reads the same on the bash 3.2 a
+          # maintainer has locally as it does on the runner.
+          for entry in \
+            "server:src/constants/permissions.ts" \
+            "client:src/packages/socket/src/lib/permissions.ts"
+          do
+            repo="${entry%%:*}"
+            path="${entry#*:}"
+
+            # actions/checkout leaves an empty directory for each gitlink, and
+            # clone refuses a directory that has anything in it.
+            rm -rf "packages/${repo}"
+
+            git clone --quiet --filter=blob:none --no-checkout \
+              "https://github.com/Gryt-chat/${repo}.git" "packages/${repo}"
+            git -C "packages/${repo}" checkout --quiet origin/main -- "${path}"
+            echo "${repo}: $(git -C "packages/${repo}" rev-parse --short origin/main)"
+          done
+
+      - name: Compare
+        shell: bash
+        run: node .github/scripts/check-permission-labels.mjs

--- a/.github/workflows/permission-labels.yml
+++ b/.github/workflows/permission-labels.yml
@@ -82,3 +82,5 @@ jobs:
       - name: Compare
         shell: bash
         run: node .github/scripts/check-permission-labels.mjs
+
+# Trigger note: the check reads source as text, so it needs no install step.


### PR DESCRIPTION
Adds `.github/workflows/permission-labels.yml` and `.github/scripts/check-permission-labels.mjs`, and lists the workflow in `discord-ci-notify.yml`.

### What it's for

The server owns the list of permissions and ships it with the role editor payload. The client owns the labels and one-line descriptions, deliberately — how a permission is worded is not the server's business. Nothing checks the two still line up.

When they don't, the role editor puts the permission in a group called "Newer than this client" and draws it as a bare id. It saves and applies correctly the whole time, which is why it survives: nothing is broken, it only looks broken. Happened with `upload_avatar_image` in GRYT-866, and again with `set_activity` in GRYT-929 — that one caught by reading the two lists side by side, not by anything running.

Neither repository's CI can see the other. The superproject can, and `avatar-parity.yml` already does exactly this for `@gryt/owl`, down to the schedule trigger — the gitlink bump that changes which two versions ship together carries `[skip ci]`, so a `push` trigger would skip the commits worth checking.

### It is red on merge, on purpose

`server:main` has `set_activity` since Gryt-chat/server#142 merged. `client:main` has no label for it until Gryt-chat/client#415 lands. So this check fails against both repos at main right now:

```
server ships 41 permissions
client labels 40
::error::set_activity is shipped by the server and has no label in the client — it will render as a bare id under "Newer than this client".
```

That's the live drift, not a contrived case. Holding the check back until the thing it detects has gone away seemed like the wrong instinct, but it does mean the scheduled run goes red until client#415 merges. Say if you'd rather it went in after.

### What to look at

The part I'd read closely is the pair of guards against passing while having read nothing. The check greps TypeScript source, so if `export const PERMISSIONS = [` gets renamed, or `PERMISSION_GROUPS` stops being `{ id, label }` entries, an empty extraction compares cleanly against anything and reports agreement — a green check that has stopped checking. Both cases exit 1 saying the check needs rewriting instead.

The other judgment call: it fails in both directions. A label with no permission behind it is a switch the role editor offers and the server ignores, which I think is worse than a missing switch, but it does mean removing a permission now needs both repos touched.

### Checked

Ran it against six cases before committing — a missing label, an orphaned label, a duplicate label, a renamed server constant, a reshaped client list, and an unchecked-out submodule. Each fails with the message it should. Also ran the workflow's clone step against the real remotes, which fetches one file from each repo via a blobless clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)