### PR TITLE
Publish to winget on every release (GRYT-1021)

### DIFF
--- a/.github/scripts/check-winget-manifests.mjs
+++ b/.github/scripts/check-winget-manifests.mjs
@@ -1,0 +1,68 @@
+/* eslint-env node */
+
+/**
+ * The winget manifests match Microsoft's schema, with the placeholders filled.
+ *
+ * Two things this catches that reading them does not. A bare 64-zero checksum
+ * parses as the integer 0 rather than a string, so the file is invalid as
+ * committed and the error only appears at submission. And the three manifests
+ * carry the version three times, so one that stops being rewritten points at a
+ * release that does not exist.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dir = join(root, "packaging", "winget");
+
+const FILES = {
+  "Gryt.GrytChat.yaml": "version",
+  "Gryt.GrytChat.installer.yaml": "installer",
+  "Gryt.GrytChat.locale.en-US.yaml": "defaultLocale",
+};
+
+const PLACEHOLDER_VERSION = "0.0.0";
+const PLACEHOLDER_SHA = "0".repeat(64);
+
+for (const [file, type] of Object.entries(FILES)) {
+  const text = readFileSync(join(dir, file), "utf8");
+
+  assert.match(
+    text,
+    /^PackageIdentifier: Gryt\.GrytChat$/m,
+    `${file}: every manifest carries the same PackageIdentifier`,
+  );
+  assert.match(text, new RegExp(`^ManifestType: ${type}$`, "m"), `${file}: wrong ManifestType`);
+  assert.match(text, /^ManifestVersion: \d+\.\d+\.\d+$/m, `${file}: no ManifestVersion`);
+  assert.match(
+    text,
+    new RegExp(`^PackageVersion: ${PLACEHOLDER_VERSION.replace(/\./g, "\\.")}$`, "m"),
+    `${file}: PackageVersion is not the placeholder the workflow rewrites`,
+  );
+}
+
+const installer = readFileSync(join(dir, "Gryt.GrytChat.installer.yaml"), "utf8");
+
+// Quoted, or YAML reads it as a number and the schema rejects it.
+assert.match(
+  installer,
+  new RegExp(`InstallerSha256: "${PLACEHOLDER_SHA}"`),
+  "the checksum placeholder must be quoted, or YAML parses 64 zeros as the integer 0",
+);
+
+assert.ok(
+  installer.includes(`releases/download/v${PLACEHOLDER_VERSION}/`) &&
+    installer.includes(`Gryt-Chat-${PLACEHOLDER_VERSION}-win-x64-slim.exe`),
+  "the installer URL must carry the version placeholder twice, tag and filename",
+);
+
+// Slim, matching the site and the Homebrew cask.
+assert.ok(
+  !installer.includes("-win-x64.exe"),
+  "the installer points at the full build; the site and the cask ship slim",
+);
+
+console.log(`winget manifests: ok, ${Object.keys(FILES).length} files`);

--- a/.github/workflows/discord-ci-notify.yml
+++ b/.github/workflows/discord-ci-notify.yml
@@ -17,9 +17,10 @@ on:
       - Publish snap to the Snap Store
       - Publish the Homebrew cask
       - Publish to the AUR
+      - Publish to winget
       - Release Client
       - Release Server
-      - Skills shipped
+      - Repo checks
       - Store auth check
       - Store cancel pending submission
       - Sync Vikunja task

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,109 @@
+name: Publish to winget
+
+# packaging/winget/ is the source of truth. The three manifests are copied and
+# their version, URL and checksum rewritten, then wingetcreate opens a pull
+# request against microsoft/winget-pkgs.
+#
+# Unlike the AUR and the tap, the far end is somebody else's review queue. The
+# first submission of a new package is read by a person, and Gryt has a history
+# there worth not repeating: GRYT-969.
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish, e.g. v1.9.24'
+        required: true
+        type: string
+
+concurrency:
+  group: publish-winget
+  cancel-in-progress: true
+
+jobs:
+  publish-winget:
+    name: Publish to winget
+    runs-on: windows-latest
+
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !contains(github.event.release.tag_name, '-beta')
+
+    timeout-minutes: 20
+
+    env:
+      OWNER: Gryt-chat
+      REPO: gryt
+      TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      PACKAGE: Gryt.GrytChat
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the manifests for this release
+        id: build
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${TAG#v}"
+          EXE="Gryt-Chat-${VERSION}-win-x64-slim.exe"
+
+          gh release download "$TAG" --repo "$OWNER/$REPO" \
+            --pattern 'SHA256SUMS.txt' --dir .
+
+          SUM="$(awk -v f="$EXE" '$2 == f { print $1 }' SHA256SUMS.txt)"
+
+          if [[ -z "$SUM" ]]; then
+            echo "::error::SHA256SUMS.txt for $TAG has no entry for $EXE."
+            exit 1
+          fi
+
+          # winget wants the date the release went out, not the day this runs.
+          DATE="$(gh release view "$TAG" --repo "$OWNER/$REPO" --json publishedAt --jq '.publishedAt[:10]')"
+
+          mkdir -p out
+          cp packaging/winget/*.yaml out/
+
+          # Uppercase, because that is what a sha256 field is checked against.
+          SUM_UPPER="$(echo "$SUM" | tr 'a-f' 'A-F')"
+
+          for f in out/*.yaml; do
+            sed -i \
+              -e "s|0\.0\.0|${VERSION}|g" \
+              -e "s|0\{64\}|${SUM_UPPER}|" \
+              -e "s|1970-01-01|${DATE}|" \
+              "$f"
+          done
+
+          echo "Manifests now say:"
+          grep -hE 'PackageVersion|InstallerUrl|InstallerSha256|ReleaseDate' out/*.yaml
+
+          # A sed that matched nothing leaves a placeholder, which would submit
+          # a manifest pointing at version 0.0.0.
+          ! grep -qE '0\.0\.0|0{64}|1970-01-01' out/*.yaml
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Submit to microsoft/winget-pkgs
+        shell: bash
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_PKGS_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${WINGET_TOKEN:-}" ]]; then
+            echo "WINGET_PKGS_TOKEN is not set, skipping winget."
+            echo "The manifests were built and validated; nothing was submitted."
+            exit 0
+          fi
+
+          winget install --id Microsoft.WingetCreate --exact --silent \
+            --accept-source-agreements --accept-package-agreements
+
+          wingetcreate submit --token "$WINGET_TOKEN" out

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -1,22 +1,24 @@
-name: Skills shipped
+name: Repo checks
 
-# CLAUDE.md requires two prose skills on everything that leaves the repository.
-# Both used to be installed per machine, and twice a machine did not have one:
-# nothing failed, the copy just went out unedited.
+# Small checks on things nothing else reads: the skills CLAUDE.md requires, and
+# the winget manifests, which are otherwise only validated at submission.
 
 on:
   pull_request:
     paths:
       - .claude/CLAUDE.md
       - .claude/skills/**
+      - packaging/winget/**
       - .github/scripts/check-skills-shipped.mjs
-      - .github/workflows/skills-shipped.yml
+      - .github/scripts/check-winget-manifests.mjs
+      - .github/workflows/repo-checks.yml
 
   push:
     branches: [main]
     paths:
       - .claude/CLAUDE.md
       - .claude/skills/**
+      - packaging/winget/**
 
   workflow_dispatch:
 
@@ -24,8 +26,8 @@ permissions:
   contents: read
 
 jobs:
-  skills-shipped:
-    name: Skills shipped
+  repo-checks:
+    name: Repo checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -35,3 +37,4 @@ jobs:
         with:
           node-version: 24
       - run: node .github/scripts/check-skills-shipped.mjs
+      - run: node .github/scripts/check-winget-manifests.mjs

--- a/packaging/winget/Gryt.GrytChat.installer.yaml
+++ b/packaging/winget/Gryt.GrytChat.installer.yaml
@@ -1,0 +1,22 @@
+# Installer manifest. publish-winget.yml rewrites PackageVersion,
+# InstallerUrl and InstallerSha256.
+#
+# The installers are unsigned until GRYT-848 buys a certificate, so there is no
+# SignatureSha256 and SmartScreen warns on first run.
+PackageIdentifier: Gryt.GrytChat
+PackageVersion: 0.0.0
+InstallerType: nullsoft
+# electron-builder builds oneClick with perMachine false, so it installs into
+# the user profile and never asks for elevation.
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: "1970-01-01"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Gryt-chat/gryt/releases/download/v0.0.0/Gryt-Chat-0.0.0-win-x64-slim.exe
+    InstallerSha256: "0000000000000000000000000000000000000000000000000000000000000000"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/Gryt.GrytChat.locale.en-US.yaml
+++ b/packaging/winget/Gryt.GrytChat.locale.en-US.yaml
@@ -1,0 +1,45 @@
+# Locale manifest, the listing itself. publish-winget.yml rewrites
+# PackageVersion and ReleaseNotesUrl.
+PackageIdentifier: Gryt.GrytChat
+PackageVersion: 0.0.0
+PackageLocale: en-US
+Publisher: Gryt
+PublisherUrl: https://gryt.chat/
+PublisherSupportUrl: https://github.com/Gryt-chat/gryt/issues
+PackageName: Gryt Chat
+PackageUrl: https://gryt.chat/
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/Gryt-chat/gryt/blob/main/LICENSE
+Copyright: Copyright (c) Gryt
+ShortDescription: Voice and text chat you host yourself
+Description: |-
+  Gryt is a place a community sits in. The channels and roles stay put, and
+  people drop in when they feel like it.
+
+  You run the server. Point the app at a machine you control, and a spare PC in
+  the corner counts. That is where the messages live, so there is no company
+  holding them and no trial tier that expires.
+
+  Voice goes over WebRTC through an SFU, so one server relays the audio and a
+  call with eight people in it does not turn into eight separate uploads from
+  your laptop. Screen sharing takes the audio with it, and video works the same
+  way.
+
+  Messages are encrypted and the keys are yours. Your identity is a keypair the
+  app makes and keeps on your device, not an account somebody else can lock you
+  out of.
+
+  The whole thing is open source under the AGPL: the desktop client, the server,
+  the media server and the docs.
+Moniker: gryt
+Tags:
+  - chat
+  - voice
+  - voip
+  - self-hosted
+  - open-source
+  - webrtc
+  - screen-sharing
+ReleaseNotesUrl: https://github.com/Gryt-chat/gryt/releases/tag/v0.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/Gryt.GrytChat.yaml
+++ b/packaging/winget/Gryt.GrytChat.yaml
@@ -1,0 +1,6 @@
+# Version manifest. publish-winget.yml rewrites PackageVersion.
+PackageIdentifier: Gryt.GrytChat
+PackageVersion: 0.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Windows already has the Microsoft Store, so this is about being found rather than filling a gap. People browse these catalogues.

Three manifests in `packaging/winget/` where changing them is a reviewed PR, a workflow that rewrites version, URL, checksum and release date, and `wingetcreate` opening the PR against `microsoft/winget-pkgs`.

## Checked against v1.9.24, not assumed

**The Windows installers are not signed.** The certificate table in `Gryt-Chat-1.9.24-win-x64-slim.exe` is offset 0, size 0 — read off the PE header over a range request rather than downloading 96MB to find out. winget accepts unsigned installers, SmartScreen warns on them, and reviewers may raise it. GRYT-848 is the certificate. Worth knowing before submitting.

**`InstallerType: nullsoft`, `Scope: user`**, because electron-builder builds NSIS `oneClick` with `perMachine: false`. Read off `electron-builder.yml` rather than guessed.

## A bug the schema caught

The checksum placeholder is quoted. Sixty-four zeros unquoted parse as the integer `0`:

```
['Installers', 0, 'InstallerSha256'] 0 is not of type 'string'
```

So the file was invalid as committed, and it would only have surfaced at submission. `check-winget-manifests.mjs` holds that, plus three other things nothing else reads.

## Submission still needs a person

The workflow builds and validates the manifests with no token and submits nothing — same dormant-until-credentials pattern as the Snap, Store and Homebrew steps. Set `WINGET_PKGS_TOKEN` when you want it live.

The first submission of a new package is read by a human, and Gryt has history there (GRYT-969), so that first one is yours or Carlo's rather than a workflow's.

## Verified

Against Microsoft's own published v1.6.0 JSON schemas, fetched from `microsoft/winget-cli`:

- All three manifests validate, as committed and again after simulating the release rewrite with real v1.9.24 values.
- The rewritten `InstallerUrl` returns 200 and serves 96,733,863 bytes, and the downloaded file hashes to exactly the checksum the manifest carries.
- Four mutations, all caught: unquoted checksum, pointing at the full build instead of slim, a manifest that stops being rewritten, and the identifier drifting between files.
- Every workflow in the repo is in the notify list, checked again.

`skills-shipped.yml` becomes `repo-checks.yml` now that it runs two.

## What to look at

**It ships the slim build**, matching the site and the Homebrew cask. The AUR still ships full. Nobody chose that split and it is worth one answer rather than a third opinion here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
