### PR TITLE
Fail when the socket API stops being described (GRYT-1028)

### DIFF
--- a/.github/scripts/check-socket-coverage.mjs
+++ b/.github/scripts/check-socket-coverage.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Does `build/server-api` still describe every socket event the server has?
+ *
+ * The page is hand-written, unlike the three generated reference pages beside
+ * it, and it had fallen to 114 of 211 events without anything noticing. Whole
+ * features were missing — direct messages, threads, forums and calls, all four
+ * of which are documented now.
+ *
+ * It is not generated, deliberately. The page is organised by what somebody is
+ * trying to do (Joining, Sessions, Chat, Voice, Moderation) and reads well;
+ * generating it would trade that for an alphabetical list of 211 rows. Nothing
+ * in it is wrong. So this checks coverage and leaves the writing alone.
+ *
+ * Run it with --list to see what is missing rather than only how much.
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const SERVER = "packages/server/src";
+const PAGE = "packages/docs/content/docs/build/server-api.mdx";
+
+/**
+ * Events the server never speaks, so their absence is not a gap.
+ *
+ * `connect`, `disconnect` and friends are Socket.IO's own, documented by
+ * Socket.IO. The rest are names built at runtime from a variable, which this
+ * cannot resolve and a reader would not look up.
+ */
+const NOT_OURS = new Set([
+  "connect", "disconnect", "connect_error", "disconnecting", "error",
+]);
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".ts") && !p.endsWith(".test.ts")) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Three registration styles, because the server uses all three.
+ *
+ *   'chat:send': async (payload) => {}     a key in an EventHandlerMap
+ *   socket.on("session:restore", ...)      registered directly
+ *   socket.emit("member:joined", ...)      server to client
+ *
+ * A first pass at this counted only the first style and reported that two
+ * documented events did not exist. Both were real, registered the second way.
+ */
+function eventsInSource() {
+  const found = new Map();
+
+  for (const file of walk(SERVER)) {
+    const text = readFileSync(file, "utf8");
+    const short = file.replace(`${SERVER}/`, "");
+
+    const add = (name, kind) => {
+      if (NOT_OURS.has(name)) return;
+      if (!found.has(name)) found.set(name, { kind, file: short });
+    };
+
+    for (const m of text.matchAll(/^\s*['"]([a-z][a-zA-Z]*:[a-zA-Z:_.-]+)['"]\s*:/gm)) {
+      add(m[1], "handler");
+    }
+    for (const m of text.matchAll(/\.on\(\s*['"]([a-z][a-zA-Z]*:[a-zA-Z:_.-]+)['"]/g)) {
+      add(m[1], "handler");
+    }
+    /* Any emit-ish call, not only `.emit(`. calls.ts sends through a local
+       `emitTo(userId, "call:incoming", …)` helper, and matching `.emit(` alone
+       missed call:incoming, call:ringing and call:withdrawn — three events the
+       client listens for. */
+    for (const m of text.matchAll(/emit[A-Za-z]*\(\s*(?:[^,()]{1,60},\s*)?['"]([a-zA-Z]+:[a-zA-Z:_.-]+)['"]/g)) {
+      add(m[1], "emit");
+    }
+  }
+
+  return found;
+}
+
+/** Anything in a backtick on the page counts as documented. */
+function eventsInPage() {
+  const text = readFileSync(PAGE, "utf8");
+  return new Set(
+    [...text.matchAll(/`([a-zA-Z]+:[a-zA-Z:_.-]+)`/g)].map((m) => m[1]),
+  );
+}
+
+const source = eventsInSource();
+const documented = eventsInPage();
+
+const missing = [...source.keys()].filter((e) => !documented.has(e)).sort();
+const stale = [...documented].filter((e) => !source.has(e)).sort();
+
+const covered = source.size - missing.length;
+const pct = Math.round((covered / source.size) * 100);
+
+console.log(`socket coverage: ${covered}/${source.size} events documented (${pct}%)`);
+
+if (stale.length > 0) {
+  console.log(`\n${stale.length} documented but not in the source:`);
+  for (const e of stale) console.log(`  ${e}`);
+}
+
+if (missing.length > 0) {
+  const byPrefix = new Map();
+  for (const e of missing) {
+    const p = e.split(":")[0];
+    byPrefix.set(p, (byPrefix.get(p) ?? 0) + 1);
+  }
+
+  console.log(`\n${missing.length} in the source, not on the page:`);
+  for (const [p, n] of [...byPrefix].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(n).padStart(3)}  ${p}:*`);
+  }
+
+  if (process.argv.includes("--list")) {
+    console.log();
+    for (const e of missing) console.log(`  ${e.padEnd(34)} ${source.get(e).file}`);
+  } else {
+    console.log("\nRun with --list to see them, and which file each is in.");
+  }
+}
+
+/**
+ * A floor rather than a target.
+ *
+ * Failing on anything under 100% would mean this check goes red the moment
+ * somebody adds an event, which trains people to ignore it — and the page then
+ * rots anyway. A floor fails only when coverage gets worse than it is today,
+ * so the number can be raised as the page catches up, and never silently slips.
+ */
+const FLOOR = 70;
+
+if (stale.length > 0) {
+  console.error(`\nThe page describes ${stale.length} events the server does not have.`);
+  process.exit(1);
+}
+
+if (pct < FLOOR) {
+  console.error(`\nCoverage fell below ${FLOOR}%. Document the new events, or say why not.`);
+  process.exit(1);
+}

--- a/.github/workflows/api-reference.yml
+++ b/.github/workflows/api-reference.yml
@@ -66,9 +66,11 @@ jobs:
           #
           # A path-limited checkout on a blobless clone fetches the few blobs
           # each side needs and nothing else. docs takes the whole content tree
-          # because the generator writes into it and then diffs what it wrote.
+          # because the generator writes into it and then diffs what it wrote,
+          # and server takes all of src because the socket coverage check has to
+          # find handlers and emits across every handler file, not just plugins.
           for entry in \
-            "server:src/plugins" \
+            "server:src" \
             "client:src/packages/addons/src" \
             "bot:src" \
             "docs:content/docs"
@@ -102,3 +104,10 @@ jobs:
       - name: Compare
         shell: bash
         run: node .github/scripts/generate-api-reference.mjs --check
+
+      # server-api is the one reference page still written by hand, so nothing
+      # stops it falling behind. It had reached 114 of 211 socket events with
+      # whole features missing before anybody counted.
+      - name: Check the socket API is still fully described
+        shell: bash
+        run: node .github/scripts/check-socket-coverage.mjs


### PR DESCRIPTION
`server-api` is the one reference page still written by hand. The three beside it are generated, and CI fails when they drift. This one had nothing — it reached **114 of 211 events** with direct messages, calls, threads and forums missing entirely before anybody counted.

```
socket coverage: 147/211 events documented (70%)

64 in the source, not on the page:
   35  server:*
    7  user:*
    6  voice:*
    ...
Run with --list to see them, and which file each is in.
```

## It stays hand-written, deliberately

The page is organised by what somebody is trying to do — Joining, Sessions, Chat, Voice, Moderation — and generating it would trade that for an alphabetical list of 211 rows. Nothing in it is wrong. Coverage was the only problem, so this counts coverage and leaves the writing alone.

**A floor, not a target.** Requiring 100% would go red the moment anybody adds an event, which teaches people to ignore it and lets the page rot anyway. 70% is where the page lands after [docs#101](https://github.com/Gryt-chat/docs/pull/101), so it fails only when coverage gets *worse*, and the number goes up as the page catches up.

It also fails on the opposite mistake: an event described on the page that the server doesn't have.

## Three wrong answers before the right one

The extractor looks the way it does because of them, and they're the reason this took measuring rather than grepping:

- **macOS `grep -E` has no `\s`** — the first count silently matched nothing and looked like a finding
- **Handlers registered as `socket.on` in `socket/index.ts`** aren't in any handler map. Missing them reported `server:identify` and `session:restore` as non-existent; both are real
- **`calls.ts` sends through a local `emitTo` helper**, so matching `.emit(` missed three events the client listens for

## One CI change

The compare job now checks out all of `server:src` rather than `src/plugins`, because handlers and emits are spread across every handler file. It's a blobless clone, so the cost is small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)