### PR TITLE
Fix the AUR PKGBUILD, and put it where it gets reviewed (GRYT-975)

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -3,10 +3,9 @@ name: Publish to the AUR
 # The CachyOS Package Installer, paru and yay all browse the AUR, so this is the
 # only Arch-side listing there is to keep current.
 #
-# This clones the AUR repo rather than using packages/client/aur, and rewrites
-# only pkgver, pkgrel and sha256sums. Structural PKGBUILD changes are made in
-# that submodule and pushed by hand; the next run starts from whatever the AUR
-# holds, so the two do not fight.
+# packaging/aur/PKGBUILD is the source of truth. It is copied over whatever the
+# AUR holds, so a packaging change is a reviewed pull request rather than a push
+# nobody sees. GRYT-975 is what the other way round cost.
 
 on:
   release:
@@ -97,6 +96,26 @@ jobs:
             --dir .
 
           SUM="$(sha256sum "$DEB" | cut -d' ' -f1)"
+
+          # Read at the tag, so a re-run for an older release packages that
+          # release's PKGBUILD rather than whatever main says today. Tags cut
+          # before this file existed fall back to main; without that the first
+          # release after it landed could not publish at all.
+          at() {
+            gh api "repos/$OWNER/$REPO/contents/packaging/aur/PKGBUILD?ref=$1" \
+              --jq '.content' 2>/dev/null | base64 -d
+          }
+
+          if at "$TAG" > pkgbuild.candidate && [[ -s pkgbuild.candidate ]]; then
+            echo "Using packaging/aur/PKGBUILD from $TAG."
+          elif at main > pkgbuild.candidate && [[ -s pkgbuild.candidate ]]; then
+            echo "$TAG predates packaging/aur/PKGBUILD. Using main's."
+          else
+            echo "::error::No packaging/aur/PKGBUILD at $TAG or on main."
+            exit 1
+          fi
+
+          cp pkgbuild.candidate aur/PKGBUILD
 
           cd aur
 

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Gryt Chat <sivert@gryt.chat>
+#
+# publish-aur.yml copies this file into the AUR repo on every release and
+# rewrites pkgver, pkgrel and sha256sums, so those three are placeholders.
+pkgname=gryt-chat-bin
+pkgver=1.1.24
+pkgrel=1
+pkgdesc='Gryt Chat — real-time voice chat desktop client'
+arch=('x86_64')
+url='https://gryt.chat'
+license=('AGPL-3.0-or-later')
+depends=('alsa-lib' 'gtk3' 'libnotify' 'libxss' 'libxtst' 'nss' 'xdg-utils')
+optdepends=(
+  'libappindicator-gtk3: tray icon support'
+  'avahi: LAN server discovery via mDNS'
+)
+provides=('gryt-chat')
+conflicts=('gryt-chat')
+options=('!strip' '!debug')
+source=("https://github.com/Gryt-chat/gryt/releases/download/v${pkgver}/Gryt-Chat-${pkgver}-linux-amd64.deb")
+sha256sums=('SKIP')
+
+package() {
+  bsdtar -xf data.tar.xz -C "${pkgdir}/"
+
+  find "${pkgdir}" -type d -exec chmod 755 {} +
+
+  # The binary lives in a directory with a space in it, so /usr/bin gets a link.
+  install -dm755 "${pkgdir}/usr/bin"
+  ln -sf '/opt/Gryt Chat/gryt-chat' "${pkgdir}/usr/bin/gryt-chat"
+}


### PR DESCRIPTION
## The package does not build

Built against the real v1.9.24 `.deb` on an Arch box:

```
install: '.../usr/share/applications/gryt-chat.desktop' and
'.../usr/share/applications/gryt-chat.desktop' are the same file
==> ERROR: A failure occurred in package().
```

`package()` installed a file onto itself. `bsdtar` puts the desktop file in `$pkgdir` two lines above, so the install was a no-op *and* an error. It has been there since the package was written.

Four lines gone and it builds:

```
built: gryt-chat-bin-1.9.24-1-x86_64.pkg.tar.zst
pkgname = gryt-chat-bin
pkgver = 1.9.24-1
license = AGPL-3.0-or-later
opt/Gryt Chat/gryt-chat
usr/bin/gryt-chat
usr/share/applications/gryt-chat.desktop
```

## Why it stayed broken for six months

The PKGBUILD lived only in a submodule whose remote is the AUR itself. Changing it meant committing inside the submodule and pushing straight to `aur.archlinux.org` — no PR, no review, no CI. It was the one thing shipped without anyone reading it.

And [#215](https://github.com/Gryt-chat/gryt/pull/215) made that worse, not better: it treated whatever is on the AUR as the source of truth and rewrites only `pkgver`/`pkgrel`/`sha256sums`. Its first run would have published the *correct version of a package that still fails to build*, to everyone using paru, yay or the CachyOS installer.

I said in that PR that the PKGBUILD was still correct. It wasn't — I'd checked the asset name, the `data.tar.xz` member and both install paths, all of which pass, and concluded from that it built.

## What changes

`packaging/aur/PKGBUILD` is the source of truth. The workflow copies it over the AUR's copy before rewriting the version fields, so a packaging change is an ordinary reviewed PR.

**Read at the release tag, not main**, so re-running an old tag packages that release's PKGBUILD. Tags cut before this file existed fall back to `main` — without that the first release after this lands couldn't publish at all. Both branches tested against the real API.

`pkgver`, `pkgrel` and `sha256sums` stay placeholders in the committed file; the workflow rewrites all three and generates `.SRCINFO`, so each fact has one home.

## Verified

On a real Arch machine, with the exact file in this PR: `makepkg --printsrcinfo` generates cleanly, `makepkg` builds, and the resulting package carries the right metadata and all three key paths. Not verified: the push itself, which still needs `AUR_SSH_PRIVATE_KEY`.

Pairs with [Gryt-chat/client#451](https://github.com/Gryt-chat/client/pull/451), which drops the submodule. Either merge order is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)