### PR TITLE
Wait long enough for the AUR RPC to catch up (GRYT-981)

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -188,6 +188,11 @@ jobs:
           git commit -m "Update to ${VERSION}"
           git push origin master
 
+      # The RPC is what paru, yay and the CachyOS installer actually read, so it
+      # is the thing worth holding to — but it is cached behind the database it
+      # reports on. Measured on the first successful publish: the package page
+      # showed 1.9.24-1 immediately and the RPC kept saying 1.1.24-1 for about
+      # five minutes. Six 20-second attempts called that a failed publish.
       - name: Check the AUR is serving it
         if: always() && steps.checkout.outputs.active == 'true'
         shell: bash
@@ -196,7 +201,7 @@ jobs:
 
           VERSION="${TAG#v}"
 
-          for attempt in $(seq 1 6); do
+          for attempt in $(seq 1 15); do
             LIVE="$(
               curl -sfS "https://aur.archlinux.org/rpc/v5/info?arg[]=${AUR_PKG}" \
                 | python3 -c "import json,sys; r=json.load(sys.stdin).get('results',[]); print(r[0]['Version'] if r else '')" 2>/dev/null || true
@@ -209,9 +214,11 @@ jobs:
             fi
 
             echo "Attempt $attempt: ${AUR_PKG} is \"${LIVE:-unknown}\", waiting for ${VERSION}-1."
-            sleep 20
+            sleep 30
           done
 
           echo "::error::The AUR is serving \"${LIVE:-unknown}\" for ${AUR_PKG}, not ${VERSION}-1."
+          echo "The push may still have worked and the RPC be lagging further than"
+          echo "usual — the package page is the database, the RPC is a cache of it."
           echo "See https://aur.archlinux.org/packages/${AUR_PKG}"
           exit 1


### PR DESCRIPTION
**Gryt is on the AUR at 1.9.24-1.** The push landed (`5cb6b83..2c4348e master -> master`), the package page read `Package Details: gryt-chat-bin 1.9.24-1` straight away, and the git repo holds the right PKGBUILD, `.SRCINFO` and checksum. CachyOS, paru and yay users get the current version.

The run went red anyway, and that was my verification being wrong rather than the publish failing.

## The RPC is a cache

The step polls `aur.archlinux.org/rpc/v5/info` six times at 20 seconds. Measured straight after the push, the RPC kept answering the old version for about **five minutes** while the database was already correct:

```
19:27:52  RPC: 1.1.24-1
19:28:22  RPC: 1.1.24-1
19:28:53  RPC: 1.9.24-1
```

Two minutes was never going to be enough.

## Fix

15 attempts at 30 seconds — 7.5 minutes against a five-minute lag, inside the job's 20-minute timeout.

Still the RPC rather than the package page: the RPC is what paru, yay and the CachyOS Package Installer actually query, so it's the thing worth holding the publish to. The page would pass sooner and prove less, and scraping HTML for it would be worse than waiting.

The failure message now says the push may have worked and the RPC be lagging, and points at the page as the database rather than the cache — so the next red doesn't send someone looking for a broken push that isn't there.

## Third fix to this workflow, and each failure caught something

A PKGBUILD that never built, a container that chowned the runner's files, and now a stale read. None of them published anything wrong. The first two would have gone green under the `continue-on-error` pattern this replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)