### PR TITLE
Finish the sentence the comment rule ends on, and give it a number

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -392,6 +392,10 @@ This reverses what this file used to say. It claimed the comments here were load
 and long on purpose, and that was true of some of them and became an excuse for the rest.
 The result is code you have to read around.
 
+The scale of it, measured on 2026-09-07: `packages/mobile` carries **8517 comment lines
+against 37520 lines of TypeScript**, so 23% of it. `src/connection/useConnection.ts` is
+39% comments and `src/shell/tabs.ts` is 70%.
+
 Delete on sight:
 
 - **Narration.** A comment that says what the next line says. `// increment the counter`.
@@ -413,4 +417,10 @@ Keep, and let it run past two lines if it has to:
 - **A decision that will otherwise be re-litigated.** Not the history of it — the
   conclusion, once, where the code is.
 
-The test: **would somebody make a mistake without it?** Not "is this interesting", not "did
+The test: **would somebody make a mistake without it?** Not "is this interesting", not
+"did I think hard about this". If nobody trips without it, it goes in the commit message,
+or nowhere.
+
+This applies to workflow YAML, shell scripts and config as much as to TypeScript. Those
+are where the longest blocks end up, because they are the files where an agent feels least
+sure and writes an essay to compensate.


### PR DESCRIPTION
You asked me to add a comment rule. It's already there, and it's good — I was working off a stale copy of `CLAUDE.md` in my worktree, which is why I spent the session writing exactly what it tells me not to.

Two things it was missing.

## It ends mid-sentence

`.claude/CLAUDE.md` line 416 is the last line in the file:

> The test: **would somebody make a mistake without it?** Not "is this interesting", not "did

and then it stops. The rule's own test has no ending.

## It makes the argument without the number

`packages/mobile` is **8517 comment lines against 37520 lines of TypeScript** — 23%. `src/connection/useConnection.ts` is 39%. `src/shell/tabs.ts` is 70%.

## And it doesn't say it covers YAML

That's where the longest blocks actually end up, because those are the files an agent is least sure about and writes an essay to compensate. `publish-snap.yml` went in yesterday ([#213](https://github.com/Gryt-chat/gryt/pull/213)) with a fifteen-line comment about what the step *used to* do — which the section already lists first under "delete on sight".

## Where I'm applying it

- `publish-aur.yml`, on the GRYT-972 branch, rewritten before it's opened
- the `site` copy branch, comments cut from three paragraphs each to one line
- `publish-snap.yml`'s history comments are already merged; worth a follow-up rather than a revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)