### PR TITLE
The console is at console.gryt.chat

### DIFF
--- a/ops/internal/status/README.md
+++ b/ops/internal/status/README.md
@@ -89,10 +89,15 @@ neither leaves a container behind.
 
 ## Announcing an outage
 
-The console at `status.gryt.chat/console` posts announcements — Gatus renders
-them at the top of the page, and the Gryt client shows the same words as a
-banner to everybody signed in. One place to post, so the page and the banner
-cannot disagree.
+The console at [console.gryt.chat](https://console.gryt.chat) posts
+announcements — Gatus renders them at the top of the page, and the Gryt client
+shows the same words as a banner to everybody signed in. One place to post, so
+the page and the banner cannot disagree.
+
+It used to be at `status.gryt.chat/console`, which was a path nobody could
+remember at the moment they needed it. That route is gone. The app still works
+under a prefix, because it emits relative URLs and the server injects a
+`<base href>` to match, so nothing had to change to move it.
 
 It lives in its own repository, [Gryt-chat/console][console], and is pulled
 here as an image rather than built on this box. It writes


### PR DESCRIPTION
`status.gryt.chat/console` is a path nobody can remember at the moment they need it. `console.gryt.chat` is the address, and the Cloudflare public hostname for the old path is being removed.

Nothing had to change to move it: the app emits relative URLs and its server injects a matching `<base href>` per request, so it already served correctly at the root. The console repo's own README is [Gryt-chat/console#2](https://github.com/Gryt-chat/console/pull/2).

Verified `https://console.gryt.chat/` and `/api/state` both answer 200 (resolving past a stale local DNS cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)