### PR TITLE
Flatpak packaging, built and linted but not yet submitted (GRYT-969)

### DIFF
--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,0 +1,48 @@
+# Flatpak packaging
+
+**Carlo submits this to Flathub. Nothing here opens a pull request against
+`flathub/flathub`.** Two attempts from `sivert-io` were closed in March, one of
+them as "AI slop", and Gryt's standing there is spent one attempt at a time.
+GRYT-969 has the history.
+
+## What is here
+
+| File | What it is |
+|---|---|
+| `chat.gryt.Gryt.yml` | The manifest. Builds from the release `.deb`. |
+| `chat.gryt.Gryt.metainfo.xml` | AppStream metadata: the store page. |
+| `chat.gryt.Gryt.desktop` | Desktop entry, including the `gryt://` handler. |
+| `chat.gryt.Gryt.sh` | Launcher. Electron needs `zypak-wrapper` under a runtime. |
+
+`url`, `sha256` and the `<release>` are placeholders, rewritten per release the
+same way `packaging/aur/PKGBUILD` and `packaging/homebrew/gryt-chat.rb` are.
+
+## Building it
+
+On a machine with flatpak:
+
+```bash
+flatpak install --user flathub org.flatpak.Builder
+flatpak run org.flatpak.Builder --force-clean --user \
+  --install-deps-from=flathub --repo=repo --install builddir chat.gryt.Gryt.yml
+```
+
+Then the three checks Flathub CI runs:
+
+```bash
+flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest chat.gryt.Gryt.yml
+flatpak run --command=flatpak-builder-lint org.flatpak.Builder builddir builddir
+flatpak run --command=flatpak-builder-lint org.flatpak.Builder repo repo
+```
+
+## Still open before submission
+
+- **The app ID is Carlo's to settle.** `chat.gryt.Gryt` is used throughout
+  because gryt.chat is the domain, but their `io.github.*` form is also allowed.
+  Changing it means renaming all four files.
+- **Screenshots** point at the video posters gryt.chat already serves. They are
+  real and reachable, but they are `.webp` posters rather than pictures taken for
+  a store page.
+- **The sandbox has not been exercised.** Voice, screen sharing through the
+  portal and the `gryt://` handler all need a desktop session to test, and the
+  build was done over SSH on a box with no session running.

--- a/packaging/flatpak/chat.gryt.Gryt.desktop
+++ b/packaging/flatpak/chat.gryt.Gryt.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Gryt Chat
+Comment=Real-time voice chat
+Exec=gryt-chat %u
+Icon=chat.gryt.Gryt
+Terminal=false
+Type=Application
+Categories=Network;InstantMessaging;AudioVideo;
+MimeType=x-scheme-handler/gryt;
+StartupWMClass=Gryt Chat

--- a/packaging/flatpak/chat.gryt.Gryt.metainfo.xml
+++ b/packaging/flatpak/chat.gryt.Gryt.metainfo.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The app ID is Carlo's to settle before submission. gryt.chat is the domain,
+     so the prefix is chat.gryt. and not the com.gryt. the closed March attempt
+     used. -->
+<component type="desktop-application">
+  <id>chat.gryt.Gryt</id>
+
+  <name>Gryt Chat</name>
+  <summary>Real-time voice chat</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>AGPL-3.0-or-later</project_license>
+
+  <developer id="chat.gryt">
+    <name>Gryt</name>
+  </developer>
+
+  <description>
+    <p>
+      Gryt is voice chat you can host yourself. Talk in voice channels, send
+      messages, share your screen, and run the server on your own machine if you
+      want to — or join somebody else's.
+    </p>
+    <p>
+      Every server is separate. You join with a key your device holds rather
+      than an account on someone else's computer, so a server you run answers to
+      you and nobody has to sign up anywhere to talk on it.
+    </p>
+    <p>What it does:</p>
+    <ul>
+      <li>Voice channels, with screen sharing and video</li>
+      <li>Text channels, direct messages and group messages</li>
+      <li>Servers you host yourself, on a LAN or on the internet</li>
+      <li>Roles and permissions, set per server</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">chat.gryt.Gryt.desktop</launchable>
+
+  <url type="homepage">https://gryt.chat/</url>
+  <url type="bugtracker">https://github.com/Gryt-chat/gryt/issues</url>
+  <url type="vcs-browser">https://github.com/Gryt-chat/gryt</url>
+
+  <!-- These are the video posters gryt.chat already serves, so they are real
+       screenshots at a stable URL. Flathub fetches and mirrors them at build
+       time, so an unreachable one fails the build. -->
+  <screenshots>
+    <screenshot type="default">
+      <image>https://gryt.chat/home/client-live.poster.webp</image>
+      <caption>A voice channel, with the member list and chat alongside</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gryt.chat/home/screen-share.poster.webp</image>
+      <caption>Sharing a screen in a call</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gryt.chat/home/create-server.poster.webp</image>
+      <caption>Creating a server to host yourself</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gryt.chat/home/avatar-editor.poster.webp</image>
+      <caption>Designing an owl avatar</caption>
+    </screenshot>
+  </screenshots>
+
+  <categories>
+    <category>Network</category>
+    <category>InstantMessaging</category>
+    <category>AudioVideo</category>
+  </categories>
+
+  <keywords>
+    <keyword>voice</keyword>
+    <keyword>chat</keyword>
+    <keyword>voip</keyword>
+    <keyword>selfhosted</keyword>
+  </keywords>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </supports>
+
+  <requires>
+    <display_length compare="ge">768</display_length>
+  </requires>
+
+  <content_rating type="oars-1.1">
+    <!-- People talk to each other and can send each other pictures, and Gryt
+         does not moderate what they say. Everything else is none. -->
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+  </content_rating>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#968ff8</color>
+    <color type="primary" scheme_preference="dark">#2a2438</color>
+  </branding>
+
+  <!-- Rewritten per release. `date` alone is dropped by appstreamcli compose
+       with "Ignoring release element without timestamp or date", so both go in. -->
+  <releases>
+    <release version="0.0.0" date="2026-01-01" timestamp="1767225600">
+      <url type="details">https://github.com/Gryt-chat/gryt/releases</url>
+    </release>
+  </releases>
+</component>

--- a/packaging/flatpak/chat.gryt.Gryt.sh
+++ b/packaging/flatpak/chat.gryt.Gryt.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Electron under a Flatpak runtime needs the sandbox disabled, because the
+# runtime already is one and the chrome-sandbox binary is not setuid here.
+exec zypak-wrapper /app/lib/gryt-chat/gryt-chat "$@"

--- a/packaging/flatpak/chat.gryt.Gryt.yml
+++ b/packaging/flatpak/chat.gryt.Gryt.yml
@@ -1,0 +1,72 @@
+# Draft. Carlo submits this to Flathub; nothing here opens a PR against
+# flathub/flathub. See GRYT-969 for why that boundary exists.
+#
+# `url` and `sha256` are rewritten per release, the same way the PKGBUILD and
+# the Homebrew cask are.
+id: chat.gryt.Gryt
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+# 25.08 rather than 26.08: the runtime has to match the Electron base app, and
+# org.electronjs.Electron2.BaseApp has no 26.08 branch. The linter says so as a
+# warning; following it would not build.
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
+command: gryt-chat
+separate-locales: false
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=network
+  - --socket=pulseaudio
+  # Voice needs a camera for video calls, and the mic arrives over pulseaudio.
+  - --device=all
+  # Screen sharing needs no talk-name: portals are reachable from every sandbox,
+  # and asking for them is an error to flatpak-builder-lint.
+  # Tray icon.
+  - --talk-name=org.kde.StatusNotifierWatcher
+  # electron-updater must not run inside the sandbox: Flathub owns updates here,
+  # and an app that rewrites itself would be replaced on the next flatpak update
+  # anyway. The client reads this to hide its updater UI.
+  - --env=GRYT_MANAGED_UPDATES=1
+
+modules:
+  - name: gryt-chat
+    buildsystem: simple
+    build-commands:
+      - ar x gryt-chat.deb
+      - tar -xf data.tar.xz
+      # The binary lives in a directory with a space in it.
+      - mkdir -p /app/lib/gryt-chat
+      - cp -a "opt/Gryt Chat/." /app/lib/gryt-chat/
+      - install -Dm755 chat.gryt.Gryt.sh /app/bin/gryt-chat
+      - install -Dm644 chat.gryt.Gryt.desktop /app/share/applications/chat.gryt.Gryt.desktop
+      - install -Dm644 chat.gryt.Gryt.metainfo.xml /app/share/metainfo/chat.gryt.Gryt.metainfo.xml
+      # flatpak refuses an icon over 512x512 and the deb ships one 1024x1024,
+      # so the sizes are made here. ffmpeg because the freedesktop SDK has no
+      # ImageMagick. A missing icon is a Flathub rejection, so finding no source
+      # fails the build rather than the review.
+      - |
+        src="$(ls usr/share/icons/hicolor/*/apps/gryt-chat.png | head -1)"
+        test -n "$src"
+        for size in 512 256 128 64 48 32 16; do
+          ffmpeg -loglevel error -i "$src" -vf "scale=${size}:${size}:flags=lanczos" \
+            -frames:v 1 "icon-${size}.png"
+          install -Dm644 "icon-${size}.png" \
+            "/app/share/icons/hicolor/${size}x${size}/apps/chat.gryt.Gryt.png"
+        done
+    sources:
+      - type: file
+        path: chat.gryt.Gryt.sh
+      - type: file
+        path: chat.gryt.Gryt.desktop
+      - type: file
+        path: chat.gryt.Gryt.metainfo.xml
+      - type: file
+        dest-filename: gryt-chat.deb
+        url: https://github.com/Gryt-chat/gryt/releases/download/v0.0.0/Gryt-Chat-0.0.0-linux-amd64.deb
+        sha256: '0000000000000000000000000000000000000000000000000000000000000000'
+        only-arches: [x86_64]


### PR DESCRIPTION
**Carlo submits this. Nothing here opens a pull request against `flathub/flathub`, and nothing should** — GRYT-969 has the March history and why that boundary is worth keeping.

**All four files were written by Claude (Opus 5).** Carlo needs that stated plainly, not buried: Flathub requires submitters to disclose AI-generated packaging, and undisclosed content can mean a permanent ban. The commit says the same thing so `git log` carries it.

The manifest builds from the release `.deb`, the way `packaging/aur/PKGBUILD` and `packaging/homebrew/gryt-chat.rb` do, with `url` and `sha256` as placeholders.

## What building it actually found

It was built on the CachyOS box against v1.9.24 rather than written and handed over. Four things would have failed a submission:

1. **`--talk-name=org.freedesktop.portal.*` is an error**, not an optimisation. Portals are reachable from every sandbox, so asking for them is redundant and `flatpak-builder-lint` rejects it. This is the stanza most Electron manifests copy from each other.
2. **The runtime has to be 25.08**, not the 26.08 the linter recommends, because `org.electronjs.Electron2.BaseApp` has no 26.08 branch. Following the linter here would not build.
3. **flatpak refuses an icon over 512×512**, and the deb ships exactly one 1024×1024 and nothing else. The manifest resamples with ffmpeg — the freedesktop SDK has no ImageMagick — but that is the wrong place for it, so [GRYT-1008](https://tasks.sivert.io/tasks/1065) moves it into the client where deb and snap get the sizes too.
4. **A `--` inside an XML comment** made the metainfo unparseable. It surfaced as `appstreamcli compose failed: Child process exited with code 1`, with nothing pointing at a comment.

## Verified, and what is not

Verified on the box, with the same tooling Flathub CI uses:

- `flatpak-builder-lint manifest` — clean apart from the 26.08 note above.
- The build completes and installs: `Installing app/chat.gryt.Gryt/x86_64/master`.
- `appstreamcli validate` — passes, one pedantic note about the capital letter in the ID, which is correct for a `chat.gryt.Gryt` style ID.

**Not verified.** `flatpak-builder-lint builddir` and `repo` then reported two more errors — a release element with a `date` but no `timestamp`, and screenshots that 404 because `https://gryt.chat/screenshots/app.png` does not exist. Both are fixed in this branch: the release carries both attributes now, and the screenshots point at the video posters gryt.chat already serves (all four return 200). **Neither fix has been re-run** — the Linux box went off the network before the rebuild. The README has the three commands.

**The sandbox is untested.** Voice, screen sharing through the portal and the `gryt://` handler all need a desktop session, and the box was on a tty. That is the part of GRYT-969 that says "tested, not assumed", and it is still owed.

## Open before Carlo submits

- **The app ID is his to settle.** `chat.gryt.Gryt` throughout, because gryt.chat is the domain and `com.gryt.Chat` is what the closed March attempt used. Their `io.github.*` form is also allowed. Changing it renames all four files.
- **Screenshots are video posters**, not pictures taken for a store page. Real and reachable, but `.webp` and cropped for a different job.

## Why this is worth the trouble

The desktop file carries `MimeType=x-scheme-handler/gryt`, so the `gryt://` association comes from packaging instead of the app writing one at runtime and pointing it at a path that can move. That is the whole GRYT-965 / GRYT-967 class of bug, gone by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
