### PR TITLE
Publish a Homebrew cask on every release (GRYT-1006)

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,0 +1,169 @@
+name: Publish the Homebrew cask
+
+# packaging/homebrew/gryt-chat.rb is the source of truth. It is copied into the
+# tap, so a packaging change is a reviewed pull request rather than a push
+# nobody sees.
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish, e.g. v1.9.24'
+        required: true
+        type: string
+
+concurrency:
+  group: publish-homebrew
+  cancel-in-progress: true
+
+jobs:
+  publish-homebrew:
+    name: Publish the Homebrew cask
+    runs-on: ubuntu-latest
+
+    # A `release` event does not know which dispatch produced it, so the channel
+    # is read off the tag.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !contains(github.event.release.tag_name, '-beta')
+
+    # No continue-on-error: GRYT-971 is what a publisher that cannot fail costs.
+    timeout-minutes: 15
+
+    env:
+      OWNER: Gryt-chat
+      REPO: gryt
+      TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      TAP_REPO: Gryt-chat/homebrew-tap
+      CASK: gryt-chat
+
+    steps:
+      - name: Check out the tap
+        id: checkout
+        shell: bash
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${HOMEBREW_TAP_TOKEN:-}" ]]; then
+            echo "HOMEBREW_TAP_TOKEN is not set, skipping the tap."
+            echo "active=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git clone --depth 1 \
+            "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
+
+          echo "active=true" >> "$GITHUB_OUTPUT"
+
+      - name: Rewrite the cask for this release
+        if: steps.checkout.outputs.active == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${TAG#v}"
+          DMG="Gryt-Chat-${VERSION}-mac-arm64-slim.dmg"
+
+          # From the release's own SHA256SUMS.txt rather than by downloading a
+          # 110MB disk image to hash it.
+          gh release download "$TAG" --repo "$OWNER/$REPO" \
+            --pattern 'SHA256SUMS.txt' --dir .
+
+          SUM="$(awk -v f="$DMG" '$2 == f { print $1 }' SHA256SUMS.txt)"
+
+          if [[ -z "$SUM" ]]; then
+            echo "::error::SHA256SUMS.txt for $TAG has no entry for $DMG."
+            echo "Either the macOS build did not upload, or its name changed."
+            exit 1
+          fi
+
+          # Read at the tag, so a re-run for an older release packages that
+          # release's cask. Tags cut before this file existed fall back to main.
+          at() {
+            gh api "repos/$OWNER/$REPO/contents/packaging/homebrew/${CASK}.rb?ref=$1" \
+              --jq '.content' 2>/dev/null | base64 -d
+          }
+
+          if at "$TAG" > cask.candidate && [[ -s cask.candidate ]]; then
+            echo "Using packaging/homebrew/${CASK}.rb from $TAG."
+          elif at main > cask.candidate && [[ -s cask.candidate ]]; then
+            echo "$TAG predates packaging/homebrew/${CASK}.rb. Using main's."
+          else
+            echo "::error::No packaging/homebrew/${CASK}.rb at $TAG or on main."
+            exit 1
+          fi
+
+          mkdir -p tap/Casks
+          cp cask.candidate "tap/Casks/${CASK}.rb"
+
+          # Anchored, so neither can match the same text inside the url further
+          # down the file.
+          sed -i \
+            -e "s/^  version \".*\"/  version \"${VERSION}\"/" \
+            -e "s/^  sha256 \".*\"/  sha256 \"${SUM}\"/" \
+            "tap/Casks/${CASK}.rb"
+
+          echo "The cask now says:"
+          grep -E '^  (version|sha256) ' "tap/Casks/${CASK}.rb"
+
+          # A sed that matched nothing leaves the placeholder in place, which
+          # would publish a cask pointing at version 0.0.0.
+          grep -qx "  version \"${VERSION}\"" "tap/Casks/${CASK}.rb"
+          grep -qx "  sha256 \"${SUM}\"" "tap/Casks/${CASK}.rb"
+
+      - name: Push it to the tap
+        if: steps.checkout.outputs.active == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${TAG#v}"
+
+          cd tap
+          git add "Casks/${CASK}.rb"
+
+          if git diff --cached --quiet; then
+            echo "Already at ${VERSION}. Nothing to push."
+            exit 0
+          fi
+
+          git config user.name "Gryt Chat"
+          git config user.email "sivert@gryt.chat"
+
+          git commit -m "${CASK} ${VERSION}"
+          git push
+
+      # GRYT-971 is what a publisher that only checks its own upload costs. Read
+      # back over plain HTTPS, the same view a `brew update` gets, so this cannot
+      # pass on something only the pusher can see.
+      - name: Check the tap is serving it
+        if: always() && steps.checkout.outputs.active == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${TAG#v}"
+          RAW="https://raw.githubusercontent.com/${TAP_REPO}/HEAD/Casks/${CASK}.rb"
+
+          for attempt in $(seq 1 10); do
+            LIVE="$(curl -sfS "$RAW" 2>/dev/null | sed -n 's/^  version "\(.*\)"$/\1/p' || true)"
+
+            if [[ "$LIVE" == "$VERSION" ]]; then
+              echo "${TAP_REPO} is serving ${CASK} $LIVE. Correct."
+              exit 0
+            fi
+
+            echo "Attempt $attempt: the tap says \"${LIVE:-unknown}\", waiting for ${VERSION}."
+            sleep 20
+          done
+
+          echo "::error::${TAP_REPO} is serving \"${LIVE:-unknown}\" for ${CASK}, not ${VERSION}."
+          echo "See https://github.com/${TAP_REPO}/blob/HEAD/Casks/${CASK}.rb"
+          exit 1

--- a/packaging/homebrew/gryt-chat.rb
+++ b/packaging/homebrew/gryt-chat.rb
@@ -1,0 +1,37 @@
+# version and sha256 are placeholders. publish-homebrew.yml rewrites both.
+cask "gryt-chat" do
+  version "0.0.0"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+
+  # Slim, matching what the site hands over by default.
+  url "https://github.com/Gryt-chat/gryt/releases/download/v#{version}/Gryt-Chat-#{version}-mac-arm64-slim.dmg",
+      verified: "github.com/Gryt-chat/gryt/"
+  name "Gryt Chat"
+  desc "Real-time voice chat"
+  homepage "https://gryt.chat/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  # Without this, brew upgrade reinstalls over a copy electron-updater has
+  # already moved on.
+  auto_updates true
+  # No Intel artefact is built, and the DMG has no x86_64 slice for Rosetta.
+  depends_on arch: :arm64
+  depends_on macos: :monterey
+
+  app "Gryt Chat.app"
+
+  # Only on --zap, never on an ordinary uninstall: this holds the identity
+  # keypair, and losing it loses every server the person had joined.
+  zap trash: [
+    "~/Library/Application Support/Gryt Chat",
+    "~/Library/Caches/com.gryt.chat",
+    "~/Library/Caches/com.gryt.chat.ShipIt",
+    "~/Library/HTTPStorages/com.gryt.chat",
+    "~/Library/Preferences/com.gryt.chat.plist",
+    "~/Library/Saved Application State/com.gryt.chat.savedState",
+  ]
+end


### PR DESCRIPTION
macOS is the one platform with no package-manager route in. Windows has the Microsoft Store, Linux has the Snap Store and the AUR, and a Mac user has to find the site and drag a DMG.

Same shape as `publish-aur.yml`: the cask lives in `packaging/` where changing it is a reviewed PR, the workflow rewrites version and sha256 on release and pushes, and a check afterwards reads the tap back over plain HTTPS instead of trusting the push. That last step exists because of GRYT-971 — the Snap Store sat four weeks behind while every run reported success.

The checksum comes out of the release's own `SHA256SUMS.txt` rather than downloading a 110MB disk image to hash it.

## Checked against v1.9.24, not assumed

I expected a Gatekeeper problem, because `electron-builder.yml` has no notarize block. It turns out the release workflow signs with a Developer ID and the build is notarized:

```
Authority=Developer ID Application: SVEKT GULLSERG - HANSEN (8883W2XTQ8)
flags=0x10000(runtime)
spctl: source=Notarized Developer ID
stapler validate: The validate action worked!
```

So no quarantine workaround and nothing to document. The other two:

- **arm64 only.** There is no Intel artefact at all, so `depends_on arch: :arm64` refuses clearly rather than installing something that cannot run. Rosetta would not help — the DMG has no x86_64 slice.
- **macOS 12**, read off the app's own `LSMinimumSystemVersion` rather than guessed from the Electron version.

`auto_updates true` because electron-updater already owns the version. Without it `brew upgrade` reinstalls over a copy the app has already moved past.

## Our own tap

`homebrew-cask` proper is a pull request per release against someone else's review queue, and GRYT-961 already records how that went at Flathub. A tap we own updates on our own schedule, and moving later is a rename.

**Dormant until you create `Gryt-chat/homebrew-tap` and set `HOMEBREW_TAP_TOKEN`** — same pattern as the Snap and Microsoft Store steps, so merging this cannot affect a release.

## What to look at

**The cask ships the slim build, matching the site's default. The AUR ships the full one.** `packaging/aur/PKGBUILD` points at `Gryt-Chat-x.y.z-linux-amd64.deb`, not `-slim`, while the site hands over slim on every platform. Nobody decided that, they just diverged, and Homebrew should not quietly become a third answer. Say which you want and I will make them agree.

## Verified

`brew` was run against the real cask, in a throwaway local tap, on this Mac:

- `brew style --cask` — no offences. It caught two things on the way: `depends_on macos: ">= :monterey"` is deprecated in favour of the symbol, and `auto_updates` was in the wrong stanza position.
- `brew audit --cask --strict` — exit 0.
- `brew fetch --cask` — downloads from the release URL and verifies the sha256. `✔︎ Cask gryt-chat (1.9.24)`.
- The workflow's exact `sed` was run against the committed placeholder file and the result re-audited, so the rewrite is checked rather than assumed. Both `grep -qx` guards pass.

Not run: `brew install --cask`. Gryt Chat is already in `/Applications` on this machine and installing would have replaced your copy. What that leaves untested is the app-move, which is the one line of pure boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
