### PR TITLE
Move the journald driver out of the file self-hosters run

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -5,7 +5,7 @@ Operational scripts and deployment artifacts.
 ### For self-hosters (public)
 
 - `ops/deploy/host/compose.yml` — production-style Docker Compose stack (Cloudflare Tunnel friendly)
-- `ops/deploy/compose/*` — additional compose stacks used during development/testing
+- `ops/deploy/compose/prod.yml`, `beta.yml`, `dev.yml`, `dev-deps.yml` — additional compose stacks used during development/testing
 - `ops/helm/gryt/*` — Kubernetes Helm chart
 
 ### For contributors (public)
@@ -16,3 +16,4 @@ Operational scripts and deployment artifacts.
 ### Internal (project-owned infrastructure)
 
 - `ops/internal/*` — used to run the project’s own hosted services (e.g. `gryt.chat`, `docs.gryt.chat`, `feedback.gryt.chat`)
+- `ops/deploy/compose/*.local.yml` — overrides merged on top of the stack file next to them, for the box the project runs itself. Anything that assumes that box goes here and not in the stack file. The journald log driver is one: it needs systemd, and Docker won't start a container with it on a host that hasn't got it.

--- a/ops/deploy/compose/beta.local.yml
+++ b/ops/deploy/compose/beta.local.yml
@@ -3,7 +3,54 @@
 ##   docker compose -f beta.yml -f beta.local.yml --env-file .env.beta up -d
 ##
 
+# Logs that survive the container.
+#
+# The default json-file driver keeps its files under the container, so `docker
+# compose up -d` on a new image takes the old container's entire history with
+# it. On 2026-09-06 a voice drop on pp could not be diagnosed for exactly that
+# reason: the server had been up for seventeen hours through the incident, was
+# recreated ten minutes later by a routine deploy, and every line it had written
+# went with it.
+#
+# journald keeps them in the system journal instead, where they outlive the
+# container and are searchable by time across every service at once. `docker
+# logs` still works — the driver supports reading back.
+#
+# This sits in the override and not in the stack file next to it, because the
+# journald driver needs journald on the host. Without systemd — Alpine, a
+# minimal container host, WSL with systemd off — Docker refuses the container
+# with "journald is not enabled on this host" and it never starts at all. The
+# stack file is one self-hosters are pointed at, so a logging choice made there
+# becomes their boot failure. This file is the project's own box, and that box
+# runs systemd.
+#
+# There is no max-size here for the same reason in reverse: log options belong
+# to the driver, and max-size is json-file's. journald rejects it, so a file
+# carrying both would break whichever driver it did not match.
+#
+# Applied to the long-lived services only. The init containers run once and say
+# nothing worth keeping, and MinIO is noisy enough to be worth leaving where it
+# is.
+x-logging: &gryt-logging
+  driver: journald
+  options:
+    tag: "{{.Name}}"
+
 services:
+  # The long-lived services from the stack file, here only to pick up the
+  # journald driver above. Everything else about them stays as it is there.
+  sfu:
+    logging: *gryt-logging
+
+  server:
+    logging: *gryt-logging
+
+  image-worker:
+    logging: *gryt-logging
+
+  client:
+    logging: *gryt-logging
+
   # Override minio-init to also create the NT beta bucket
   minio-init:
     environment:
@@ -23,6 +70,7 @@ services:
   server-nt:
     image: ghcr.io/gryt-chat/server:${SERVER_VERSION:-latest-beta}
     container_name: gryt-beta-server-nt
+    logging: *gryt-logging
     ports:
       - "${NT_SERVER_PORT:-5011}:5000"
     environment:
@@ -93,6 +141,7 @@ services:
   image-worker-nt:
     image: ghcr.io/gryt-chat/image-worker:${IMAGE_WORKER_VERSION:-latest-beta}
     container_name: gryt-beta-image-worker-nt
+    logging: *gryt-logging
     # The server runs with host networking, so it cannot reach this container
     # by service name — it has to come in through a published port. Bound to
     # loopback: this is a health endpoint for the server beside it, not

--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -1,26 +1,5 @@
 name: gryt-beta
 
-# Logs that survive the container.
-#
-# The default json-file driver keeps its files under the container, so `docker
-# compose up -d` on a new image takes the old container's entire history with
-# it. On 2026-09-06 a voice drop on pp could not be diagnosed for exactly that
-# reason: the server had been up for seventeen hours through the incident, was
-# recreated ten minutes later by a routine deploy, and every line it had written
-# went with it.
-#
-# journald keeps them in the system journal instead, where they outlive the
-# container and are searchable by time across every service at once. `docker
-# logs` still works — the driver supports reading back.
-#
-# Applied to the long-lived services only. The init containers run once and say
-# nothing worth keeping, and MinIO is noisy enough to be worth leaving where it
-# is.
-x-logging: &gryt-logging
-  driver: journald
-  options:
-    tag: "{{.Name}}"
-
 services:
   # ── Object Storage ───────────────────────────────────────────────────────
   minio:
@@ -86,7 +65,6 @@ services:
   sfu:
     image: ghcr.io/gryt-chat/sfu:${SFU_VERSION:-latest-beta}
     container_name: gryt-beta-sfu
-    logging: *gryt-logging
     ports:
       - "${SFU_PORT:-5015}:5005"
       - "${ICE_UDP_MUX_PORT:-4443}:${ICE_UDP_MUX_PORT:-4443}/udp"
@@ -123,7 +101,6 @@ services:
   server:
     image: ghcr.io/gryt-chat/server:${SERVER_VERSION:-latest-beta}
     container_name: gryt-beta-server
-    logging: *gryt-logging
     network_mode: host
     extra_hosts:
       - "sfu:127.0.0.1"
@@ -219,7 +196,6 @@ services:
   image-worker:
     image: ghcr.io/gryt-chat/image-worker:${IMAGE_WORKER_VERSION:-latest-beta}
     container_name: gryt-beta-image-worker
-    logging: *gryt-logging
     # The server runs with host networking, so it cannot reach this container
     # by service name — it has to come in through a published port. Bound to
     # loopback: this is a health endpoint for the server beside it, not
@@ -268,7 +244,6 @@ services:
   client:
     image: ghcr.io/gryt-chat/client:${CLIENT_VERSION:-latest-beta}
     container_name: gryt-beta-client
-    logging: *gryt-logging
     profiles: ["web"]
     ports:
       - "${CLIENT_PORT:-3667}:80"

--- a/ops/deploy/compose/prod.local.yml
+++ b/ops/deploy/compose/prod.local.yml
@@ -3,7 +3,54 @@
 ##   docker compose -f prod.yml -f prod.local.yml --env-file .env.prod up -d
 ##
 
+# Logs that survive the container.
+#
+# The default json-file driver keeps its files under the container, so `docker
+# compose up -d` on a new image takes the old container's entire history with
+# it. On 2026-09-06 a voice drop on pp could not be diagnosed for exactly that
+# reason: the server had been up for seventeen hours through the incident, was
+# recreated ten minutes later by a routine deploy, and every line it had written
+# went with it.
+#
+# journald keeps them in the system journal instead, where they outlive the
+# container and are searchable by time across every service at once. `docker
+# logs` still works — the driver supports reading back.
+#
+# This sits in the override and not in the stack file next to it, because the
+# journald driver needs journald on the host. Without systemd — Alpine, a
+# minimal container host, WSL with systemd off — Docker refuses the container
+# with "journald is not enabled on this host" and it never starts at all. The
+# stack file is one self-hosters are pointed at, so a logging choice made there
+# becomes their boot failure. This file is the project's own box, and that box
+# runs systemd.
+#
+# There is no max-size here for the same reason in reverse: log options belong
+# to the driver, and max-size is json-file's. journald rejects it, so a file
+# carrying both would break whichever driver it did not match.
+#
+# Applied to the long-lived services only. The init containers run once and say
+# nothing worth keeping, and MinIO is noisy enough to be worth leaving where it
+# is.
+x-logging: &gryt-logging
+  driver: journald
+  options:
+    tag: "{{.Name}}"
+
 services:
+  # The long-lived services from the stack file, here only to pick up the
+  # journald driver above. Everything else about them stays as it is there.
+  sfu:
+    logging: *gryt-logging
+
+  server:
+    logging: *gryt-logging
+
+  image-worker:
+    logging: *gryt-logging
+
+  client:
+    logging: *gryt-logging
+
   # Override minio-init to also create the NT bucket
   minio-init:
     environment:
@@ -23,6 +70,7 @@ services:
   server-nt:
     image: ghcr.io/gryt-chat/server:${SERVER_VERSION:-latest}
     container_name: gryt-prod-server-nt
+    logging: *gryt-logging
     ports:
       - "${NT_SERVER_PORT:-5001}:5000"
     environment:
@@ -84,6 +132,7 @@ services:
   image-worker-nt:
     image: ghcr.io/gryt-chat/image-worker:${IMAGE_WORKER_VERSION:-latest}
     container_name: gryt-prod-image-worker-nt
+    logging: *gryt-logging
     # The server runs with host networking, so it cannot reach this container
     # by service name — it has to come in through a published port. Bound to
     # loopback: this is a health endpoint for the server beside it, not

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -1,26 +1,5 @@
 name: gryt-prod
 
-# Logs that survive the container.
-#
-# The default json-file driver keeps its files under the container, so `docker
-# compose up -d` on a new image takes the old container's entire history with
-# it. On 2026-09-06 a voice drop on pp could not be diagnosed for exactly that
-# reason: the server had been up for seventeen hours through the incident, was
-# recreated ten minutes later by a routine deploy, and every line it had written
-# went with it.
-#
-# journald keeps them in the system journal instead, where they outlive the
-# container and are searchable by time across every service at once. `docker
-# logs` still works — the driver supports reading back.
-#
-# Applied to the long-lived services only. The init containers run once and say
-# nothing worth keeping, and MinIO is noisy enough to be worth leaving where it
-# is.
-x-logging: &gryt-logging
-  driver: journald
-  options:
-    tag: "{{.Name}}"
-
 services:
   # ── Object Storage ───────────────────────────────────────────────────────
   minio:
@@ -80,7 +59,6 @@ services:
   sfu:
     image: ghcr.io/gryt-chat/sfu:${SFU_VERSION:-latest}
     container_name: gryt-prod-sfu
-    logging: *gryt-logging
     ports:
       - "${SFU_PORT:-5005}:5005"
       - "${ICE_UDP_MUX_PORT:-3478}:${ICE_UDP_MUX_PORT:-3478}/udp"
@@ -116,7 +94,6 @@ services:
   server:
     image: ghcr.io/gryt-chat/server:${SERVER_VERSION:-latest}
     container_name: gryt-prod-server
-    logging: *gryt-logging
     network_mode: host
     extra_hosts:
       - "sfu:127.0.0.1"
@@ -204,7 +181,6 @@ services:
   image-worker:
     image: ghcr.io/gryt-chat/image-worker:${IMAGE_WORKER_VERSION:-latest}
     container_name: gryt-prod-image-worker
-    logging: *gryt-logging
     # The server runs with host networking, so it cannot reach this container
     # by service name — it has to come in through a published port. Bound to
     # loopback: this is a health endpoint for the server beside it, not
@@ -374,7 +350,6 @@ services:
   client:
     image: ghcr.io/gryt-chat/client:${CLIENT_VERSION:-latest}
     container_name: gryt-prod-client
-    logging: *gryt-logging
     profiles: ["web"]
     ports:
       - "${CLIENT_PORT:-3666}:80"


### PR DESCRIPTION
## What is wrong

#194 set `logging: driver: journald` on `sfu`, `server`, `image-worker` and `client` in `ops/deploy/compose/prod.yml` and `beta.yml`. `ops/README.md` lists `ops/deploy/compose/*` under **For self-hosters (public)**.

The journald driver needs journald on the host. Without systemd — Alpine, a minimal container host, WSL with systemd off — Docker refuses with `journald is not enabled on this host` and the container never starts. Anyone pulling those files got a stack that will not come up.

## What changed

- `prod.yml` and `beta.yml` go back to the Docker default. No env var, no conditional options block.
- `prod.local.yml` and `beta.local.yml` carry the `x-logging` anchor and the `logging:` keys instead. The box already composes with them (`prod: prod.yml, prod.local.yml, pp.yml` and `beta: beta.yml, beta.local.yml`), so journald on dev.lan is unchanged.
- `server-nt` and `image-worker-nt` get it too. They exist only in the local files, so #194 never reached them, and they were the last long-lived containers on that box still writing json-file.
- `ops/README.md` lists `*.local.yml` as internal rather than folding it into the public glob.

There is no `max-size` anywhere on purpose. Log options belong to a driver and `max-size` is json-file's, so journald rejects it and a file carrying both breaks whichever driver it does not match.

## What to look at

- **The `server-nt` and `image-worker-nt` lines.** One line each, same intent, but it is more than a straight move of what #194 added. Drop them if you would rather this PR only undid the mistake.
- **The `client` stub.** `client` sits behind `profiles: ["web"]` in the stack file and the override adds nothing but `logging:`. I checked the merge resolves to a real service rather than declaring one with no image, but it is the one that looked odd.

## Verified

`docker compose config` on both stacks, with and without the override:

| Files | Services on journald |
|---|---|
| `-f prod.yml` | none |
| `-f prod.yml -f prod.local.yml` | sfu, server, image-worker, client, server-nt, image-worker-nt |
| `-f beta.yml` | none |
| `-f beta.yml -f beta.local.yml` | the same six |

minio and the init containers stay on the default, which is what #194 wanted.

## Follow-ups

Both were left undecided by #194 and are now filed rather than sitting in a PR body:

- #196 — `ops/deploy/host/compose.yml` is the primary self-host stack and has no logging configuration at all.
- #197 — `pp.yml` is not in this repo, so `server-pp`, the server the 2026-09-06 voice drop happened on, is not covered by any commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)