### PR TITLE
Give a Pi build a timeout, and put the deploy in the repo (GRYT-958)

### DIFF
--- a/ops/deploy/rpi/README.md
+++ b/ops/deploy/rpi/README.md
@@ -1,0 +1,97 @@
+# The Raspberry Pi that serves the web
+
+`gryt.chat`, `docs.gryt.chat`, `ui.gryt.chat`, `app.gryt.chat` and
+`beta.gryt.chat` all run on one Pi. This directory is what runs them.
+
+Until now these four files existed **only on the Pi**, in `/home/sivert/gryt/`,
+untracked. That meant no history, no review, and no copy anywhere if the SD card
+died. They are here now; the Pi still runs from its own copies, and adopting a
+change is a deliberate step (below).
+
+| File | Where it lives on the Pi |
+|---|---|
+| `update.sh` | `/home/sivert/gryt/update.sh` |
+| `compose.yml` | `/home/sivert/gryt/compose.yml` |
+| `gryt-update.service` | `/etc/systemd/system/gryt-update.service` |
+| `gryt-update.timer` | `/etc/systemd/system/gryt-update.timer` |
+
+## How it works
+
+The timer fires every five minutes. `update.sh` takes a `flock` so two runs
+never overlap, then walks the services in order:
+
+1. **`site`, `docs`, `ui`** are built from source. Each has its own clone under
+   `/home/sivert/gryt/<name>`. The script fetches, refuses anything that isn't a
+   clean fast-forward, builds, and only writes `.deployed/<name>.sha` once the
+   container is up. A failure leaves the running container alone and backs off —
+   5 minutes, then 10, 20, 40, capped at 6 hours for the same commit.
+2. **`app` and `beta`** are images, not builds. There is no commit to compare, so
+   it pulls the tag and restarts only if the image id moved. They go last so a
+   slow source build never delays a client release.
+
+## What went wrong on 2026-09-07, and what stops it now
+
+A `bun install` inside the `ui` build wedged after printing
+`Slow filesystem detected`. Nothing had a timeout, so:
+
+- the build sat there for **1h45m** with the machine idle at 0.78 load,
+- it held the `flock` the whole time,
+- every subsequent timer firing exited immediately on `flock -n`,
+- so `site` and `docs` — quick builds, with six merged pull requests waiting —
+  were never checked again.
+
+Nothing failed. `systemctl is-active` said `activating`, which is exactly what a
+healthy long build says.
+
+Two changes, deliberately belt and braces:
+
+- **`BUILD_TIMEOUT=40m` in `update.sh`.** One stuck build is killed, counted as a
+  failure so it lands on the retry backoff, and **the services after it in the
+  same run still get their turn**. This is the one that matters: it means a
+  wedged `ui` no longer costs `site` and `docs` anything.
+- **`TimeoutStartSec=2h` on the unit.** `Type=oneshot` defaults to
+  `infinity`, which is why systemd was content to wait forever. This catches a
+  hang somewhere the script's own timeout does not cover.
+
+The log now distinguishes the two, because they have different causes — a build
+that *fails* is usually the source, and one that *hangs* is usually the box:
+
+```
+[…] [ui] BUILD TIMED OUT after 40m; running container untouched
+[…] [ui] BUILD FAILED; running container untouched
+```
+
+## Adopting a change from here
+
+The Pi does not pull this directory. Copy deliberately, and watch one cycle
+before walking away:
+
+```bash
+scp ops/deploy/rpi/update.sh rpi:/home/sivert/gryt/update.sh
+ssh rpi 'chmod +x /home/sivert/gryt/update.sh'
+```
+
+For the units, which need root:
+
+```bash
+scp ops/deploy/rpi/gryt-update.service ops/deploy/rpi/gryt-update.timer rpi:/tmp/
+ssh rpi 'sudo install -m644 /tmp/gryt-update.{service,timer} /etc/systemd/system/ \
+  && sudo systemctl daemon-reload'
+```
+
+Then watch a run rather than assuming:
+
+```bash
+ssh rpi 'systemctl start gryt-update.service; journalctl -u gryt-update.service -f'
+```
+
+## Things worth knowing before touching it
+
+- **Never `docker system prune` here.** The build caches are what keep a Pi
+  build to minutes rather than an hour.
+- **A build failure is not a deploy failure.** The running container is left
+  alone on purpose; a site that is an hour stale beats a site that is 502.
+- **`.deployed/<name>.sha` is the record**, not the git checkout. A checkout can
+  be ahead of what is actually serving if a build failed after the fast-forward.
+- The clones under `/home/sivert/gryt/<name>` are **not** the superproject's
+  submodules. They are separate shallow clones, one per deployed service.

--- a/ops/deploy/rpi/compose.yml
+++ b/ops/deploy/rpi/compose.yml
@@ -1,0 +1,85 @@
+name: gryt-web
+
+services:
+  site:
+    build:
+      context: ./site
+      network: host
+    image: gryt-site:local
+    container_name: gryt-site
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+
+  docs:
+    build:
+      context: ./docs
+      dockerfile: ../local/Dockerfile.docs
+      network: host
+    image: gryt-docs:local
+    container_name: gryt-docs
+    restart: unless-stopped
+    ports:
+      - "8081:3000"
+
+  app:
+    image: ghcr.io/gryt-chat/client:latest
+    container_name: gryt-app
+    restart: unless-stopped
+    ports:
+      - "8082:80"
+    environment:
+      GRYT_OIDC_ISSUER: https://auth.gryt.chat/realms/gryt
+      GRYT_OIDC_REALM: gryt
+      GRYT_OIDC_CLIENT_ID: gryt-web
+      GRYT_IDENTITY_URL: https://id.gryt.chat
+      GRYT_AUTH_API: https://auth.gryt.chat
+      GRYT_AUTH_CALLBACK_URL: https://gryt.chat/auth/callback
+    healthcheck:
+      test:
+        - CMD
+        - wget
+        - --no-verbose
+        - --tries=1
+        - --spider
+        - http://127.0.0.1/health
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  beta:
+    image: ghcr.io/gryt-chat/client:latest-beta
+    container_name: gryt-beta
+    restart: unless-stopped
+    ports:
+      - "8083:80"
+    environment:
+      GRYT_OIDC_ISSUER: https://auth.gryt.chat/realms/gryt
+      GRYT_OIDC_REALM: gryt
+      GRYT_OIDC_CLIENT_ID: gryt-web
+      GRYT_IDENTITY_URL: https://id.gryt.chat
+      GRYT_AUTH_API: https://auth.gryt.chat
+      GRYT_AUTH_CALLBACK_URL: https://gryt.chat/auth/callback
+    healthcheck:
+      test:
+        - CMD
+        - wget
+        - --no-verbose
+        - --tries=1
+        - --spider
+        - http://127.0.0.1/health
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  ui:
+    build:
+      context: ./ui
+      network: host
+    image: gryt-ui:local
+    container_name: gryt-ui
+    restart: unless-stopped
+    ports:
+      - "8084:80"

--- a/ops/deploy/rpi/gryt-update.service
+++ b/ops/deploy/rpi/gryt-update.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Update Gryt site and docs
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=sivert
+WorkingDirectory=/home/sivert/gryt
+ExecStart=/home/sivert/gryt/update.sh
+
+# The backstop for a hang the script's own `timeout` does not cover.
+#
+# `Type=oneshot` defaults to TimeoutStartSec=infinity, which is why the run on
+# 2026-09-07 sat "activating" for an hour and three quarters with the machine
+# idle at 0.78 load. Two hours is comfortably longer than a full pass — three
+# source builds at up to forty minutes each is bounded by the script — so
+# reaching this means something outside a build is stuck.
+TimeoutStartSec=2h

--- a/ops/deploy/rpi/gryt-update.timer
+++ b/ops/deploy/rpi/gryt-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check Gryt site and docs every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitInactiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ops/deploy/rpi/update.sh
+++ b/ops/deploy/rpi/update.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+
+set -u
+
+BASE="/home/sivert/gryt"
+COMPOSE="$BASE/compose.yml"
+STATE="$BASE/.deployed"
+
+# First retry after 5 min, then 10, 20, 40...
+# Cap repeated failures at 6 hours.
+RETRY_BASE=300
+RETRY_CAP=21600
+
+# How long one image may take to build before it is given up on.
+#
+# This is the fix for the failure on 2026-09-07: a `bun install` inside the ui
+# build wedged after printing "Slow filesystem detected", and because a build
+# had no timeout it held the lock below for an hour and three quarters. Every
+# cycle after it exited immediately on `flock -n`, so site and docs — which are
+# quick, and which had merged changes waiting — were never checked again. Six
+# merged pull requests sat undeployed until somebody looked at the box.
+#
+# Forty minutes is roughly twice the ui build's honest worst case on this Pi.
+# A build that overruns it is not slow, it is stuck.
+BUILD_TIMEOUT=40m
+
+mkdir -p "$STATE"
+
+# Extra protection against overlapping builds.
+exec 9>"$BASE/.update.lock"
+flock -n 9 || {
+    echo "[$(date -Is)] updater already running; skipping"
+    exit 0
+}
+
+retry_delay() {
+    local attempts="$1"
+    local delay="$RETRY_BASE"
+    local i
+
+    for ((i=1; i<attempts; i++)); do
+        delay=$((delay * 2))
+        if ((delay >= RETRY_CAP)); then
+            echo "$RETRY_CAP"
+            return
+        fi
+    done
+
+    echo "$delay"
+}
+
+update_service() {
+    local repo="$1"
+    local service="$2"
+
+    local dir="$BASE/$repo"
+    local statefile="$STATE/$repo.sha"
+    local failedfile="$STATE/$repo.failed"
+
+    local head target deployed dirty
+    local failed_commit attempts next_try now delay
+
+    echo
+    echo "[$(date -Is)] [$service] checking"
+
+    # Never overwrite local tracked changes.
+    dirty="$(git -C "$dir" status --porcelain --untracked-files=no)"
+
+    if [[ -n "$dirty" ]]; then
+        echo "[$(date -Is)] [$service] local tracked changes present; skipping"
+        return 1
+    fi
+
+    if ! git -C "$dir" fetch --quiet origin main; then
+        echo "[$(date -Is)] [$service] git fetch failed"
+        return 1
+    fi
+
+    head="$(git -C "$dir" rev-parse HEAD)"
+    target="$(git -C "$dir" rev-parse origin/main)"
+    deployed="$(cat "$statefile" 2>/dev/null || echo unknown)"
+
+    if [[ "$head" == "$target" && "$deployed" == "$target" ]]; then
+        echo "[$(date -Is)] [$service] current ${target:0:12}"
+        return 0
+    fi
+
+    # Handle retry backoff for the same failed commit.
+    now="$(date +%s)"
+
+    if [[ -f "$failedfile" ]]; then
+        read -r failed_commit attempts next_try < "$failedfile"
+
+        if [[ "$failed_commit" == "$target" && "$now" -lt "$next_try" ]]; then
+            echo "[$(date -Is)] [$service] ${target:0:12} previously failed ${attempts}x; retry later"
+            return 1
+        fi
+    else
+        failed_commit=""
+        attempts=0
+        next_try=0
+    fi
+
+    # Only accept a clean fast-forward from the current checkout.
+    if [[ "$head" != "$target" ]]; then
+        if ! git -C "$dir" merge-base --is-ancestor "$head" "$target"; then
+            echo "[$(date -Is)] [$service] origin/main is not a clean fast-forward; skipping"
+            return 1
+        fi
+
+        if ! git -C "$dir" merge --ff-only --quiet origin/main; then
+            echo "[$(date -Is)] [$service] fast-forward failed"
+            return 1
+        fi
+
+        echo "[$(date -Is)] [$service] source ${head:0:12} -> ${target:0:12}"
+    fi
+
+    echo "[$(date -Is)] [$service] building ${target:0:12}"
+
+    # `timeout` rather than a bare build. A stuck build is killed and counted as
+    # a failure, which puts it on the retry backoff below and — crucially —
+    # lets the services after it in this run carry on.
+    local status_code=0
+    timeout "$BUILD_TIMEOUT" docker compose -f "$COMPOSE" build "$service" || status_code=$?
+
+    if (( status_code != 0 )); then
+        if [[ "$failed_commit" != "$target" ]]; then
+            attempts=0
+        fi
+
+        attempts=$((attempts + 1))
+        delay="$(retry_delay "$attempts")"
+
+        printf '%s %s %s\n' \
+            "$target" \
+            "$attempts" \
+            "$((now + delay))" \
+            > "$failedfile"
+
+        # 124 is `timeout`'s own exit code. Worth separating: a build that
+        # fails is usually the source, and one that hangs is usually the box.
+        if (( status_code == 124 )); then
+            echo "[$(date -Is)] [$service] BUILD TIMED OUT after $BUILD_TIMEOUT; running container untouched"
+        else
+            echo "[$(date -Is)] [$service] BUILD FAILED; running container untouched"
+        fi
+        return 1
+    fi
+
+    echo "[$(date -Is)] [$service] deploying"
+
+    if ! docker compose -f "$COMPOSE" up -d --no-deps "$service"; then
+        echo "[$(date -Is)] [$service] deploy failed"
+        return 1
+    fi
+
+    printf '%s\n' "$target" > "$statefile"
+    rm -f "$failedfile"
+
+    echo "[$(date -Is)] [$service] deployed ${target:0:12}"
+}
+
+# The web clients are images, not build contexts, so there is no commit to
+# compare against. The published tag stays the same and the id under it moves,
+# which is the only thing that says a release happened.
+#
+# Nothing pulled these until this existed. The dev box's refresh script covers
+# gryt-prod-client and gryt-beta-client, but those are leftovers on 3666 and
+# 3667 that nothing routes to; app.gryt.chat and beta.gryt.chat are here.
+update_image() {
+    local service="$1"
+    local container="$2"
+
+    local image before after
+
+    echo
+    echo "[$(date -Is)] [$service] checking"
+
+    image="$(docker inspect "$container" --format '{{.Config.Image}}' 2>/dev/null)"
+
+    if [[ -z "$image" ]]; then
+        echo "[$(date -Is)] [$service] no container named $container; skipping"
+        return 1
+    fi
+
+    before="$(docker inspect "$container" --format '{{.Image}}' 2>/dev/null)"
+
+    if ! docker pull --quiet "$image" >/dev/null; then
+        echo "[$(date -Is)] [$service] pull of $image failed; running container untouched"
+        return 1
+    fi
+
+    after="$(docker image inspect "$image" --format '{{.Id}}' 2>/dev/null)"
+
+    if [[ "$before" == "$after" ]]; then
+        echo "[$(date -Is)] [$service] current ${after:7:12}"
+        return 0
+    fi
+
+    echo "[$(date -Is)] [$service] image ${before:7:12} -> ${after:7:12}"
+
+    if ! docker compose -f "$COMPOSE" up -d --no-deps "$service"; then
+        echo "[$(date -Is)] [$service] deploy failed"
+        return 1
+    fi
+
+    echo "[$(date -Is)] [$service] deployed ${after:7:12}"
+}
+
+status=0
+
+# Deliberately serial. Never build both simultaneously.
+update_service site site || status=1
+update_service docs docs || status=1
+update_service ui ui || status=1
+
+# After the source builds, so a slow ui build never delays a client release.
+update_image app gryt-app || status=1
+update_image beta gryt-beta || status=1
+
+exit "$status"


### PR DESCRIPTION
A `bun install` inside the `ui` image build wedged today after printing
`Slow filesystem detected`. Nothing had a timeout, so:

- it sat for **1h45m** with the machine idle at 0.78 load,
- it held `update.sh`'s `flock` the whole time,
- every timer firing after it exited immediately on `flock -n`,
- so `site` and `docs` — quick builds, with **six merged PRs waiting** — were
  never checked again.

**Nothing failed.** `systemctl is-active` said `activating`, which is exactly
what a healthy long build says. There was no signal short of reading the journal
timestamps and noticing the last line was two hours old.

## Two causes, two fixes

**`update.sh` ran `docker compose build` with nothing around it.**
`BUILD_TIMEOUT=40m` bounds each one now. A stuck build is killed, counted as a
failure so it lands on the backoff that already existed, and — the clause that
matters — **the services after it in the same run still get their turn.** A
wedged `ui` costs `site` and `docs` nothing.

**The unit is `Type=oneshot`, which defaults to `TimeoutStartSec=infinity`.**
That's why systemd was content to wait forever. Two hours as a backstop for a
hang the script's own timeout doesn't cover.

The log separates the two outcomes, because they have different causes — a build
that *fails* is usually the source, one that *hangs* is usually the box:

```
[…] [ui] BUILD TIMED OUT after 40m; running container untouched
[…] [ui] BUILD FAILED; running container untouched
```

## I was wrong about the ordering

I told you the ordering was the bug — site → docs → ui under one lock. It isn't:
they're already in that order, and in a normal run site and docs finish first.
What actually starved them is that a hang holds the lock forever, so *subsequent*
cycles never start. The fix is a timeout, not a reorder.

## Also: these files only existed on the Pi

`update.sh`, `compose.yml` and both units were untracked in `/home/sivert/gryt/`.
No history, no review, and no copy anywhere if the SD card died. They're in
`ops/deploy/rpi/` now with a README covering how the Pi is wired, what the script
does, how to adopt a change, and what not to touch. That's the half of GRYT-841
worth doing first.

## What I did to the box, and what I didn't

**Did:** killed the wedged run by PID (`bash update.sh` and its one
`docker compose build ui` child, both owned by `sivert`), so the backlog could
deploy. All seven containers stayed up and healthy throughout — the script leaves
running containers alone on failure by design. The timer is scheduled again.

**Didn't:** install any of this. `systemctl stop` needs a password I don't have,
and repointing a production deploy is a deliberate step, not a side effect of a
PR. The README has the two `scp` commands when you want them.