### PR TITLE
Give the status console a config directory it can write

### DIFF
--- a/ops/internal/status/README.md
+++ b/ops/internal/status/README.md
@@ -102,6 +102,12 @@ here as an image rather than built on this box. It writes
 
 [console]: https://github.com/Gryt-chat/console
 
+`config/` has to be writable by uid 1000. The image runs as `node`, Docker
+doesn't chown a bind mount, and a root-owned directory means announcements
+can't post. `update.sh` chowns it on every cycle, so there's nothing to do by
+hand. It's written down because the symptom is a 502 from the console, which
+points nowhere near permissions.
+
 Updating it:
 
 ```bash

--- a/ops/internal/status/update.sh
+++ b/ops/internal/status/update.sh
@@ -205,7 +205,36 @@ update_image() {
     echo "[$(date -Is)] [$service] deployed ${after:7:12}"
 }
 
+# ── The one thing the compose file cannot state ──────────────────────────
+
+# The console runs as uid 1000 and writes announcements.yaml into the config
+# directory. Docker does not chown a bind mount, so a root-owned directory on
+# the host leaves it unable to write the only file it exists to write.
+#
+# That is what happened: the write threw EACCES, the throw killed the process,
+# and console.gryt.chat answered 502 while Docker restarted it in a loop. The
+# console handles the failure now, but it still cannot post, so fix the cause
+# here — every cycle, so a fresh install and a hand-made directory both end up
+# right without anybody remembering this.
+#
+# Gatus mounts the same directory read-only and does not care who owns it.
+ensure_config_writable() {
+    local dir="$DEST/config" owner
+
+    owner="$(stat -c '%u:%g' "$dir" 2>/dev/null)" || return 0
+    [[ "$owner" == "1000:1000" ]] && return 0
+
+    echo "[$(date -Is)] [config] $dir is owned by $owner; the console runs as 1000"
+    chown -R 1000:1000 "$dir" || {
+        echo "[$(date -Is)] [config] chown failed; announcements will not post"
+        return 1
+    }
+    echo "[$(date -Is)] [config] chowned to 1000:1000"
+}
+
 status=0
+
+ensure_config_writable || status=1
 
 # Config first: a compose change may be what introduces the service the pull
 # below is for.


### PR DESCRIPTION
Posting an announcement on `console.gryt.chat` returned 502 and restarted the container. `/opt/gryt-status/config` is owned by root; the console image runs as `node` (uid 1000); Docker doesn't chown a bind mount. So the console has never been able to write `announcements.yaml` — it just hadn't been tried since it was deployed.

`update.sh` now chowns the directory to `1000:1000` when it isn't, every cycle rather than once, so a fresh install gets it too. Gatus mounts the same directory `:ro` and doesn't care who owns it.

Already applied by hand on the VPS:

```
drwxr-xr-x 2 1000 1000 4096 /opt/gryt-status/config
config is writable by 1000
```

`https://console.gryt.chat/api/state` → 200, `https://status.gryt.chat/` → 200.

The console's own half is [Gryt-chat/console#1](https://github.com/Gryt-chat/console/pull/1): a throw in the request handler is a 500 with the reason now, instead of an unhandled rejection that exits the process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)