### PR TITLE
Drop the deprecated verified stanza from the cask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ snapcraft-creds
 # Claude Code local settings (CLAUDE.md itself is tracked)
 .claude/settings.local.json
 
+# `npx skills add` writes these into whatever directory it runs in. The skills
+# that ship live in .claude/skills/ and are tracked; a per-machine install is
+# not, and untracked files here get swept up by a stray `git add -A`.
+.agents/
+skills-lock.json
+
 # Env files (never commit secrets)
 .env
 .env.*

--- a/packaging/homebrew/gryt-chat.rb
+++ b/packaging/homebrew/gryt-chat.rb
@@ -4,8 +4,7 @@ cask "gryt-chat" do
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"
 
   # Slim, matching what the site hands over by default.
-  url "https://github.com/Gryt-chat/gryt/releases/download/v#{version}/Gryt-Chat-#{version}-mac-arm64-slim.dmg",
-      verified: "github.com/Gryt-chat/gryt/"
+  url "https://github.com/Gryt-chat/gryt/releases/download/v#{version}/Gryt-Chat-#{version}-mac-arm64-slim.dmg"
   name "Gryt Chat"
   desc "Real-time voice chat"
   homepage "https://gryt.chat/"


### PR DESCRIPTION
The tap is live and serving 1.9.24. Running `brew info --cask gryt-chat` against it warns on every invocation:

```
Warning: Calling the `verified` parameter in the `url` stanza is deprecated!
Use the default URL verification behaviour instead.
```

`brew audit --strict` did not catch this when I checked the cask in a throwaway local tap before #227, and `brew style` still does not. Only loading it from a real tap surfaces it — which running the publisher for v1.9.24 is what made possible.

The default behaviour it points at is the same check by another route: the URL host has to match the homepage or be a known host, and `github.com` is one.

Verified against the live tap with the fix applied: `brew info` clean, `brew style` no offences, `brew audit --cask --strict` exit 0.

## Also here

`.gitignore` for `.agents/` and `skills-lock.json`. `npx skills add` writes those into whatever directory it runs in, and it ran in a worktree. The skills that ship are tracked under `.claude/skills/`; a per-machine install is not, and untracked files in the tree are what a stray `git add -A` sweeps up — which CLAUDE.md warns about for exactly this reason.

Small and unrelated to the cask, but both are one-line consequences of yesterday's two merges rather than new work.

## Not fixed here, and worth deciding

**Homebrew 6.0.22 refuses casks from untrusted third-party taps.** A first-time user gets:

```
Refusing to load cask gryt-chat/tap/gryt-chat from untrusted tap gryt-chat/tap.
Run `brew trust --cask gryt-chat/tap/gryt-chat` or `brew trust gryt-chat/tap` to trust it.
Error: Cannot tap gryt-chat/tap: invalid syntax in tap!
```

So `brew install --cask Gryt-chat/tap/gryt-chat` does not work on its own, and the second line makes it look like the cask is broken rather than untrusted. The tap README needs the `brew trust` step, and so does the site's macOS download page if the tap is ever linked from it. Tracked as GRYT-1024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
