### PR TITLE
Ship the slim client on the AUR too, and let a private snap publish (GRYT-1037)

### DIFF
--- a/.github/scripts/check-aur-pkgbuilds.mjs
+++ b/.github/scripts/check-aur-pkgbuilds.mjs
@@ -1,0 +1,93 @@
+/* eslint-env node */
+
+/**
+ * The two AUR PKGBUILDs are the same package twice, so they have to stay that
+ * way apart from four lines.
+ *
+ * They are separate files rather than one generated from the other because the
+ * AUR takes a literal PKGBUILD and publish-aur.yml copies one over. Nothing at
+ * publish time compares them, and a depends= added to one and not the other
+ * builds fine and installs a package missing a library.
+ *
+ * Also holds the three lines publish-aur.yml rewrites with anchored seds. Rename
+ * one and the sed matches nothing, which publishes a package pointing at an old
+ * release rather than failing.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "packaging", "aur");
+
+const FULL = "gryt-chat-bin";
+const SLIM = "gryt-chat-slim-bin";
+
+const full = readFileSync(join(dir, "PKGBUILD"), "utf8");
+const slim = readFileSync(join(dir, "PKGBUILD.slim"), "utf8");
+
+const ALLOWED_TO_DIFFER = ["pkgname=", "pkgdesc=", "conflicts=", "source="];
+
+// Comments carry the difference between the two headers, and blank lines move
+// with them.
+const code = (text) =>
+  text
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line !== "" && !line.trimStart().startsWith("#"));
+
+const a = code(full);
+const b = code(slim);
+
+assert.equal(
+  a.length,
+  b.length,
+  `PKGBUILD has ${a.length} lines of code and PKGBUILD.slim has ${b.length}`,
+);
+
+for (const [i, line] of a.entries()) {
+  if (line === b[i]) continue;
+
+  assert.ok(
+    ALLOWED_TO_DIFFER.some((key) => line.startsWith(key) && b[i].startsWith(key)),
+    `the two PKGBUILDs differ on a line that is not one of ${ALLOWED_TO_DIFFER.join(", ")}:\n` +
+      `  PKGBUILD:      ${line}\n` +
+      `  PKGBUILD.slim: ${b[i]}`,
+  );
+}
+
+for (const [name, text, pkgname, other] of [
+  ["PKGBUILD", full, FULL, SLIM],
+  ["PKGBUILD.slim", slim, SLIM, FULL],
+]) {
+  assert.match(text, new RegExp(`^pkgname=${pkgname}$`, "m"), `${name}: wrong pkgname`);
+
+  // Both install /opt/Gryt Chat, so installing one over the other silently
+  // overwrites its files.
+  assert.match(
+    text,
+    new RegExp(`^conflicts=\\(.*'${other}'.*\\)$`, "m"),
+    `${name}: must declare ${other} in conflicts`,
+  );
+  assert.match(text, /^provides=\('gryt-chat'\)$/m, `${name}: must provide gryt-chat`);
+
+  // publish-aur.yml rewrites these three by anchored sed and then greps to
+  // confirm the rewrite landed.
+  assert.match(text, /^pkgver=\d+\.\d+\.\d+$/m, `${name}: no pkgver for the workflow to rewrite`);
+  assert.match(text, /^pkgrel=\d+$/m, `${name}: no pkgrel for the workflow to rewrite`);
+  assert.match(text, /^sha256sums=\('SKIP'\)$/m, `${name}: sha256sums is not the placeholder`);
+}
+
+const sourceOf = (text) => text.match(/^source=\("(.+)"\)$/m)?.[1];
+
+assert.ok(
+  sourceOf(full)?.endsWith("-linux-amd64.deb"),
+  "PKGBUILD must build from the full deb",
+);
+assert.ok(
+  sourceOf(slim)?.endsWith("-linux-amd64-slim.deb"),
+  "PKGBUILD.slim must build from the slim deb",
+);
+
+console.log(`AUR PKGBUILDs: ok, ${FULL} and ${SLIM} agree`);

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -24,8 +24,25 @@ concurrency:
 
 jobs:
   publish-aur:
-    name: Publish to the AUR
+    name: Publish ${{ matrix.variant }} to the AUR
     runs-on: ubuntu-latest
+
+    # Both variants. The AUR creates the repository on first push, so the slim
+    # package needs no account work -- unlike a snap name, which is global.
+    #
+    # Independent jobs: slim failing must not stop full publishing.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: full
+            pkg: gryt-chat-bin
+            pkgbuild: PKGBUILD
+            suffix: ""
+          - variant: slim
+            pkg: gryt-chat-slim-bin
+            pkgbuild: PKGBUILD.slim
+            suffix: "-slim"
 
     # A `release` event does not know which dispatch produced it, so the channel
     # is read off the tag. Betas do not go in `gryt-chat-bin`.
@@ -40,7 +57,9 @@ jobs:
       OWNER: Gryt-chat
       REPO: gryt
       TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
-      AUR_PKG: gryt-chat-bin
+      AUR_PKG: ${{ matrix.pkg }}
+      PKGBUILD_FILE: ${{ matrix.pkgbuild }}
+      SUFFIX: ${{ matrix.suffix }}
 
     steps:
       - name: Check out the AUR package
@@ -88,7 +107,7 @@ jobs:
           set -euo pipefail
 
           VERSION="${TAG#v}"
-          DEB="Gryt-Chat-${VERSION}-linux-amd64.deb"
+          DEB="Gryt-Chat-${VERSION}-linux-amd64${SUFFIX}.deb"
 
           gh release download "$TAG" \
             --repo "$OWNER/$REPO" \
@@ -102,16 +121,16 @@ jobs:
           # before this file existed fall back to main; without that the first
           # release after it landed could not publish at all.
           at() {
-            gh api "repos/$OWNER/$REPO/contents/packaging/aur/PKGBUILD?ref=$1" \
+            gh api "repos/$OWNER/$REPO/contents/packaging/aur/${PKGBUILD_FILE}?ref=$1" \
               --jq '.content' 2>/dev/null | base64 -d
           }
 
           if at "$TAG" > pkgbuild.candidate && [[ -s pkgbuild.candidate ]]; then
-            echo "Using packaging/aur/PKGBUILD from $TAG."
+            echo "Using packaging/aur/${PKGBUILD_FILE} from $TAG."
           elif at main > pkgbuild.candidate && [[ -s pkgbuild.candidate ]]; then
-            echo "$TAG predates packaging/aur/PKGBUILD. Using main's."
+            echo "$TAG predates packaging/aur/${PKGBUILD_FILE}. Using main's."
           else
-            echo "::error::No packaging/aur/PKGBUILD at $TAG or on main."
+            echo "::error::No packaging/aur/${PKGBUILD_FILE} at $TAG or on main."
             exit 1
           fi
 

--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -113,27 +113,43 @@ jobs:
           snapcraft --version
 
       # A snap name is global and has to be registered in the Store before
-      # anything can be pushed to it. Checked against the public API rather than
-      # discovered as an upload failure, so an unregistered variant skips with a
+      # anything can be pushed to it, so an unregistered variant skips with a
       # notice instead of turning every release red.
+      #
+      # Asked as the publisher, not through the public API. api.snapcraft.io only
+      # knows about snaps that are public and have a released revision, so a name
+      # that is registered but private answers 404 there — which is exactly the
+      # state a new variant is in before its first upload. Measured on
+      # gryt-chat-slim on 2026-09-08: registered, private, 404. The public check
+      # this replaces would have skipped it on every release forever, and the
+      # skip is what stops the upload that would let it be made public.
       - name: Is this snap name registered
         id: registered
         shell: bash
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: |
           set -euo pipefail
 
-          # The status code, not curl's -f. 200 is registered, 404 is not, and
-          # anything else is the Store having a bad day rather than an answer.
-          CODE="$(curl -s -o /dev/null -w '%{http_code}' \
-            -H 'Snap-Device-Series: 16' \
-            "https://api.snapcraft.io/v2/snaps/info/${SNAP_NAME}")"
+          if [[ -z "${SNAPCRAFT_STORE_CREDENTIALS:-}" ]]; then
+            echo "yes=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::SNAPCRAFT_STORE_CREDENTIALS is not set, skipping the Store."
+            exit 0
+          fi
 
-          if [[ "$CODE" == "200" ]]; then
+          snapcraft names > names.txt
+
+          echo "Names registered to this account:"
+          cat names.txt
+
+          # Column 1 is the name in both the table and its header. Matched as a
+          # whole field so gryt-chat does not match gryt-chat-slim.
+          if awk -v n="$SNAP_NAME" '$1 == n { found = 1 } END { exit !found }' names.txt; then
             echo "yes=true" >> "$GITHUB_OUTPUT"
           else
             echo "yes=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::${SNAP_NAME} is not registered in the Snap Store (HTTP ${CODE}), skipping."
-            echo "Register it with: snapcraft register ${SNAP_NAME}"
+            echo "::notice::${SNAP_NAME} is not registered to this account, skipping."
+            echo "Register it at https://snapcraft.io/account/register-snap"
           fi
 
       - name: Download the snap from the release
@@ -299,21 +315,55 @@ jobs:
           VERSION="${TAG#v}"
 
           # The Store's own caches take a moment to catch up with a release.
+          SEEN=""
           for attempt in $(seq 1 10); do
-            LIVE="$(
-              curl -sfS -H "Snap-Device-Series: 16" \
-                "https://api.snapcraft.io/v2/snaps/info/$SNAP_NAME?fields=version" \
-                | python3 -c "import json,sys; m=json.load(sys.stdin).get('channel-map',[]); print(next((c['version'] for c in m if c['channel']['name']=='stable' and c['channel']['architecture']=='amd64'), ''))" 2>/dev/null || true
-            )"
+            CODE="$(curl -s -o info.json -w '%{http_code}' \
+              -H "Snap-Device-Series: 16" \
+              "https://api.snapcraft.io/v2/snaps/info/$SNAP_NAME?fields=version")"
+
+            if [[ "$CODE" == "200" ]]; then
+              SEEN=yes
+              LIVE="$(
+                python3 -c "import json,sys; m=json.load(open('info.json')).get('channel-map',[]); print(next((c['version'] for c in m if c['channel']['name']=='stable' and c['channel']['architecture']=='amd64'), ''))" 2>/dev/null || true
+              )"
+
+              if [[ "$LIVE" == "$VERSION" ]]; then
+                echo "latest/stable on amd64 is $LIVE. Correct."
+                exit 0
+              fi
+
+              echo "Attempt $attempt: latest/stable is \"${LIVE:-unknown}\", waiting for $VERSION."
+            else
+              echo "Attempt $attempt: the public API answers HTTP $CODE for $SNAP_NAME."
+            fi
+
+            sleep 30
+          done
+
+          # Never a 200, so this snap is not public and the check above cannot
+          # see it however long it waits. Ask as the publisher instead.
+          if [[ -z "$SEEN" ]]; then
+            snapcraft status "$SNAP_NAME" --arch amd64 > status.txt
+
+            echo "Publisher view:"
+            cat status.txt
+
+            # Channel then Version, so the field after "stable" is the version.
+            # Read that way rather than by column number because the Track and
+            # Arch columns are only printed on some rows.
+            LIVE="$(awk '{ for (i = 1; i <= NF; i++) if ($i == "stable") { print $(i + 1); exit } }' status.txt)"
 
             if [[ "$LIVE" == "$VERSION" ]]; then
               echo "latest/stable on amd64 is $LIVE. Correct."
+              echo "::notice::$SNAP_NAME is not public, so only the publisher can see this."
+              echo "Make it public at https://snapcraft.io/$SNAP_NAME/settings"
               exit 0
             fi
 
-            echo "Attempt $attempt: latest/stable is \"${LIVE:-unknown}\", waiting for $VERSION."
-            sleep 30
-          done
+            echo "::error::latest/stable holds \"${LIVE:-nothing}\" for $SNAP_NAME, not $VERSION."
+            echo "See https://snapcraft.io/$SNAP_NAME/releases"
+            exit 1
+          fi
 
           echo "::error::The Snap Store is serving \"${LIVE:-unknown}\" on latest/stable, not $VERSION."
           echo "The revision was uploaded but never reached the channel, so anyone who"

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -1,7 +1,8 @@
 name: Repo checks
 
-# Small checks on things nothing else reads: the skills CLAUDE.md requires, and
-# the winget manifests, which are otherwise only validated at submission.
+# Small checks on things nothing else reads: the skills CLAUDE.md requires, the
+# winget manifests, which are otherwise only validated at submission, and the two
+# AUR PKGBUILDs, which are the same package twice and drift silently.
 
 on:
   pull_request:
@@ -9,8 +10,10 @@ on:
       - .claude/CLAUDE.md
       - .claude/skills/**
       - packaging/winget/**
+      - packaging/aur/**
       - .github/scripts/check-skills-shipped.mjs
       - .github/scripts/check-winget-manifests.mjs
+      - .github/scripts/check-aur-pkgbuilds.mjs
       - .github/workflows/repo-checks.yml
 
   push:
@@ -19,6 +22,7 @@ on:
       - .claude/CLAUDE.md
       - .claude/skills/**
       - packaging/winget/**
+      - packaging/aur/**
 
   workflow_dispatch:
 
@@ -38,3 +42,4 @@ jobs:
           node-version: 24
       - run: node .github/scripts/check-skills-shipped.mjs
       - run: node .github/scripts/check-winget-manifests.mjs
+      - run: node .github/scripts/check-aur-pkgbuilds.mjs

--- a/packaging/aur/PKGBUILD.slim
+++ b/packaging/aur/PKGBUILD.slim
@@ -2,10 +2,14 @@
 #
 # publish-aur.yml copies this file into the AUR repo on every release and
 # rewrites pkgver, pkgrel and sha256sums, so those three are placeholders.
-pkgname=gryt-chat-bin
+#
+# The slim build: same client, no embedded server. Everything below except
+# pkgname, pkgdesc, conflicts and the source URL must match PKGBUILD, and
+# check-aur-pkgbuilds.mjs holds them to that.
+pkgname=gryt-chat-slim-bin
 pkgver=1.1.24
 pkgrel=1
-pkgdesc='Gryt Chat — real-time voice chat desktop client'
+pkgdesc='Gryt Chat — real-time voice chat desktop client, without the built-in server'
 arch=('x86_64')
 url='https://gryt.chat'
 license=('AGPL-3.0-or-later')
@@ -16,9 +20,9 @@ optdepends=(
 )
 provides=('gryt-chat')
 # Both variants install /opt/Gryt Chat, so only one of them at a time.
-conflicts=('gryt-chat' 'gryt-chat-slim-bin')
+conflicts=('gryt-chat' 'gryt-chat-bin')
 options=('!strip' '!debug')
-source=("https://github.com/Gryt-chat/gryt/releases/download/v${pkgver}/Gryt-Chat-${pkgver}-linux-amd64.deb")
+source=("https://github.com/Gryt-chat/gryt/releases/download/v${pkgver}/Gryt-Chat-${pkgver}-linux-amd64-slim.deb")
 sha256sums=('SKIP')
 
 package() {


### PR DESCRIPTION
Second half of GRYT-1037: both variants on every channel. The snap half merged in #234, this is the AUR, plus a bug in the snap publisher that the AUR work turned up.

## The AUR

`gryt-chat-bin` stays the full build. `gryt-chat-slim-bin` is the same client without the embedded server, from `packaging/aur/PKGBUILD.slim`. `publish-aur.yml` runs as a matrix over the two with `fail-fast: false`, so slim failing doesn't stop full publishing.

Both install `/opt/Gryt Chat`, so each declares the other in `conflicts` and both `provides=('gryt-chat')`. Installing one replaces the other rather than quietly overwriting its files.

The AUR needs nothing from you for this. It creates the repository on the first push, so `gryt-chat-slim-bin` appears the next time a release publishes.

`check-aur-pkgbuilds.mjs` holds the two files together. They're the same package twice, nothing at publish time compares them, and a `depends=` added to one and not the other builds fine and installs a package missing a library. It allows exactly four lines to differ: `pkgname`, `pkgdesc`, `conflicts`, `source`. It also holds the three lines `publish-aur.yml` rewrites by anchored sed — rename one and the sed matches nothing, and what gets published points at an old release instead of failing.

## The snap bug

Found while checking `gryt-chat-slim` was ready to publish, and it would have made the registration you just did useless.

The guard that skips an unregistered variant asked `api.snapcraft.io`. That API only knows about snaps that are public **and** have a released revision. A registered but private name answers 404 there, which is the state every new variant is in before its first upload. Measured on `gryt-chat-slim` today: registered, private, 404. So the guard would have skipped it on every release forever, and the skip is what stops the upload that would let it be made public.

It asks `snapcraft names` as the publisher now, which sees private and unpublished names.

The step that checks the Store is serving the right version had the same blind spot, and would have failed the job *after* a successful publish. It falls back to the publisher view when the public API never answers, and the notice says which snap is private and where to change it.

## What to look at

- `snapcraft names` output parsing. I matched column 1 as a whole field, so `gryt-chat` can't match `gryt-chat-slim`. I couldn't run the command here — no snapcraft on macOS, and it needs the store credentials — so the column layout is from the docs rather than from a run.
- Same for `snapcraft status`. I read the field after `stable` rather than a column number, because the Track and Arch columns are only printed on some rows. Dry-ran the awk against three plausible layouts including a snap with no released revision.

## Checks

`check-aur-pkgbuilds.mjs` runs in `repo-checks.yml`. Mutation tested against eight changes — a `depends` on one side only, a dropped `conflicts`, slim pointing at the full deb, a renamed `pkgver`, a real `sha256sums`, a dropped `provides`, a renamed slim package, and an edited `package()` body. All eight caught.

Every `run:` body in the three touched workflows passes `bash -n`.

## Still to go on GRYT-1037

Homebrew (flip `gryt-chat` to full, add `gryt-chat-slim`) and winget (`Gryt.GrytChat` plus `Gryt.GrytChat.Slim`). The Microsoft Store's second product is yours to create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
