### PR TITLE
Store auth check: run non-interactively with a placeholder sellerId

### DIFF
--- a/.github/workflows/store-auth-check.yml
+++ b/.github/workflows/store-auth-check.yml
@@ -1,13 +1,12 @@
 name: Store auth check
 
 # A hand-run check that the Microsoft Store publishing credentials work, and a
-# way to answer one question the docs are vague on: whether `msstore` needs a
-# sellerId at all, or authenticates from tenant + client + secret alone. It
-# reconfigures WITHOUT sellerId on purpose, then lists the account's apps. If
-# that succeeds, the release step (GRYT-960) does not need SELLER_ID; if it
-# fails asking for a seller, we know we have to find one. Reads secrets, prints
-# no secret — msstore info shows the stored config (tenant/seller/client), never
-# the client secret.
+# way to learn what msstore does with the sellerId. Reconfigure refuses to run
+# non-interactively without one, so we hand it a placeholder and then look at
+# what `msstore info` stored and whether `apps list` / `apps get` actually work.
+# If the account's apps come back, the app-credential auth is what matters and
+# the seller value is not enforced; if they fail, the error tells us what it
+# wants. Prints stored config (tenant/seller/client), never the client secret.
 
 on:
   workflow_dispatch:
@@ -23,7 +22,7 @@ jobs:
       - name: Set up the Microsoft Store CLI
         uses: microsoft/microsoft-store-apppublisher@v1.1
 
-      - name: Reconfigure without a sellerId, then probe the account
+      - name: Reconfigure with a placeholder sellerId, then probe the account
         shell: pwsh
         env:
           AZURE_AD_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
@@ -32,18 +31,19 @@ jobs:
         run: |
           $ErrorActionPreference = "Continue"
 
-          Write-Host "=== reconfigure (no --sellerId) ==="
+          Write-Host "=== reconfigure (placeholder --sellerId 0) ==="
           msstore reconfigure `
             --tenantId $env:AZURE_AD_TENANT_ID `
+            --sellerId 0 `
             --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
             --clientSecret $env:AZURE_AD_APPLICATION_SECRET
           Write-Host "reconfigure exit code: $LASTEXITCODE"
 
-          Write-Host "=== msstore info (stored config; no secret) ==="
+          Write-Host "=== msstore info -v (stored config; no secret) ==="
           msstore info -v
 
-          Write-Host "=== msstore apps list ==="
+          Write-Host "=== msstore apps list -v ==="
           msstore apps list -v
 
-          Write-Host "=== msstore apps get 9PKPT1C2M95Q (the Gryt listing) ==="
+          Write-Host "=== msstore apps get 9PKPT1C2M95Q -v ==="
           msstore apps get 9PKPT1C2M95Q -v


### PR DESCRIPTION
reconfigure without a sellerId prompts interactively and dies in CI. This hands it a placeholder `--sellerId 0` and then inspects `msstore info` / `apps list` / `apps get` to learn whether the seller value is enforced or the app credential is what authorizes. Merge and I'll re-dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)