### PR TITLE
Push the AUR package on every release (GRYT-972)

### DIFF
--- a/.github/workflows/discord-ci-notify.yml
+++ b/.github/workflows/discord-ci-notify.yml
@@ -15,6 +15,7 @@ on:
       - Avatar parity
       - Permission labels
       - Publish snap to the Snap Store
+      - Publish to the AUR
       - Release Client
       - Release Server
       - Store auth check

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -64,8 +64,9 @@ jobs:
 
           # Pinned rather than ssh-keyscan'd: this pushes a package anyone on
           # Arch can install, so first-use trust is not good enough.
+          # SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4
           cat >> ~/.ssh/known_hosts <<'HOSTKEY'
-          aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV2nZ+MrNgFvHmVbtfsRQFtu
+          aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN
           HOSTKEY
 
           cat >> ~/.ssh/config <<'SSHCONFIG'

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,0 +1,188 @@
+name: Publish to the AUR
+
+# The CachyOS Package Installer, paru and yay all browse the AUR, so this is the
+# only Arch-side listing there is to keep current.
+#
+# This clones the AUR repo rather than using packages/client/aur, and rewrites
+# only pkgver, pkgrel and sha256sums. Structural PKGBUILD changes are made in
+# that submodule and pushed by hand; the next run starts from whatever the AUR
+# holds, so the two do not fight.
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish, e.g. v1.9.24'
+        required: true
+        type: string
+
+concurrency:
+  group: publish-aur
+  cancel-in-progress: true
+
+jobs:
+  publish-aur:
+    name: Publish to the AUR
+    runs-on: ubuntu-latest
+
+    # A `release` event does not know which dispatch produced it, so the channel
+    # is read off the tag. Betas do not go in `gryt-chat-bin`.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !contains(github.event.release.tag_name, '-beta')
+
+    # No continue-on-error: GRYT-971 is what a publisher that cannot fail costs.
+    timeout-minutes: 20
+
+    env:
+      OWNER: Gryt-chat
+      REPO: gryt
+      TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      AUR_PKG: gryt-chat-bin
+
+    steps:
+      - name: Check out the AUR package
+        id: checkout
+        shell: bash
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${AUR_SSH_PRIVATE_KEY:-}" ]]; then
+            echo "AUR_SSH_PRIVATE_KEY is not set, skipping the AUR."
+            echo "active=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+
+          # Pinned rather than ssh-keyscan'd: this pushes a package anyone on
+          # Arch can install, so first-use trust is not good enough.
+          cat >> ~/.ssh/known_hosts <<'HOSTKEY'
+          aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV2nZ+MrNgFvHmVbtfsRQFtu
+          HOSTKEY
+
+          cat >> ~/.ssh/config <<'SSHCONFIG'
+          Host aur.archlinux.org
+            User aur
+            IdentityFile ~/.ssh/aur
+            IdentitiesOnly yes
+          SSHCONFIG
+
+          git clone "ssh://aur@aur.archlinux.org/${AUR_PKG}.git" aur
+
+          echo "active=true" >> "$GITHUB_OUTPUT"
+
+      - name: Rewrite the PKGBUILD for this release
+        if: steps.checkout.outputs.active == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${TAG#v}"
+          DEB="Gryt-Chat-${VERSION}-linux-amd64.deb"
+
+          gh release download "$TAG" \
+            --repo "$OWNER/$REPO" \
+            --pattern "$DEB" \
+            --dir .
+
+          SUM="$(sha256sum "$DEB" | cut -d' ' -f1)"
+
+          cd aur
+
+          # Anchored, so none of these can match the same text inside the URL
+          # further down the file.
+          sed -i \
+            -e "s/^pkgver=.*/pkgver=${VERSION}/" \
+            -e "s/^pkgrel=.*/pkgrel=1/" \
+            -e "s/^sha256sums=.*/sha256sums=('${SUM}')/" \
+            PKGBUILD
+
+          echo "PKGBUILD now says:"
+          grep -E '^(pkgver|pkgrel|sha256sums)=' PKGBUILD
+
+          # A sed that matched nothing leaves the old version in place, which
+          # would publish a package pointing at the wrong release.
+          grep -qx "pkgver=${VERSION}" PKGBUILD
+          grep -qx "sha256sums=('${SUM}')" PKGBUILD
+
+      - name: Regenerate .SRCINFO
+        if: steps.checkout.outputs.active == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # makepkg --printsrcinfo is the only supported way to write this file,
+          # it needs Arch, and it refuses to run as root.
+          docker run --rm -v "$PWD/aur:/pkg" archlinux:base-devel bash -c '
+            useradd -m build
+            chown -R build /pkg
+            cd /pkg
+            su build -c "makepkg --printsrcinfo" > /pkg/.SRCINFO.new
+          '
+
+          mv aur/.SRCINFO.new aur/.SRCINFO
+
+          echo ".SRCINFO now says:"
+          grep -E '^\s+(pkgver|pkgrel|sha256sums|source)' aur/.SRCINFO || true
+
+      - name: Push it to the AUR
+        if: steps.checkout.outputs.active == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${TAG#v}"
+
+          cd aur
+
+          # By name, not -A: the AUR takes these two files and nothing else.
+          git add PKGBUILD .SRCINFO
+
+          if git diff --cached --quiet; then
+            echo "Already at ${VERSION}. Nothing to push."
+            exit 0
+          fi
+
+          git config user.name "Gryt Chat"
+          git config user.email "sivert@gryt.chat"
+
+          git commit -m "Update to ${VERSION}"
+          git push origin master
+
+      - name: Check the AUR is serving it
+        if: always() && steps.checkout.outputs.active == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${TAG#v}"
+
+          for attempt in $(seq 1 6); do
+            LIVE="$(
+              curl -sfS "https://aur.archlinux.org/rpc/v5/info?arg[]=${AUR_PKG}" \
+                | python3 -c "import json,sys; r=json.load(sys.stdin).get('results',[]); print(r[0]['Version'] if r else '')" 2>/dev/null || true
+            )"
+
+            # The RPC reports pkgver-pkgrel, and pkgrel is reset to 1 above.
+            if [[ "$LIVE" == "${VERSION}-1" ]]; then
+              echo "${AUR_PKG} is at $LIVE. Correct."
+              exit 0
+            fi
+
+            echo "Attempt $attempt: ${AUR_PKG} is \"${LIVE:-unknown}\", waiting for ${VERSION}-1."
+            sleep 20
+          done
+
+          echo "::error::The AUR is serving \"${LIVE:-unknown}\" for ${AUR_PKG}, not ${VERSION}-1."
+          echo "See https://aur.archlinux.org/packages/${AUR_PKG}"
+          exit 1

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -792,16 +792,6 @@ jobs:
           git submodule sync -- packages/client packages/server packages/sfu packages/image-worker
           git submodule update --init --force -- packages/client packages/server packages/sfu packages/image-worker
 
-      - name: Checkout AUR submodule
-        if: runner.os == 'Linux'
-        working-directory: packages/client
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          git submodule sync -- aur
-          git submodule update --init --force -- aur
-
       - name: Verify packaged client version
         shell: bash
         run: |


### PR DESCRIPTION
## Why this one matters for discovery

The CachyOS Package Installer browses the AUR, so there is no separate CachyOS listing to submit — this is it, and the same goes for paru, yay, and every other Arch desktop with a package browser.

`gryt-chat-bin` has been at **1.1.24-1 since 10 March**, 0 votes, while releases went to 1.9.24. Somebody discovering Gryt through the CachyOS installer today installs a build from six months ago. That's a worse first impression than not being listed.

## Most of the machinery was already here, doing nothing

- `packages/client/aur` is a submodule pointing at `ssh://aur@aur.archlinux.org/gryt-chat-bin.git`, holding `PKGBUILD` and `.SRCINFO`
- `release-client.yml` had a **Checkout AUR submodule** step that ran on every Linux release
- Nothing ever wrote to it or pushed it. The three commits in that repo are hand-made: *"Update to 1.1.24"*, *"Update to 1.1.20"*, *"Update to 1.1.17"*

## The PKGBUILD is still correct

Checked against the real v1.9.24 `.deb`, so this is not a rewrite:

| Assumption | Still true? |
|---|---|
| `Gryt-Chat-${pkgver}-linux-amd64.deb` | yes, exact match |
| payload member is `data.tar.xz` | yes |
| `/opt/Gryt Chat/gryt-chat` | yes |
| `/usr/share/applications/gryt-chat.desktop` | yes |

Only `pkgver`, `sha256sums` and `.SRCINFO` are stale. `sha256sums` was `SKIP` and is now the real checksum.

## Shape

`publish-aur.yml` alongside `publish-snap.yml`: release-triggered, stable only, dispatchable by tag, dormant until the credential exists. Downloads the `.deb`, rewrites three anchored fields, regenerates `.SRCINFO` with `makepkg --printsrcinfo` in an `archlinux:base-devel` container, pushes.

**The last step asks the AUR RPC what version is actually published and fails when it isn't this one.** That's GRYT-971's lesson applied up front: a publisher that reports on the act of pushing rather than the result can sit six months stale with every run green.

## Two things to look at

**The host key.** Pinned rather than `ssh-keyscan`'d, because this pushes a package anyone on Arch can install. I got it wrong on the first commit — wrote the tail from memory — and the second commit fixes it. Verified across three lookups as `SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4`. Worth checking against a source you trust before merging, since a wrong pin fails the push and a *malicious* one would not.

**The submodule stays, and CI doesn't use it.** The workflow clones the AUR repo directly and rewrites only `pkgver`/`pkgrel`/`sha256sums`. Structural PKGBUILD changes get made in `packages/client/aur` and pushed by hand; the next run starts from whatever the AUR holds, so the two don't fight. The alternative — pushing through the submodule — needs a gitlink commit back to `main` from CI, which is a lot more machinery for a file that changes twice a year.

## Needs you

An SSH key registered on your AUR account, private half as `AUR_SSH_PRIVATE_KEY`. Everything is dormant until then.

## Open question, not decided here

The PKGBUILD packages the **full** `.deb`, with the embedded server. Everywhere a person is offered the choice the default is `-slim`. Left as-is to avoid an unforced change, but it's worth deciding rather than inheriting.

## Also

Drops the dead checkout step from `release-client.yml`, and lists the new workflow in `discord-ci-notify.yml` — unlisted means it notifies nobody.

## Verified

`yaml-lint` clean; the `known_hosts` heredoc's YAML indentation confirmed tolerated by `ssh-keygen -F`; all three `sed` anchors confirmed to match the current PKGBUILD, with `grep -qx` guards so a non-matching `sed` fails loudly instead of publishing the wrong version.

Untested until the credential exists: the container `makepkg` step and the push itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)