### PR TITLE
Stop Docker Compose eating the password hash (GRYT-988)

### DIFF
--- a/ops/internal/status/README.md
+++ b/ops/internal/status/README.md
@@ -85,7 +85,16 @@ printf '%s' 'the-password-from-bitwarden' |   node ops/internal/status/console/h
 Put the output in `/opt/gryt-status/.env` on the VPS:
 
 ```
-CONSOLE_PASSWORD_HASH=scrypt$...$...
+CONSOLE_PASSWORD_HASH=scrypt:...:...
+```
+
+The separator is a colon because Docker Compose interpolates `$` in a `.env`
+value. The first version of this used `$`, and the salt and hash arrived at the
+container substituted away as undefined variables — every password wrong, with
+nothing saying why. Compose does warn, on `docker compose config`:
+
+```
+warning: The "jPZaAtOEGAA3u7hRr92SrQ" variable is not set. Defaulting to a blank string.
 ```
 
 The hash goes on the VPS, the password goes in Bitwarden, and neither is in this

--- a/ops/internal/status/console/hash-password.mjs
+++ b/ops/internal/status/console/hash-password.mjs
@@ -27,5 +27,8 @@ process.stdin.on("end", () => {
   const salt = randomBytes(16);
   const hash = scryptSync(password, salt, 32);
 
-  console.log(`scrypt$${salt.toString("base64")}$${hash.toString("base64")}`);
+  /* Colon-delimited, not $. Docker Compose interpolates $ in a .env value, so
+     a $-delimited hash arrives with the salt and hash substituted away as
+     undefined variables. Base64 never contains a colon. */
+  console.log(`scrypt:${salt.toString("base64")}:${hash.toString("base64")}`);
 });

--- a/ops/internal/status/console/server.mjs
+++ b/ops/internal/status/console/server.mjs
@@ -30,10 +30,25 @@ const TYPES = ["outage", "warning", "information", "operational"];
 
 /* ── Password ─────────────────────────────────────────────────────────── */
 
-/** `scrypt$<salt base64>$<hash base64>`, as printed by `--hash`. */
+/**
+ * `scrypt:<salt base64>:<hash base64>`, as printed by hash-password.mjs.
+ *
+ * `$` is still accepted because the first version of this used it, but never
+ * emitted: Docker Compose interpolates `$` in a .env value, so a $-delimited
+ * hash reaches the container with the salt and hash substituted away as
+ * undefined variables, and every password is wrong for a reason nothing says
+ * out loud.
+ */
+function parseHash() {
+  const parts = PASSWORD_HASH.includes(":")
+    ? PASSWORD_HASH.split(":")
+    : PASSWORD_HASH.split("$");
+  return parts.length === 3 && parts[0] === "scrypt" ? parts : null;
+}
+
 function verifyPassword(password) {
-  const parts = PASSWORD_HASH.split("$");
-  if (parts.length !== 3 || parts[0] !== "scrypt") return false;
+  const parts = parseHash();
+  if (!parts) return false;
 
   const salt = Buffer.from(parts[1], "base64");
   const expected = Buffer.from(parts[2], "base64");
@@ -222,6 +237,16 @@ createServer(async (req, res) => {
     if (throttled(ip)) return send(res, 429, page(false, "Too many attempts. Wait 15 minutes."));
     if (!PASSWORD_HASH) return send(res, 500, page(false, "CONSOLE_PASSWORD_HASH is not set."));
 
+    /* Says the hash is broken rather than the password is wrong. The two look
+       identical from here and only one of them is the person's fault. */
+    if (!parseHash()) {
+      return send(
+        res,
+        500,
+        page(false, `CONSOLE_PASSWORD_HASH is malformed (${PASSWORD_HASH.length} chars). Re-run hash-password.mjs.`),
+      );
+    }
+
     if (!verifyPassword(form.get("password") || "")) {
       recordFailure(ip);
       return send(res, 401, page(false, "Wrong password."));
@@ -267,4 +292,9 @@ createServer(async (req, res) => {
 }).listen(PORT, "0.0.0.0", () => {
   console.log(`status console on :${PORT}, writing ${FILE}`);
   if (!PASSWORD_HASH) console.warn("CONSOLE_PASSWORD_HASH is not set — nobody can sign in.");
+  else if (!parseHash())
+    console.warn(
+      `CONSOLE_PASSWORD_HASH is malformed (${PASSWORD_HASH.length} chars) — nobody can sign in. ` +
+        "If it contains $, Docker Compose ate it; re-run hash-password.mjs for a colon-delimited one.",
+    );
 });


### PR DESCRIPTION
The console rejected the correct password.

The hash format was `scrypt$salt$hash`, and **Docker Compose interpolates `$` in a `.env` value**. So the salt and hash were substituted away as undefined variables:

```
warning: The "jPZaAtOEGAA3u7hRr92SrQ" variable is not set. Defaulting to a blank string.
warning: The "byRzukOxtmbohrxxwfpykntVs3Q1clfVJejEEeYaOpk" variable is not set. Defaulting to a blank string.
```

The container received **9 characters**. No password could ever have matched.

## Fix

Colon separator. Base64 never contains one, so there's nothing left for Compose to interpret. `$` is still accepted when *reading*, for anything already deployed, but never emitted.

**A malformed hash now says so**, instead of saying the password is wrong. From the login form those two look identical and only one of them is the user's fault — which is exactly why this cost a round trip to find. Reported on the page, and again at startup with the likely cause:

```
CONSOLE_PASSWORD_HASH is malformed (6 chars) — nobody can sign in.
If it contains $, Docker Compose ate it; re-run hash-password.mjs for a colon-delimited one.
```

## Verified

Against a real Compose stack, since that's where the bug lived:

```
generated: scrypt:CXrXNf0...   (delimiter: colon)
interpolation warnings: 0
chars received by container: 76
right password: 200
wrong password: 401
truncated hash: reports itself, on the page and in the log
```

## Needs re-running after this

The hash on the VPS is the `$` kind. Regenerate and replace it:

```bash
printf '%s' 'the-password-from-bitwarden' | node ops/internal/status/console/hash-password.mjs
```

Same password from Bitwarden — only the encoding changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)