### PR TITLE
Pull the superproject from the web client timer too

### DIFF
--- a/ops/internal/README.md
+++ b/ops/internal/README.md
@@ -203,10 +203,23 @@ executable itself — so the symlink is what keeps the unit free of anybody's ho
 
 ```bash
 sudo ln -sfn "$PWD/ops/internal/refresh-web-client.sh" /usr/local/bin/gryt-web-client-refresh
+sudo ln -sfn "$PWD/ops/internal/pull-superproject.sh" /usr/local/bin/gryt-pull-superproject
 sudo cp ops/internal/systemd/gryt-web-client-refresh.{service,timer} /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now gryt-web-client-refresh.timer
 ```
+
+The second symlink is the same one the sites timer installs. It is on both on purpose, as
+an `ExecStartPre`, so every tick fast-forwards the checkout before anything deploys from
+it.
+
+For a while only the sites timer had it. On 2026-09-06 that timer turned out to be
+disabled, so the checkout had not moved since 2026-09-01 and sat around thirty commits
+behind. This timer kept firing every ten minutes and reporting everything current, which
+was true of the images and not of the compose files it deploys from.
+
+The units themselves are copied rather than symlinked, so changing one means running the
+`cp` and `daemon-reload` again. The scripts they point at update with `git pull`.
 
 It fires every ten minutes and runs as root, which is the usual arrangement for a system
 unit talking to the Docker socket. To run as somebody else, drop in an override with

--- a/ops/internal/systemd/gryt-web-client-refresh.service
+++ b/ops/internal/systemd/gryt-web-client-refresh.service
@@ -7,6 +7,31 @@ Requires=docker.service
 [Service]
 Type=oneshot
 
+# Bring the checkout up to date first, so ops/ changes reach this machine.
+#
+# The same ExecStartPre is on gryt-sites-refresh.service, and for a while that
+# was the only place it lived. On 2026-09-06 the sites timer turned out to be
+# disabled, so nothing had pulled the superproject since 2026-09-01 and the
+# checkout sat around thirty commits behind — including the two compose changes
+# this unit deploys from. This unit kept firing every ten minutes and reporting
+# success the whole time, because it reads each stack's compose files off the
+# running container's labels and those paths were all still there.
+#
+# So the pull hangs off both timers now. One of them being off is then a slow
+# rebuild or a slow image, rather than a machine quietly deploying from last
+# week.
+#
+# Cheap and idempotent: a fetch and a fast-forward that exits without a word
+# when there is nothing to move. If both timers do land together, one loses the
+# index lock, says so, and picks it up on the next tick.
+#
+# A separate process on purpose. The refresher below is symlinked out of the
+# checkout this pull rewrites, and bash reads a script as it runs it, so pulling
+# from inside the refresher could replace its own remaining lines underneath it.
+#
+# The leading dash so a failed pull does not stop the refresh.
+ExecStartPre=-/usr/local/bin/gryt-pull-superproject
+
 # A symlink into the checkout rather than a copy, so `git pull` updates the
 # script and nothing has to be installed again. systemd needs a literal
 # absolute path here — it does not expand variables in the executable itself —


### PR DESCRIPTION
## What I found

The box is deploying from a checkout that stopped moving on 2026-09-01.

`gryt-pull-superproject` is the only thing that fast-forwards `/home/sivert/gryt`, and it hangs off `gryt-sites-refresh.service` as an `ExecStartPre`. That timer is `disabled` on dev.lan and last ran 2026-09-01 22:10. So the checkout sits at `42207bb`, around thirty commits behind, and neither #194 nor #198 has reached the machine. Every container is still on `json-file`:

```
gryt-prod-sfu      ... prod.yml,prod.local.yml,pp.yml   json-file
gryt-prod-server   ... prod.yml,prod.local.yml,pp.yml   json-file
gryt-beta-sfu      ... beta.yml,beta.local.yml          json-file
```

`gryt-web-client-refresh.timer` kept firing every ten minutes through all of it and logging `already current`. It is not lying: it reads each stack's compose files off the running container's labels, and those paths had not moved. Nothing in its output says the files behind them are a week old. `docs.gryt.chat`, `gryt.chat` and `ui.gryt.chat` have not been rebuilt since 2026-09-01 either.

## What changed

`ExecStartPre=-/usr/local/bin/gryt-pull-superproject` on `gryt-web-client-refresh.service` as well, so the pull no longer depends on one timer being enabled. `ops/internal/README.md` gains the second symlink in that install block.

The pull is a fetch and a fast-forward that exits without a word when there is nothing to move, and refuses on local commits or tracked changes outside `packages/`. Running it twice as often costs nothing.

## What to look at

- **Two timers running the same pull.** They fire ten minutes apart with a randomised offset, so an overlap is unlikely rather than impossible. If they do land together one loses `index.lock`, logs it, and picks it up on the next tick. The `-` prefix means neither refresh stops for it. I think that is fine, but it is the part I would argue about.
- **This does not fix dev.lan on its own.** The unit files are copied into `/etc/systemd/system`, not symlinked, so merging this changes nothing on the box until the `cp` and `daemon-reload` are run there. Commands are in the summary I left you.
- **Whether `gryt-sites-refresh.timer` should just go back on** is a separate call and I have not touched it. Re-enabling it pulls thirty commits and rebuilds three sites on its first tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)