### PR TITLE
A page for posting status announcements (GRYT-983)

### DIFF
--- a/ops/internal/status/README.md
+++ b/ops/internal/status/README.md
@@ -46,10 +46,63 @@ scp -r ops/internal/status/* vps:/opt/gryt-status/
 ssh vps 'cd /opt/gryt-status && docker compose up -d'
 ```
 
-Gatus reads the config at start, so a change needs a restart:
+Gatus reloads the config on its own when a file in the directory changes, so a
+config edit needs nothing else. It only needs a restart when the compose file or
+the image changes:
 
 ```bash
-ssh vps 'cd /opt/gryt-status && docker compose restart'
+ssh vps 'cd /opt/gryt-status && docker compose up -d'
+```
+
+This file used to say a change needed a restart. It doesn't, and the console
+below depends on that being true.
+
+## Announcing an outage
+
+The console at `status.gryt.chat/console` posts announcements — Gatus renders
+them at the top of the page, and the Gryt client shows the same words as a
+banner to everybody signed in. One place to post, so the page and the banner
+cannot disagree.
+
+It writes `config/announcements.yaml`, which Gatus merges with `config.yaml`
+because `GATUS_CONFIG_PATH` is a directory and arrays are appended. Nothing
+touches `config.yaml`, and nothing restarts.
+
+**Resolve** archives what's up and posts an `operational` notice. That closes
+the incident on the page and stops the client banner in one write, because the
+client skips the all-clear.
+
+### Setting the password
+
+Generate a strong one in Bitwarden, then hash it. Password only, and
+deliberately so: the obvious alternative is Keycloak, which runs on the machine
+most likely to be down when somebody needs to post here.
+
+```bash
+printf '%s' 'the-password-from-bitwarden' |   node ops/internal/status/console/hash-password.mjs
+```
+
+Put the output in `/opt/gryt-status/.env` on the VPS:
+
+```
+CONSOLE_PASSWORD_HASH=scrypt$...$...
+```
+
+The hash goes on the VPS, the password goes in Bitwarden, and neither is in this
+repository. Changing the password invalidates every open session, because the
+session key is derived from the hash.
+
+### Routing the tunnel to it
+
+The console listens on `127.0.0.1:3002`. The tunnel on this VPS is token-based,
+so the route is added in the Cloudflare dashboard rather than in a file here:
+a public hostname for `status.gryt.chat` with path `/console`, pointing at
+`http://localhost:3002`.
+
+Until that route exists the console is reachable only over ssh:
+
+```bash
+ssh -L 3002:127.0.0.1:3002 vps
 ```
 
 ## Validate before you deploy
@@ -69,6 +122,15 @@ body condition shows up as `success=false` before it reaches the live page.
 
 Don't grep that output for the word `errors`. Every passing line ends in
 `errors=0`.
+
+Use `--rm` and a `timeout`, as above. A validation run on 2026-09-03 was still
+running four days later as `infallible_zhukovsky`, holding
+`config/config.yaml.new` and serving nothing, because it was started without
+either. Check `docker ps` on the VPS after validating.
+
+The console does not need this. It writes JSON, which is valid YAML, so the
+message somebody typed cannot produce a malformed file the way hand-built YAML
+quoting can.
 
 ## Reading it
 

--- a/ops/internal/status/console/Dockerfile
+++ b/ops/internal/status/console/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-alpine
+
+# No dependencies on purpose. Everything here is a Node built-in, so there is no
+# lockfile to keep current and nothing to audit on a box that only runs this.
+WORKDIR /app
+COPY server.mjs hash-password.mjs ./
+
+USER node
+EXPOSE 3002
+
+HEALTHCHECK --interval=60s --timeout=5s --start-period=5s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3002/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["node", "server.mjs"]

--- a/ops/internal/status/console/hash-password.mjs
+++ b/ops/internal/status/console/hash-password.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Turns a password into the value for CONSOLE_PASSWORD_HASH.
+ *
+ * Reads from stdin rather than argv so the password does not land in shell
+ * history or in the process list on a shared box.
+ *
+ *   printf '%s' 'the-password' | node hash-password.mjs
+ */
+
+import { randomBytes, scryptSync } from "node:crypto";
+
+let password = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (c) => (password += c));
+process.stdin.on("end", () => {
+  password = password.replace(/\n$/, "");
+
+  if (password.length < 16) {
+    console.error(
+      `Refusing: ${password.length} characters. This is the only thing between\n` +
+        "the internet and Gryt's status page. Use a generated one from Bitwarden.",
+    );
+    process.exit(1);
+  }
+
+  const salt = randomBytes(16);
+  const hash = scryptSync(password, salt, 32);
+
+  console.log(`scrypt$${salt.toString("base64")}$${hash.toString("base64")}`);
+});

--- a/ops/internal/status/console/server.mjs
+++ b/ops/internal/status/console/server.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Posts announcements to the status page (GRYT-983).
+ *
+ * Writes announcements.yaml into the directory Gatus already reads. Gatus
+ * merges every *.yaml in that directory and appends arrays, so this file adds
+ * to config.yaml without touching it, and Gatus reloads on its own.
+ *
+ * Runs on the VPS next to Gatus, not at home with the site: everything the
+ * status page describes is served from home through one Cloudflare tunnel, so a
+ * console there is unreachable at the moment it is needed.
+ *
+ * Password only, deliberately. The obvious alternative is Keycloak, which runs
+ * on the machine most likely to be down when somebody needs to post here.
+ */
+
+import { createHmac, randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
+import { createServer } from "node:http";
+import { readFileSync, renameSync, writeFileSync, existsSync, copyFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CONFIG_DIR = process.env.CONSOLE_CONFIG_DIR || "/config";
+const FILE = join(CONFIG_DIR, "announcements.yaml");
+const PORT = Number(process.env.PORT || 3002);
+const PASSWORD_HASH = process.env.CONSOLE_PASSWORD_HASH || "";
+
+const SESSION_HOURS = 12;
+const MAX_MESSAGE = 240;
+const TYPES = ["outage", "warning", "information", "operational"];
+
+/* ── Password ─────────────────────────────────────────────────────────── */
+
+/** `scrypt$<salt base64>$<hash base64>`, as printed by `--hash`. */
+function verifyPassword(password) {
+  const parts = PASSWORD_HASH.split("$");
+  if (parts.length !== 3 || parts[0] !== "scrypt") return false;
+
+  const salt = Buffer.from(parts[1], "base64");
+  const expected = Buffer.from(parts[2], "base64");
+  const actual = scryptSync(password, salt, expected.length);
+
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
+
+/* Derived from the password hash so there is one secret to keep, and rotating
+   the password invalidates every session for free. */
+const SESSION_KEY = createHmac("sha256", PASSWORD_HASH).update("session").digest();
+
+function issueSession() {
+  const expires = Date.now() + SESSION_HOURS * 3600_000;
+  const sig = createHmac("sha256", SESSION_KEY).update(String(expires)).digest("base64url");
+  return `${expires}.${sig}`;
+}
+
+function validSession(cookie) {
+  const [expires, sig] = String(cookie || "").split(".");
+  if (!expires || !sig || Number(expires) < Date.now()) return false;
+
+  const want = createHmac("sha256", SESSION_KEY).update(expires).digest("base64url");
+  const a = Buffer.from(sig);
+  const b = Buffer.from(want);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+/* One machine posts here. A fixed lockout after a handful of tries costs
+   nothing and takes offline guessing off the table. */
+const attempts = new Map();
+function throttled(ip) {
+  const a = attempts.get(ip);
+  return a && a.count >= 5 && Date.now() - a.at < 15 * 60_000;
+}
+function recordFailure(ip) {
+  const a = attempts.get(ip) ?? { count: 0, at: 0 };
+  attempts.set(ip, { count: a.count + 1, at: Date.now() });
+}
+
+/* ── The file ─────────────────────────────────────────────────────────── */
+
+function readAnnouncements() {
+  if (!existsSync(FILE)) return [];
+  try {
+    return JSON.parse(readFileSync(FILE, "utf8")).announcements ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Written as JSON, which is valid YAML.
+ *
+ * Building YAML by hand would mean quoting and escaping a message somebody
+ * typed, and getting that wrong writes a config that stops Gatus. JSON.stringify
+ * already handles it.
+ */
+function writeAnnouncements(list) {
+  const body = JSON.stringify({ announcements: list }, null, 2) + "\n";
+
+  /* Kept so a bad write can be undone by hand without reconstructing it. */
+  if (existsSync(FILE)) copyFileSync(FILE, `${FILE}.bak`);
+
+  /* Written then renamed, because Gatus watches this directory and would
+     otherwise reload a half-written file. */
+  const tmp = `${FILE}.tmp`;
+  writeFileSync(tmp, body, "utf8");
+  renameSync(tmp, FILE);
+}
+
+/* ── HTTP ─────────────────────────────────────────────────────────────── */
+
+function page(session, error) {
+  const live = session ? readAnnouncements().filter((a) => !a.archived) : [];
+  const current = live.length
+    ? `<p class="live"><strong>Live:</strong> ${escapeHtml(live[live.length - 1].message)}</p>`
+    : `<p class="quiet">Nothing announced. The banner is silent.</p>`;
+
+  const form = session
+    ? `${current}
+      <form method="post" action="announce">
+        <textarea name="message" maxlength="${MAX_MESSAGE}" rows="3" required
+          placeholder="An issue has appeared and we are investigating it."></textarea>
+        <div class="row">
+          <select name="type">
+            <option value="outage">Outage</option>
+            <option value="warning">Warning</option>
+            <option value="information">Information</option>
+          </select>
+          <button type="submit">Post</button>
+        </div>
+      </form>
+      <form method="post" action="resolve">
+        <button type="submit" class="secondary">Resolve — post the all-clear and stop the banner</button>
+      </form>`
+    : `<form method="post" action="login">
+        <input type="password" name="password" placeholder="Password" autofocus required>
+        <button type="submit">Sign in</button>
+      </form>`;
+
+  return `<!doctype html><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Gryt status console</title>
+<style>
+  :root { color-scheme: dark }
+  body { font: 15px/1.5 system-ui, sans-serif; background:#0f1115; color:#e6e8ec;
+         margin:0; display:grid; place-items:center; min-height:100vh; padding:20px }
+  main { width:100%; max-width:520px }
+  h1 { font-size:18px; margin:0 0 4px }
+  .sub { color:#8b90a0; margin:0 0 20px; font-size:13px }
+  form { display:grid; gap:10px; margin:0 0 14px }
+  textarea, input, select, button { font:inherit; padding:10px 12px; border-radius:8px;
+    border:1px solid #2a2f3a; background:#171a21; color:inherit; width:100%; box-sizing:border-box }
+  .row { display:flex; gap:10px }
+  .row select { flex:1 } .row button { flex:0 0 auto }
+  button { background:#4b5bdc; border-color:#4b5bdc; cursor:pointer; font-weight:600 }
+  .secondary { background:#171a21; border-color:#2a2f3a; font-weight:500 }
+  .error { color:#ff8080; font-size:13px; margin:0 0 12px }
+  .live { background:#2a1d1d; border:1px solid #5a2c2c; padding:10px 12px; border-radius:8px }
+  .quiet { color:#8b90a0; font-size:13px }
+</style>
+<main>
+  <h1>Status console</h1>
+  <p class="sub">Posts to status.gryt.chat and to the banner in every signed-in client.</p>
+  ${error ? `<p class="error">${escapeHtml(error)}</p>` : ""}
+  ${form}
+</main>`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+  );
+}
+
+function body(req) {
+  return new Promise((resolve) => {
+    let data = "";
+    req.on("data", (c) => {
+      data += c;
+      if (data.length > 8192) req.destroy();
+    });
+    req.on("end", () => resolve(new URLSearchParams(data)));
+  });
+}
+
+function send(res, status, html, cookie) {
+  const headers = {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "no-store",
+    "x-content-type-options": "nosniff",
+    "referrer-policy": "no-referrer",
+  };
+  if (cookie) headers["set-cookie"] = cookie;
+  res.writeHead(status, headers);
+  res.end(html);
+}
+
+const cookieFrom = (req) =>
+  Object.fromEntries(
+    (req.headers.cookie || "").split(";").map((c) => c.trim().split("=").map(decodeURIComponent)),
+  ).session;
+
+createServer(async (req, res) => {
+  /* The tunnel may route a path prefix to this service, so strip it. */
+  const path = new URL(req.url, "http://x").pathname.replace(/^\/console/, "") || "/";
+  const ip = req.headers["cf-connecting-ip"] || req.socket.remoteAddress || "?";
+  const session = validSession(cookieFrom(req));
+
+  if (req.method === "GET" && path === "/health") {
+    res.writeHead(200, { "content-type": "text/plain" });
+    return res.end("ok");
+  }
+
+  if (req.method === "GET") return send(res, 200, page(session));
+
+  if (req.method !== "POST") return send(res, 405, page(session, "Not allowed"));
+
+  const form = await body(req);
+
+  if (path === "/login") {
+    if (throttled(ip)) return send(res, 429, page(false, "Too many attempts. Wait 15 minutes."));
+    if (!PASSWORD_HASH) return send(res, 500, page(false, "CONSOLE_PASSWORD_HASH is not set."));
+
+    if (!verifyPassword(form.get("password") || "")) {
+      recordFailure(ip);
+      return send(res, 401, page(false, "Wrong password."));
+    }
+
+    attempts.delete(ip);
+    const cookie = `session=${issueSession()}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=${SESSION_HOURS * 3600}`;
+    return send(res, 200, page(true), cookie);
+  }
+
+  if (!session) return send(res, 401, page(false, "Sign in first."));
+
+  if (path === "/announce") {
+    const message = (form.get("message") || "").trim().slice(0, MAX_MESSAGE);
+    if (!message) return send(res, 400, page(true, "Say what is wrong."));
+
+    const type = TYPES.includes(form.get("type")) ? form.get("type") : "outage";
+
+    /* Everything already up is archived rather than dropped, so the status
+       page keeps the history of an incident that got updated. */
+    const list = readAnnouncements().map((a) => ({ ...a, archived: true }));
+    list.push({ timestamp: new Date().toISOString(), type, message });
+    writeAnnouncements(list);
+
+    return send(res, 200, page(true));
+  }
+
+  if (path === "/resolve") {
+    /* `operational` is Gatus's all-clear, and the client skips it — so this
+       closes the incident on the page and stops the banner in one write. */
+    const list = readAnnouncements().map((a) => ({ ...a, archived: true }));
+    list.push({
+      timestamp: new Date().toISOString(),
+      type: "operational",
+      message: "Resolved. Everything is back to normal.",
+    });
+    writeAnnouncements(list);
+
+    return send(res, 200, page(true));
+  }
+
+  return send(res, 404, page(session, "No such thing."));
+}).listen(PORT, "0.0.0.0", () => {
+  console.log(`status console on :${PORT}, writing ${FILE}`);
+  if (!PASSWORD_HASH) console.warn("CONSOLE_PASSWORD_HASH is not set — nobody can sign in.");
+});

--- a/ops/internal/status/docker-compose.yml
+++ b/ops/internal/status/docker-compose.yml
@@ -19,5 +19,25 @@ services:
       timeout: 5s
       retries: 3
 
+  # Posts announcements by writing announcements.yaml into the directory Gatus
+  # already reads. Gatus merges every *.yaml there and reloads on its own, so
+  # this never touches config.yaml and never restarts anything.
+  #
+  # It mounts the same directory read-write while Gatus keeps it read-only.
+  console:
+    build: ./console
+    container_name: gryt-status-console
+    restart: unless-stopped
+    # Loopback only, same as Gatus. The Cloudflare tunnel reaches it from this
+    # host and nothing else should — this is the one door to the status page.
+    ports:
+      - "127.0.0.1:3002:3002"
+    volumes:
+      - ./config:/config
+    environment:
+      CONSOLE_PASSWORD_HASH: ${CONSOLE_PASSWORD_HASH:?set it in .env, see README}
+    depends_on:
+      - gatus
+
 volumes:
   gatus-data:


### PR DESCRIPTION
Somewhere to post *"an issue has appeared and we are investigating it"* without ssh. At `status.gryt.chat/console`.

It came out small, because Gatus already does most of it. Posting puts the same words on the status page **and** in the banner of every signed-in client ([client#453](https://github.com/Gryt-chat/client/pull/453)) — one place to write, no way for the two to disagree.

## How it writes

Gatus merges every `*.yaml` in its config directory and appends arrays, so this writes `announcements.yaml` beside `config.yaml` and never touches it. Gatus reloads on its own — the README claimed a restart was needed, which was wrong, and this depends on it being wrong. Corrected here.

**The file is JSON, which is valid YAML.** Building YAML by hand would mean quoting and escaping a message somebody typed, and getting that wrong writes a config that stops Gatus and takes the status page down mid-outage — the exact failure your README warns about. `JSON.stringify` already handles it. Written to a temp file and renamed so a reload can't catch it half-written, with the previous copy kept as `.bak`.

**Resolve** archives what's up and posts an `operational` notice, which closes the incident on the page and stops the client banner in one write, because the client skips the all-clear.

## Auth

Password, scrypt-hashed, in an env var on the VPS. You keep the password in Bitwarden:

```bash
printf '%s' 'the-password-from-bitwarden' | node ops/internal/status/console/hash-password.mjs
```

The session key is derived from the hash, so there's one secret to keep and changing the password ends every open session. Five wrong attempts locks an address out for fifteen minutes. It refuses to hash anything under 16 characters.

## Where it runs, and why not on the site

On the VPS next to Gatus. The site is on the Pi, at home, behind the same Cloudflare tunnel as everything the status page describes — a console there is unreachable at the moment it's needed. Same reason the status page isn't at home, already written down in its README.

No dependencies. Everything is a Node built-in.

## Verified end to end against a real Gatus v5.36.0

Not just unit-tested — run against the actual image:

```
$ curl localhost/api/v1/config
{"announcements":[{"timestamp":"2026-09-07T18:06:16.712Z","type":"outage",
  "message":"An issue has appeared and we are investigating it."}],...}
```

Posting writes a file Gatus merges and serves; the client's parser raises a banner from it; **Resolve** makes the parser return `null` again; the container stays healthy throughout. Also checked: unauthenticated `POST /announce` is 401, wrong password is 401, short passwords are refused, and the image builds.

## Two things for you

**The tunnel route.** The console listens on `127.0.0.1:3002`. This VPS's tunnel is token-based, so the route is added in the Cloudflare dashboard, not in a file here — a public hostname for `status.gryt.chat`, path `/console`, to `http://localhost:3002`. Until then it's reachable over `ssh -L 3002:127.0.0.1:3002 vps`.

**A stray container.** `infallible_zhukovsky` has been running on the VPS since 2026-09-03 — a Gatus config-validation run started without `--rm`, holding `config/config.yaml.new` and serving nothing (no published port). Harmless but it's been up four days. I left it alone; it's your box. The README now says to check `docker ps` after validating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)