### PR TITLE
Let the updater update itself, and stop leaking containers (GRYT-1003)

### DIFF
--- a/ops/internal/status/README.md
+++ b/ops/internal/status/README.md
@@ -129,10 +129,16 @@ body condition shows up as `success=false` before it reaches the live page.
 Don't grep that output for the word `errors`. Every passing line ends in
 `errors=0`.
 
-Use `--rm` and a `timeout`, as above. A validation run on 2026-09-03 was still
-running four days later as `infallible_zhukovsky`, holding
-`config/config.yaml.new` and serving nothing, because it was started without
-either. Check `docker ps` on the VPS after validating.
+**Do not pipe that into `grep -q`.** It looks right and leaks a container every
+time: `grep -q` exits on its first match, the SIGPIPE kills the docker client,
+and the container it was attached to keeps running — `--rm` never gets to do
+anything. Six piled up on this box in five minutes that way, and
+`infallible_zhukovsky`, running since 2026-09-03, is the same mistake made
+once.
+
+`update.sh` does this the safe way: `docker run -d --name`, poll the logs, then
+`docker rm -f`. Copy that rather than the one-liner if you are scripting it.
+Either way, check `docker ps` afterwards.
 
 The console does not need this. It writes JSON, which is valid YAML, so the
 message somebody typed cannot produce a malformed file the way hand-built YAML

--- a/ops/internal/status/docker-compose.yml
+++ b/ops/internal/status/docker-compose.yml
@@ -13,11 +13,19 @@ services:
       - gatus-data:/data
     environment:
       GATUS_CONFIG_PATH: /config
-    healthcheck:
-      test: ["CMD", "/gatus", "--help"]
-      interval: 60s
-      timeout: 5s
-      retries: 3
+    # No healthcheck, because this image cannot hold one. It carries `/gatus`
+    # and nothing else — no shell, no wget, no ls — so every candidate fails on
+    # "executable file not found".
+    #
+    # It used to say `test: ["CMD", "/gatus", "--help"]`. Gatus has no such
+    # flag, so that booted a second copy inside the container, read the config
+    # and exited 1: a failing streak of 48 while the page served perfectly. A
+    # check that only ever says unhealthy is worse than none, because it
+    # teaches you to ignore the word.
+    #
+    # What actually watches this is the thing it is: status.gryt.chat reports
+    # on Gryt from outside, and update.sh below would fail loudly if the
+    # container stopped coming back.
 
   # Posts announcements by writing announcements.yaml into the directory Gatus
   # already reads. Gatus merges every *.yaml there and reloads on its own, so

--- a/ops/internal/status/update.sh
+++ b/ops/internal/status/update.sh
@@ -9,8 +9,10 @@
 
 set -u
 
-SRC="/opt/gryt-src"
-DEST="/opt/gryt-status"
+# Overridable so a change to this script can be exercised against scratch
+# directories before it is trusted with the real ones.
+SRC="${CONSOLE_SRC:-/opt/gryt-src}"
+DEST="${CONSOLE_DEST:-/opt/gryt-status}"
 COMPOSE="$DEST/docker-compose.yml"
 STATE="$DEST/.deployed"
 
@@ -34,12 +36,19 @@ retry_delay() {
 
 # ── The config, which lives in git ───────────────────────────────────────
 
-# The three files the sync owns. Everything else in $DEST is either written by
-# the console or holds the password, and is never touched.
+# The files the sync owns. Everything else in $DEST is either written by the
+# console or holds the password, and is never touched.
+#
+# This script is one of them. Without that, a change to it merges and never
+# runs: the copy in git updates and the copy being executed does not, which is
+# exactly the "merged, deployed nothing" the timer exists to end. The systemd
+# units are not here — changing those needs a daemon-reload, so they stay a
+# documented one-off.
 SYNCED=(
     "docker-compose.yml:$DEST/docker-compose.yml"
     "README.md:$DEST/README.md"
     "config/config.yaml:$DEST/config/config.yaml"
+    "update.sh:$DEST/update.sh"
 )
 
 files_match() {
@@ -96,11 +105,32 @@ update_config() {
     rm -rf /tmp/gatus-validate-config
     cp -r "$SRC/ops/internal/status/config" /tmp/gatus-validate-config
 
-    if ! timeout 40 docker run --rm \
+    # Named and removed explicitly, never `--rm` into a pipe.
+    #
+    # `docker run --rm ... | grep -q` looks right and leaks a container every
+    # time: grep exits on its first match, the SIGPIPE kills the docker client,
+    # and the container it was attached to keeps running. Six of them piled up
+    # on this box in five minutes, and the one from 2026-09-03 has the same
+    # cause — the validate command in this README, which is written that way.
+    local name="gatus-validate-$$"
+    docker rm -f "$name" >/dev/null 2>&1 || true
+
+    docker run -d --name "$name" \
         -v /tmp/gatus-validate-config:/config:ro \
         -v /tmp/gatus-validate-data:/data \
         -e GATUS_CONFIG_PATH=/config \
-        twinproduction/gatus:v5.36.0 2>&1 | grep -q "Validated"; then
+        twinproduction/gatus:v5.36.0 >/dev/null 2>&1 || true
+
+    local ok=1 i
+    for i in $(seq 1 20); do
+        sleep 1
+        if docker logs "$name" 2>&1 | grep -q "Validated"; then ok=0; break; fi
+        docker inspect "$name" --format '{{.State.Running}}' 2>/dev/null | grep -q true || break
+    done
+
+    docker rm -f "$name" >/dev/null 2>&1 || true
+
+    if (( ok != 0 )); then
         echo "[$(date -Is)] [config] the new config did not validate; keeping the old one"
         return 1
     fi
@@ -109,9 +139,19 @@ update_config() {
     # not in git, and a wholesale copy would delete it and lock everybody out of
     # the console. announcements.yaml is written by the console and is not in
     # git either.
-    local pair
+    # Written beside and renamed, never copied over in place. bash reads a
+    # script as it runs, so overwriting this file mid-execution would hand the
+    # running shell the second half of a different one. A rename swaps the
+    # name and leaves the open inode alone.
+    #
+    # It also matters for the Gatus config, which is watched: a half-written
+    # file is a config that does not parse.
+    local pair dest
     for pair in "${SYNCED[@]}"; do
-        cp "$SRC/ops/internal/status/${pair%%:*}" "${pair#*:}"
+        dest="${pair#*:}"
+        cp "$SRC/ops/internal/status/${pair%%:*}" "$dest.incoming"
+        chmod --reference="$dest" "$dest.incoming" 2>/dev/null || true
+        mv "$dest.incoming" "$dest"
     done
 
     if ! docker compose -f "$COMPOSE" up -d; then
@@ -120,6 +160,9 @@ update_config() {
     fi
 
     echo "[$(date -Is)] [config] deployed ${target:0:8}"
+
+    # A new copy of this script takes effect next cycle; this shell goes on
+    # running the code it started with.
 }
 
 # ── The console, which lives in a registry ───────────────────────────────


### PR DESCRIPTION
Three things, all found by watching the box after #225 merged.

## The updater couldn't update itself

It synced the compose file, the README and the Gatus config — but not `update.sh`. So a change to it merges, the copy in git updates, and the copy being *executed* doesn't:

```
running copy has files_match: 0
git copy has files_match: 2
```

That's the same "merged, deployed nothing" the timer exists to end. It syncs itself now.

Files are written beside and renamed rather than copied over in place, because bash reads a script as it runs — overwriting this file mid-execution would hand the running shell the second half of a different one. A rename swaps the name and leaves the open inode alone. It matters for the Gatus config too, which is watched: a half-written file is a config that doesn't parse. A new copy takes effect next cycle.

## The validation leaked a container per run

```
2026-09-07 21:11:20  sad_solomon
2026-09-07 21:14:30  condescending_khayyam
2026-09-07 21:14:31  focused_edison
2026-09-07 21:15:36  sharp_heyrovsky
2026-09-07 21:16:30  silly_shannon
2026-09-07 21:16:57  cool_jennings
```

Six in five minutes, all mine, all removed. `docker run --rm ... | grep -q` looks right and isn't: `grep -q` exits on its first match, the SIGPIPE kills the docker client, and the container carries on running — `--rm` never gets to do anything. It runs detached with a name now, polls the logs, and removes it.

**That corrects what I said in GRYT-1001.** `infallible_zhukovsky` isn't a run started without `--rm` — it's this same pipe, from the command in the README, which has been written that way the whole time. The README now says so.

## The Gatus healthcheck is removed, not fixed

`test: ["CMD", "/gatus", "--help"]`. Gatus has no such flag, so it booted a second copy inside the container, read the config, and exited 1 — **a failing streak of 48** while the page served perfectly:

```
status: unhealthy | failing streak: 48
```

There's no replacement. The image carries `/gatus` and nothing else:

```
$ docker exec gryt-status sh -c "echo yes"
exec: "sh": executable file not found in $PATH
$ docker exec gryt-status wget ...
exec: "wget": executable file not found in $PATH
```

I tried the obvious `wget` version first and it fails the same way. A check that can only ever say unhealthy is worse than none, because it teaches you to ignore the word — so it's gone, with a comment saying why and what actually watches this instead.

## Verified on the VPS

Self-update lands executable and parseable with `.env` untouched; a validation cycle leaves the container count exactly where it found it (`LEAKED NOTHING`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)