### PR TITLE
Add a hand-run Microsoft Store auth check (GRYT-960)

### DIFF
--- a/.github/workflows/store-auth-check.yml
+++ b/.github/workflows/store-auth-check.yml
@@ -1,0 +1,49 @@
+name: Store auth check
+
+# A hand-run check that the Microsoft Store publishing credentials work, and a
+# way to answer one question the docs are vague on: whether `msstore` needs a
+# sellerId at all, or authenticates from tenant + client + secret alone. It
+# reconfigures WITHOUT sellerId on purpose, then lists the account's apps. If
+# that succeeds, the release step (GRYT-960) does not need SELLER_ID; if it
+# fails asking for a seller, we know we have to find one. Reads secrets, prints
+# no secret — msstore info shows the stored config (tenant/seller/client), never
+# the client secret.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check Microsoft Store credentials
+    runs-on: windows-latest
+    steps:
+      - name: Set up the Microsoft Store CLI
+        uses: microsoft/microsoft-store-apppublisher@v1.1
+
+      - name: Reconfigure without a sellerId, then probe the account
+        shell: pwsh
+        env:
+          AZURE_AD_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
+          AZURE_AD_APPLICATION_CLIENT_ID: ${{ secrets.AZURE_AD_APPLICATION_CLIENT_ID }}
+          AZURE_AD_APPLICATION_SECRET: ${{ secrets.AZURE_AD_APPLICATION_SECRET }}
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          Write-Host "=== reconfigure (no --sellerId) ==="
+          msstore reconfigure `
+            --tenantId $env:AZURE_AD_TENANT_ID `
+            --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
+            --clientSecret $env:AZURE_AD_APPLICATION_SECRET
+          Write-Host "reconfigure exit code: $LASTEXITCODE"
+
+          Write-Host "=== msstore info (stored config; no secret) ==="
+          msstore info -v
+
+          Write-Host "=== msstore apps list ==="
+          msstore apps list -v
+
+          Write-Host "=== msstore apps get 9PKPT1C2M95Q (the Gryt listing) ==="
+          msstore apps get 9PKPT1C2M95Q -v


### PR DESCRIPTION
A `workflow_dispatch` job to verify the Store publishing credentials and settle one thing the docs are vague on: whether `msstore` needs a **sellerId** or authenticates from tenant + client + secret alone.

It reconfigures **without** `--sellerId`, then runs `msstore info` / `apps list` / `apps get 9PKPT1C2M95Q`:
- If `apps list` succeeds → SELLER_ID isn't needed, and I'll drop `--sellerId` from the release submit step (GRYT-960), so you never have to hunt for a Seller ID that this account doesn't surface.
- If it fails asking for a seller → we know it's required and go find it.

Reads the three secrets you just set; prints the stored config but never the client secret.

**Merge this**, then I'll dispatch it and read the logs. It also doubles as a standing "are the Store creds still good?" check for when the secret rotates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)