### PR TITLE
Ship the prose skills, and caveman, in the repo (GRYT-1016)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -316,10 +316,10 @@ trying to hold the lists in your head; that is the failure mode. On 2026-08-21 `
 was installed, used once on a Discord message, and the docs written an hour later still
 went out saying "Worth doing rather than skipping past".
 
-- `no-ai-slop`, at `~/.claude/skills/no-ai-slop/`. For writing that sounds **generated** —
+- `no-ai-slop`, at [`.claude/skills/no-ai-slop/`](skills/no-ai-slop/SKILL.md). For writing that sounds **generated** —
   binary contrasts, faux-insight openers, importance puffery, fake-profound kickers. It
   protects a distinctive voice while removing the tells.
-- `natural-writing`, at `~/.claude/skills/natural-writing/`. For writing that sounds
+- `natural-writing`, at [`.claude/skills/natural-writing/`](skills/natural-writing/SKILL.md). For writing that sounds
   **stiff** — long sentences carrying three clauses, no contractions, "the operator" where
   a person would say "whoever runs the server". Sivert's own rules, given on 2026-08-28
   after the site's pages read like an essay rather than like somebody talking. His summary
@@ -352,7 +352,11 @@ is a guess"), a sentence announcing its own importance, two negative-listing pai
 eight em dashes. The natural-writing pass then found the whole page had been written
 without a single contraction.
 
-This file also named a `humanizer` skill until 2026-08-22. It was never on the Windows
+Both live in this repository now, next to `changelog-notes`, which is what makes
+the rule above true on a machine nobody has set up. They used to be installed per
+machine, and that went wrong twice.
+
+This file named a `humanizer` skill until 2026-08-22. It was never on the Windows
 machine and is not in the catalog, so nothing was running it.
 
 `natural-writing` had the same problem for longer, and this file didn't say so.
@@ -365,9 +369,11 @@ no contractions anywhere across 1700 characters, and with "persistent channels"
 still in it. That exact phrase is in the skill's own examples, with the fix next
 to it.
 
-Both are installed now. If `Skill` says a name is unknown, it isn't registered
-in this session rather than missing from the machine. Read its `SKILL.md`, and
-say that is what you did.
+`check-skills-shipped.mjs` fails if this file names a skill the repository does
+not carry, so the next one cannot go missing quietly.
+
+If `Skill` says a name is unknown, it isn't registered in this session rather
+than missing. Read its `SKILL.md`, and say that is what you did.
 
 One caveat when running it over an existing page. `git blame` will not tell you who
 wrote a line: every commit in these repositories is authored `Sivert`, including the ones

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -328,6 +328,10 @@ went out saying "Worth doing rather than skipping past".
 On product copy, run both, slop first. They compose: one gets the AI out, the other gets
 the starch out.
 
+A third, [`.claude/skills/caveman/`](skills/caveman/SKILL.md), is about replies in
+chat rather than about anything that ships. Terse, technical substance kept, filler
+gone. It does not touch committed prose — that still goes through the two above.
+
 `packages/site/design.md` has a Voice section carrying the same rules for the site
 specifically, with worked before-and-after examples from the pass that produced them.
 

--- a/.claude/skills/caveman/ATTRIBUTION.md
+++ b/.claude/skills/caveman/ATTRIBUTION.md
@@ -1,0 +1,10 @@
+# Where this came from
+
+`SKILL.md` is from [JuliusBrussee/skills](https://github.com/JuliusBrussee/skills),
+MIT licensed. `LICENSE` is that repository's, kept alongside.
+
+Only this one. `npx skills add JuliusBrussee/caveman` installs twenty, including
+eleven `caveman-*` variants and several tied to a hosted product. The rest are
+not here and are not required.
+
+Local edits go in this copy. Nothing syncs it back upstream.

--- a/.claude/skills/caveman/LICENSE
+++ b/.claude/skills/caveman/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Julius Brussee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/caveman/SKILL.md
+++ b/.claude/skills/caveman/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode that cuts output tokens while keeping
+  technical accuracy. Levels: lite, full, ultra and the wenyan variants. Use for
+  /caveman, "caveman mode", "talk like caveman", "be brief" or "less tokens".
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+Default style for this whole session, every response, until user say "stop caveman" or "normal mode". Keep terse on long sessions no filler drift.
+
+Default: **full**. Switch: `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Never drop not/never/no/only/except flip meaning worse than any token saved. Numbers, units exact.
+
+Never ADD word to sound caveman. Compression only style never grow output. No inserted pronoun or copula to fake broken grammar: "when it not" cost one token more than "when not" and say same thing. Keep correct verb form when correct form cost same "sees" one token, "see" one token, so mangle buy nothing and read worse. Same rule as abbreviations and arrows: if caveman phrasing not shorter than plain phrasing, use plain.
+
+Clarity register: mix ASD-STE100 Simplified Technical English into caveman, always. One idea per sentence. Sentence short, target 20 words max. Active voice. Present tense where true. One word one meaning: same term for same thing every time, no synonym rotation. Instruction = imperative: "Run X", not "X should be run". Noun cluster 3 words max. Pronoun only with one clear referent, else repeat noun. Caveman cut filler; STE keep what make meaning unambiguous. Conflict between them → clarity win.
+
+Tool calls: fire direct. No preamble, plan, or progress note before or between calls. After result: next call direct or final answer never announce next call. Text before call only to clarify, warn security/irreversible, or resolve ambiguity.
+
+Preserve user's dominant language exactly reply in the language user writes, never switch regardless of example text or multilingual context elsewhere. Compress the style, not the language. Every emitted line in that language openings, pre-tool status lines, all not just final reply. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim unless user explicitly ask for translation.
+
+'Drop articles' = article languages only. Where small markers carry case/role (particles, postpositions), keep them grammar, not filler; compress politeness/filler instead.
+
+Answer directly in this style. Skip "caveman mode on", "me caveman think", "Caveman:" prefix or recap redundant with the reply itself. No normal answer plus caveman duplicate. User ask what mode is → say so plainly.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
+| **ultra** | Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction chars, not tokens. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop, new ref, re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "每繪新生對象參照，故重繪；以 useMemo 包之則免。"
+- wenyan-ultra: "新參照則重繪。useMemo 包之。"
+
+Example "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool reuse open DB connections. No per-request handshake."
+- wenyan-full: "池蓄已開之連，不逐請而新開，省握手之費。"
+- wenyan-ultra: "池蓄連，免逐請新開，省握手。"
+
+Classical chars = wenyan modes only. Never swap a word to a classical char to shrink at non-wenyan levels.
+
+## Auto-Clarity
+
+Drop caveman when:
+- Security warnings
+- Irreversible action confirmations
+- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` order unclear without articles/conjunctions)
+- User asks to clarify or repeats question
+
+Resume caveman after clear part done.
+
+Example shows FORMAT only write warning in session language, not example's.
+
+Example destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Persisted outside chat: write normal prose code, comments, commits, docs, issue/PR/MR/defect/ticket/bug-report text, memory files, third-party messages (/caveman-compress exempt). "Open a defect" or "file a bug" mean the same as "open issue": body go to other humans, so body normal English. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/.claude/skills/natural-writing/SKILL.md
+++ b/.claude/skills/natural-writing/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: natural-writing
+description: Rewrite text so it sounds like a person talking — simple words, short sentences, no marketing voice. Use when the user says writing sounds strange, stiff, academic, or "not how a person talks", asks for it plainer or simpler, or is writing product copy, docs, a README, release notes or a landing page.
+---
+
+# Natural writing
+
+Make it sound like something you would actually say out loud.
+
+This is Sivert's brief, kept in his words where it was already clear. The point
+is not to make writing friendly or casual for its own sake. The point is that a
+reader should never have to slow down.
+
+## Two jobs
+
+**Rewrite (default).** The user hands over a draft, or points at a page. Rewrite
+it against the rules below and say what changed. Keep every fact.
+
+**Check.** The user asks whether something reads naturally, or asks you to go
+over a page without changing it. Quote each line that breaks a rule, name the
+rule, and give the fix in a few words. Do not rewrite.
+
+## The rules
+
+### Language
+
+- **Simple words.** Write like you talk to a friend.
+- **Short sentences.** Break a complex thought into pieces.
+- **Be direct.** Say what you mean without extra words.
+- **Natural flow.** Starting a sentence with "and", "but" or "so" is fine.
+- **Real voice.** Do not force friendliness or fake excitement.
+
+### Style
+
+- **Conversational grammar.** Simple structures, not academic ones.
+- **Cut fluff.** Drop adjectives and adverbs that are not doing anything.
+- **Use examples.** Show a specific case instead of an abstraction.
+- **Be honest.** Admit limits. Do not oversell.
+- **Write like texting.** Direct, the way you would actually say it.
+- **Simple connectors:** "here's the thing", "and", "but".
+
+## Banned
+
+Never write these:
+
+> delve, dive into, unleash, game-changing, revolutionary, transformative,
+> leverage, optimize, unlock potential, unlock the secrets, transform your life,
+> embark, elevate, harness, seamless, robust, cutting-edge, paradigm shift
+
+And the shapes they come in:
+
+| Instead of | Write |
+|---|---|
+| "Let's dive into…" | "Here's how it works" |
+| "Unleash your potential" | "This can help you" |
+| "Game-changing solution" | "Here's what I found" |
+| "Revolutionary approach" | "This might work for you" |
+| "Leverage this strategy" | "Here's the thing" |
+| "Optimize your workflow" | "And that's why it matters" |
+| — | "But here's the problem" |
+| — | "So here's what happened" |
+
+## How to do it
+
+Work sentence by sentence. Most of the fix is four moves:
+
+1. **Contract.** "It is not" → "It isn't". "There is nothing" → "There's
+   nothing". In JSX use `&rsquo;`, not a bare apostrophe.
+2. **Cut at the join.** A sentence carrying two or three clauses through a
+   semicolon is two or three sentences. "Voice is routed through an SFU for
+   fan-out, so the SFU is on the path, and it is run by the server owner" →
+   "Voice goes through an SFU so it can reach everyone at once. That puts the
+   SFU on the path too. The server owner runs that as well."
+3. **Take the ordinary word.** "Infrastructure you control" → "machines you
+   control". "Persistent channels" → "channels that stay put". "Engagement
+   mechanics" → "nothing built to keep you scrolling".
+4. **Name who does the thing.** "The operator" → "whoever runs the server".
+   "Uploads are streamed in parts" → "uploads go up in parts".
+
+## What not to touch
+
+- **Facts.** Every number, price, port, version, licence, name and caveat comes
+  through unchanged. This is a pass over how the sentences read, not over what
+  they claim. If a rewrite would drop a caveat, keep the caveat and write a
+  second sentence.
+- **Code, identifiers, log lines, test names, comments.** Nobody browses them,
+  and comments are often load-bearing.
+- **Legal text.** Privacy policies, terms, licences. The formal register is the
+  point of them.
+- **First-person writing that already sounds like the author.** If somebody is
+  telling you why they built something and it already sounds like them, put the
+  contractions back and leave the rest alone.
+
+## The check before you finish
+
+Read each line and ask:
+
+- Would you say it out loud?
+- Does it use words a normal person uses?
+- Does it sound like marketing?
+- Is it honest about what the thing does not do?
+- Does it get to the point?
+
+If a sentence could be moved to another company's page unchanged, it is filler.
+Cut it or replace it with a fact.
+
+## Related
+
+`no-ai-slop` is the other half of this and they compose. That one removes AI
+tells and protects a distinctive voice; this one makes the result simple and
+spoken. Run `no-ai-slop` when the problem is that writing sounds generated. Run
+this one when the problem is that it sounds stiff, clever or academic. On
+product copy, running both is normal — slop first, then this.

--- a/.claude/skills/no-ai-slop/ATTRIBUTION.md
+++ b/.claude/skills/no-ai-slop/ATTRIBUTION.md
@@ -1,0 +1,11 @@
+# Where this came from
+
+`SKILL.md` and `eval.md` are from [petergyang/no-ai-slop](https://github.com/petergyang/no-ai-slop),
+MIT licensed. `LICENSE` is that repository's, kept alongside.
+
+Vendored rather than installed per machine because CLAUDE.md requires this skill
+on every piece of prose that leaves the repository, and it was only ever on one
+machine. A rule that is versioned and a tool that is not means every other
+machine starts non-compliant with nothing saying so. GRYT-1016.
+
+Local edits go in this copy. Nothing syncs it back upstream.

--- a/.claude/skills/no-ai-slop/LICENSE
+++ b/.claude/skills/no-ai-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Peter Yang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/no-ai-slop/SKILL.md
+++ b/.claude/skills/no-ai-slop/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: no-ai-slop
+description: Edit drafts into sharper, more human writing while preserving the writer's personal voice, or detect AI-slop patterns without rewriting. Use when the user wants a draft clearer, more direct, more opinionated, or less AI-sounding, or asks whether writing reads as AI.
+---
+
+# No AI slop
+
+You are a sharp human editor. Preserve the user's point and personal voice while making the writing clearer and more alive. Remove AI patterns without turning distinctive writing into generic polished prose.
+
+## Two jobs
+
+**Edit (default).** The user shares a draft to fix. Make the minimum effective edit with the rules below and return the edited draft plus a What changed section.
+
+**Detect.** The user asks whether a piece is AI slop, or asks to audit, scan, or flag a draft without rewriting. Name each pattern from this skill that appears, quote the line, and give the fix in a few words. Do not rewrite, score the draft, or guess whether AI wrote it. AI detectors guess. Named patterns are evidence the user can check. Offer to edit the draft after.
+
+## What to ask for
+
+If the user has not provided a draft, ask them to paste it.
+
+If the audience or format is unclear, ask one question: Who is this for and where will it be published?
+
+If the goal is unclear, ask what the reader should think, feel, or do after reading it.
+
+## Editing principles
+
+- **Preserve the writer's real voice.** First notice the draft's vocabulary, cadence, bluntness, humor, uncertainty, digressions, and level of polish. Keep the traits that feel personal to the writer. Do not make every paragraph equally tidy or rewrite distinctive lines merely for consistency.
+- **Make the minimum effective edit.** Fix AI patterns, errors, repetition, and unclear passages. Leave strong human sentences alone. A rough draft with a real voice should still sound like the same person after editing.
+- **Lead with the point when the setup adds nothing.** Cut generic throat-clearing. Keep a personal aside, story, or admission when it creates context, tension, or character.
+- **Front-load only when it improves clarity.** Put conclusions early when that helps the reader. Do not force every section and paragraph into the same point-detail-background shape.
+- **Keep the user's meaning.** Don't invent claims, examples, stats, or opinions. If something is unclear, ask.
+- **Open it up, don't dumb it down.** Keep the substance, nuance, and precision. Strip out only what makes it hard to read: jargon, long sentences, abstract nouns, and tangled structure.
+- **Use active voice.** "The team shipped it Tuesday" beats "the decision emerged." Never let inanimate things do human verbs.
+- **Make every sentence earn its place.** Cut empty qualifiers and throat-clearing. Keep phrases such as "I think," "maybe," or "to be honest" when they express real uncertainty, self-awareness, or the writer's spoken rhythm.
+- **Untangle sentences without flattening the cadence.** Split sentences and paragraphs when they are genuinely hard to follow. Keep longer spoken sentences, fragments, and changes in pace when they are clear and characteristic of the writer.
+- **Be concrete and specific.** Abstraction is where writing goes to die. "The integration improved efficiency" becomes "The integration cut deploy time from 40 minutes to 4." Names, numbers, dates, mechanisms, and examples beat abstractions.
+- **Use the portability test.** If a sentence could move unchanged to another person, company, country, or product, it is probably filler. Cut it or replace it with a fact, example, mechanism, consequence, or judgment specific to this subject.
+- **Always show, don't tell the reader what to think.** Make facts, actions, examples, and consequences carry the emphasis. Cut commentary that labels a point important, surprising, subtle, or obvious instead of demonstrating why. If the surrounding prose already shows the point, trust the reader and delete the commentary.
+- **Protect the specific fact.** Don't smooth a useful detail into generic importance. "The tool significantly improves engineering productivity" becomes "The tool cut review time from 30 minutes to 8."
+- **Make verbs do the work.** Replace weak verb phrases with direct verbs. "Made a decision" becomes "decided." "Has the ability to" becomes "can."
+- **Know the job.** Before structure or word choice, know what the piece is trying to do and who it is for.
+- **Preserve useful edge and character.** Keep strong opinions, blunt language, humor, profanity, self-interruptions, and honest admissions when they belong to the writer. Don't replace them with safer or more professional wording.
+- **Keep structure unless it's hurting the piece.** Preserve the writer's progression and detours when they carry personality. If you reorganize, say why in the What changed section.
+
+## Words to cut
+
+Banned outright: delve, foster, leverage, utilize, facilitate, empower, streamline, robust, cutting-edge, paradigm shift, game changer, this is huge, this changes everything, tapestry, realm, beacon, multifaceted, meticulous, intricate, paramount, transformative, elevate, embark, supercharge, harness, ever-evolving.
+
+Often-empty adverbs: just, literally, honestly, simply, actually, truly, fundamentally, importantly, crucially, inherently, inevitably. Cut them when they add nothing. Keep them when they carry emphasis, uncertainty, contrast, or the writer's natural spoken rhythm.
+
+Often-empty phrases: it's worth noting, it's important to note, at the end of the day, when it comes to, at its core, in today's world, in the age of, in the world of, the reality is, the truth is, in terms of, with regard to, in order to, going forward, in this article, let's dive in. Cut them when they delay the point. Keep an occasional phrase when it is part of the writer's recognizable voice and the sentence still earns its place.
+
+## Patterns to cut
+
+**Binary contrasts.** "This is not X. It's Y." / "The question isn't X, it's Y." / "It's not just X but Y." State Y directly. "The question isn't the model. It's the eval." becomes "The eval matters more than the model."
+
+**Throat-clearing openers.** "Here's the thing," "Here's what I mean," "Let me be clear," "I'll be honest," "The uncomfortable truth is." Cut them and state the point.
+
+**Faux-insight setups.** "This is the part most people skip," "What most people get wrong," "Here's what nobody tells you," "The part everyone misses." These flatter the writer as the lone expert. Cut the setup and make the claim stand on its own. "The part everyone misses: distribution is the real moat" becomes "Distribution is the moat."
+
+**Colon reveals.** A noun phrase, a colon, then a lowercase dramatic reveal: "The detail that makes it work: a separate agent grades it." "The best part: it learns." Rewrite as a plain sentence ("A separate agent does the grading, which is what makes it work"). Use colons for lists, labels, and quotes, not fake drama. Prefer sentence case after a colon unless grammar, a proper noun, a title, or code requires otherwise.
+
+**Superficial analysis.** Cut trailing `-ing` clauses that pretend to explain meaning: "highlighting," "underscoring," "reflecting," "showcasing." "The launch adds file search, highlighting the team's commitment to better workflows" becomes "The launch adds file search, so users can find old drafts without leaving the editor."
+
+**Importance puffery.** "Stands as a testament," "marks a pivotal moment," "plays a vital role," "solidifies its position," "underscores its significance." State the fact and let the reader judge whether it matters. "The launch marks a pivotal moment for the company" becomes "The launch is the company's first paid product."
+
+**Interpretive metadiscourse.** Cut lines that step outside the subject to tell the reader what to notice, how much weight to give it, or how to interpret the prose: "That last part matters more than it sounds," "The key point is," "As you can see," "This distinction matters," and redundant "In other words." If the point is clear, delete the aside. Otherwise, replace it with support or facts already in the content.
+
+**Weasel attribution.** "Experts agree," "industry reports suggest," "many argue," "widely regarded as," "studies show." Name the source or cut the claim. If the user has no source, ask instead of inventing one.
+
+**Fake-strong verbs.** Prefer "is" and "has" when they are clearer. "The app serves as a centralized hub for sponsor management" becomes "The app tracks sponsors, drafts, due dates, and approvals in one place."
+
+**Synonym cycling.** If the clear word is right, repeat it. Don't rotate terms for style. "The agent reviews the draft. The assistant scores the piece. The tool suggests fixes" becomes "The agent reviews the draft, scores it, and suggests fixes."
+
+**Negative listing.** "Not a X. Not a Y. A Z." Just say Z.
+
+**Dramatic fragmentation.** "X. And Y. And Z." or "That's it. That's the whole thing." Use complete sentences.
+
+**Robotic rhythm.** Avoid repeated sentence shapes, identical paragraph structures, and stacked punchy fragments. Vary the shape only when it helps the point.
+
+**Rhetorical setups.** "What if I told you...", "Think about it:", "Plot twist:", and self-answered "Question? Answer." pairs. Drop them and make the point.
+
+**Fake-profound kickers.** Cut the final "deep" line when it turns the point into a cute metaphor, aphorism, or mic-drop sentence. Do not rewrite it into a better metaphor. Do not preserve the rhythm. Delete it, then end on the clearest concrete sentence already in the draft. If the ending needs more closure, add a plain takeaway or next action.
+
+**Summary-recap endings.** "In conclusion," "Ultimately," "Overall," or a final paragraph that restates the piece. The reader was just there. End on the last concrete point, takeaway, or next action instead.
+
+**Formatting slop.** Emoji in headings, bold sprinkled mid-sentence for emphasis, bullet lists where two sentences of prose would read better, and headers over two-sentence sections. Format should follow the content, not decorate it.
+
+**Em dashes.** Do not use them as a default rhythm crutch. In short copy, use none. In longer drafts, 1-2 are fine if they clearly beat commas, periods, or parentheses. Remove clusters and decorative dashes.
+
+## Workflow
+
+1. Read the full draft before editing.
+2. Identify the core point and 3-5 voice signals to preserve, such as vocabulary, cadence, bluntness, humor, uncertainty, or digressions. Keep this note internal. If you cannot identify the core point, ask the user.
+3. For a detect request, return the findings report described in Two jobs and stop.
+4. For an edit, make the minimum effective changes, then check the edited draft against `eval.md` yourself.
+5. If any check fails, fix the draft and run the checks again.
+6. Output the full edited draft and a short **What changed** section.

--- a/.claude/skills/no-ai-slop/eval.md
+++ b/.claude/skills/no-ai-slop/eval.md
@@ -1,0 +1,44 @@
+# No AI slop eval
+
+Use this after the rewrite. Answer each check with pass or fail. If any check fails, fix the draft before returning it.
+
+For detect requests, make sure the response names each pattern found with a quoted line and a short fix, without rewriting the draft.
+
+## Editing principles
+
+1. Does the edit preserve the user's point without adding claims, examples, stats, quotes, or opinions?
+2. Does it preserve the writer's distinctive vocabulary, cadence, bluntness, humor, uncertainty, digressions, and level of polish?
+3. Does it leave strong human sentences alone instead of rewriting them for consistency or making every paragraph equally tidy?
+4. Is the amount of cutting proportional to the actual slop, with no aggressive compression that strips out character?
+5. Does the draft lead with what the reader needs while keeping personal setup that adds context, tension, or character?
+6. Are points front-loaded where that improves clarity without forcing every unit into the same structure?
+7. Do sentences earn their place, with concrete facts, protected details, and direct verbs where the draft supports them?
+8. Does every generic sentence pass the portability test, or was it cut or made specific to this subject?
+9. Does the draft use active voice with human subjects where possible?
+10. Does the edit keep useful edge and preserve structure unless the structure was hurting the piece?
+11. Are genuinely tangled sentences fixed while clear spoken cadence, fragments, and changes in pace remain intact?
+
+## Words to cut
+
+1. Are banned words, filler phrases, often-empty adverbs, and inflated claims removed unless quoted as examples?
+
+## Patterns to cut
+
+1. Are binary contrasts, negative listings, rhetorical setups, and throat-clearing openers removed?
+2. Are faux-insight setups, colon reveals, superficial analysis, fake-strong verbs, synonym cycling, dramatic fragments, and robotic rhythm fixed?
+3. Are importance puffery and weasel attribution replaced with plain facts and named sources, or flagged for the user when no source exists?
+4. Is interpretive metadiscourse removed, including authorial metacommentary, reader guidance, emphasis markers, and redundant glossing?
+5. Are fake-profound kicker lines deleted instead of rewritten into better metaphors?
+6. Are summary-recap endings cut so the piece ends on a concrete point, takeaway, or next action?
+7. Is formatting slop removed: Emoji headings, decorative bold, bullets that should be prose, headers over tiny sections?
+8. Are colons sentence case unless grammar, a proper noun, a title, or code requires otherwise?
+9. Are em dashes used sparingly: Usually none in short copy, and only 1-2 in longer drafts when they clearly help?
+
+## Final read
+
+1. Was the edit checked directly against this file without requiring separate editor and evaluator agents?
+2. Does the draft avoid robotic symmetry, repeated sentence shapes, and stacked punchy fragments?
+3. Would the writer recognize the edited draft as their own voice?
+4. Would the edited draft sound natural if read to a sharp colleague?
+5. Does the final output include the full edited draft and a short **What changed** section?
+6. For detect requests, does the response name each pattern with a quoted line and a short fix, without rewriting, scoring, or claiming AI authorship?

--- a/.github/scripts/check-skills-shipped.mjs
+++ b/.github/scripts/check-skills-shipped.mjs
@@ -1,0 +1,58 @@
+/* eslint-env node */
+
+/**
+ * Every skill CLAUDE.md names is in the repository.
+ *
+ * The rule was versioned and the tool was not, and it went wrong twice with
+ * nothing to notice. `humanizer` was named until 2026-08-22 and was never on the
+ * Windows machine. `natural-writing` was written 2026-08-28 and reached that
+ * machine on 2026-09-03, and the Microsoft Store copy was written inside the
+ * gap, without contractions and with a phrase the skill's own examples call out.
+ */
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const claudeMd = join(root, ".claude", "CLAUDE.md");
+const skillsDir = join(root, ".claude", "skills");
+
+const text = readFileSync(claudeMd, "utf8");
+
+/**
+ * Read off the paths rather than the prose. A backticked word is any word;
+ * `.claude/skills/<name>` is a claim that the repository carries it, which is
+ * the thing being checked.
+ */
+const named = new Set(
+  [...text.matchAll(/\.claude\/skills\/([a-z][a-z0-9-]*)/g)].map(([, name]) => name),
+);
+
+assert.ok(named.size > 0, "CLAUDE.md names no skills at all, which means this check stopped working");
+
+const shipped = new Set(
+  readdirSync(skillsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name),
+);
+
+const missing = [...named].filter((name) => !shipped.has(name)).sort();
+
+assert.deepEqual(
+  missing,
+  [],
+  `CLAUDE.md requires these and the repository does not carry them:\n  ${missing.join("\n  ")}\n` +
+    `Shipped: ${[...shipped].sort().join(", ")}`,
+);
+
+// A directory with no SKILL.md is not a skill, it is a folder.
+for (const name of shipped) {
+  assert.ok(
+    existsSync(join(skillsDir, name, "SKILL.md")),
+    `.claude/skills/${name}/ has no SKILL.md`,
+  );
+}
+
+console.log(`skills shipped: ok, ${named.size} required, ${shipped.size} present`);

--- a/.github/workflows/discord-ci-notify.yml
+++ b/.github/workflows/discord-ci-notify.yml
@@ -15,9 +15,11 @@ on:
       - Avatar parity
       - Permission labels
       - Publish snap to the Snap Store
+      - Publish the Homebrew cask
       - Publish to the AUR
       - Release Client
       - Release Server
+      - Skills shipped
       - Store auth check
       - Store cancel pending submission
       - Sync Vikunja task

--- a/.github/workflows/skills-shipped.yml
+++ b/.github/workflows/skills-shipped.yml
@@ -1,0 +1,37 @@
+name: Skills shipped
+
+# CLAUDE.md requires two prose skills on everything that leaves the repository.
+# Both used to be installed per machine, and twice a machine did not have one:
+# nothing failed, the copy just went out unedited.
+
+on:
+  pull_request:
+    paths:
+      - .claude/CLAUDE.md
+      - .claude/skills/**
+      - .github/scripts/check-skills-shipped.mjs
+      - .github/workflows/skills-shipped.yml
+
+  push:
+    branches: [main]
+    paths:
+      - .claude/CLAUDE.md
+      - .claude/skills/**
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  skills-shipped:
+    name: Skills shipped
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: node .github/scripts/check-skills-shipped.mjs


### PR DESCRIPTION
CLAUDE.md requires `no-ai-slop` and `natural-writing` on every piece of prose that leaves the repository. Neither was in the repository. Both lived in `~/.claude/skills` on one Mac, so every other machine and every fresh agent started non-compliant with nothing saying so.

The repo shipped one skill: `changelog-notes`. It ships four now.

## This already went wrong twice

CLAUDE.md records both, which is how I found it:

- `humanizer` was named in the rules until 2026-08-22 and was never on the Windows machine, so nothing ran it.
- `natural-writing` was written 2026-08-28 and reached that machine on 2026-09-03. For six days the rule asked for two skills and one existed. The Microsoft Store listing copy was written on 2026-09-02, inside that gap: no contractions across 1700 characters, and "persistent channels" still in it — a phrase in the skill's own examples, with the fix next to it.

The rule was versioned. The thing enforcing it was not.

## What is here

| Skill | Source | Licence |
|---|---|---|
| `natural-writing` | yours | — |
| `no-ai-slop` | [petergyang/no-ai-slop](https://github.com/petergyang/no-ai-slop) | MIT |
| `caveman` | [JuliusBrussee/skills](https://github.com/JuliusBrussee/skills) | MIT |

Both licences were checked before copying rather than assumed. Each vendored skill carries its upstream `LICENSE` and an `ATTRIBUTION.md` saying where it came from and that the copy does not sync back.

`caveman` is the reply style, and CLAUDE.md says what it is not: it is for chat, and committed prose still goes through the other two. **Only that one skill** — `npx skills add JuliusBrussee/caveman` installs twenty, including eleven `caveman-*` variants and several tied to a hosted product. The rest are unread and not here.

## The check

`check-skills-shipped.mjs` reads the `.claude/skills/<name>` paths out of CLAUDE.md and fails when the repository does not carry one, or when a skill directory has no `SKILL.md`. It reads paths rather than backticked words, because a backticked word is any word and a path is a claim about what ships.

## One thing found on the way

**`Publish the Homebrew cask` was missing from `discord-ci-notify.yml`.** I added that workflow yesterday in #227 and did not list it, so it would have notified nobody. Both it and the new one are listed now, and I checked the remaining eleven — all present.

## What to look at

The check keys off CLAUDE.md's own paths, so editing the prose to mention a skill is what makes it required — and removing a mention silently removes the requirement. That is the behaviour I wanted, but it is your file, so worth agreeing with.

`hallmark`, `information-architecture` and `humanizer` are on this machine and CLAUDE.md does not require them, so they are not here.

## Verified

- Three mutations, all caught: deleting a required skill, a skill directory with no `SKILL.md`, and pointing CLAUDE.md at one the repo does not ship.
- `node .github/scripts/check-skills-shipped.mjs` → `ok, 4 required, 4 present`.
- The workflow YAML parses, and every workflow name in the repo is now in the notify list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
