### PR TITLE
Stop the .SRCINFO container chowning the runner's files (GRYT-980)

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -143,14 +143,23 @@ jobs:
 
           # makepkg --printsrcinfo is the only supported way to write this file,
           # it needs Arch, and it refuses to run as root.
-          docker run --rm -v "$PWD/aur:/pkg" archlinux:base-devel bash -c '
-            useradd -m build
-            chown -R build /pkg
-            cd /pkg
-            su build -c "makepkg --printsrcinfo" > /pkg/.SRCINFO.new
-          '
+          #
+          # Mounted read-only and copied inside, because `chown -R build` on a
+          # writable bind mount changes the owner of the host's files too, and
+          # the runner is then locked out of the directory it has to commit in.
+          docker run --rm -v "$PWD/aur:/pkg:ro" archlinux:base-devel bash -c '
+            set -e
+            useradd -m build >&2
+            cp -r /pkg /tmp/pkg >&2
+            chown -R build /tmp/pkg >&2
+            cd /tmp/pkg
+            su build -c "makepkg --printsrcinfo"
+          ' > srcinfo.new
 
-          mv aur/.SRCINFO.new aur/.SRCINFO
+          # An empty file here would commit a .SRCINFO that tells the AUR nothing.
+          [[ -s srcinfo.new ]] && grep -q '^pkgbase = ' srcinfo.new
+
+          mv srcinfo.new aur/.SRCINFO
 
           echo ".SRCINFO now says:"
           grep -E '^\s+(pkgver|pkgrel|sha256sums|source)' aur/.SRCINFO || true


### PR DESCRIPTION
First real run of `publish-aur.yml` ([run 34146921951](https://github.com/Gryt-chat/gryt/actions/runs/34146921951)), dispatched for v1.9.24 once the secret existed.

**The SSH key works.** Clone and PKGBUILD rewrite both succeeded. Then:

```
mv: cannot move 'aur/.SRCINFO.new' to 'aur/.SRCINFO': Permission denied
```

The step bind-mounted `aur/` writable and ran `chown -R build /pkg` inside the container. A bind mount isn't namespaced for ownership, so that chown changed the owner of the *runner's* files, and the runner could no longer write in the directory it has to commit in.

## Fix

Mount read-only, copy inside the container, print to stdout, redirect on the host. The host tree is never chowned, and `makepkg` still gets a tree owned by the unprivileged user it insists on.

Plus a guard that the output is non-empty and starts with `pkgbase = ` — a container failing quietly would otherwise commit an empty `.SRCINFO`.

## It failed safe, and the verification earned its place

**Push it to the AUR** was skipped, so the AUR is untouched. Then the check added in GRYT-971 did exactly what it was written for, on its first outing:

```
Attempt 1: gryt-chat-bin is "1.1.24-1", waiting for 1.9.24-1.
...
##[error]The AUR is serving "1.1.24-1" for gryt-chat-bin, not 1.9.24-1.
```

Under the old `continue-on-error` pattern this run would have gone green.

## Verified

Locally with Docker against the real `packaging/aur/PKGBUILD` from main: `.SRCINFO` generates correctly, host ownership is unchanged (`uid 501` before and after), and the `mv` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)