### PR TITLE
Give the console a volume for its lockout ledger

### DIFF
--- a/ops/internal/status/README.md
+++ b/ops/internal/status/README.md
@@ -107,6 +107,12 @@ here as an image rather than built on this box. It writes
 
 [console]: https://github.com/Gryt-chat/console
 
+The console keeps its lockout ledger — failed sign-ins, lockouts, bans — on the
+`console-data` volume rather than in `config/`, because Gatus merges every
+`*.yaml` in that directory into its own configuration and console state there is
+one filename away from stopping the status page. It has to survive a restart, or
+whatever restarts the container forgives every lockout.
+
 `config/` has to be writable by uid 1000. The image runs as `node`, Docker
 doesn't chown a bind mount, and a root-owned directory means announcements
 can't post. `update.sh` chowns it on every cycle, so there's nothing to do by

--- a/ops/internal/status/docker-compose.yml
+++ b/ops/internal/status/docker-compose.yml
@@ -45,6 +45,16 @@ services:
       - "127.0.0.1:3002:3002"
     volumes:
       - ./config:/config
+      # Who has been getting the password wrong, and who is banned. Its own
+      # volume rather than a corner of ./config, because Gatus merges every
+      # *.yaml it finds in that directory into its own configuration — console
+      # state in there is one filename away from the status page refusing to
+      # start, during the outage it was meant to report.
+      #
+      # It has to survive a restart. An in-memory lockout is defeated by
+      # whatever restarts the container, and a container that restarts on a
+      # crash is exactly what somebody guessing gets to provoke.
+      - console-data:/data
     environment:
       CONSOLE_PASSWORD_HASH: ${CONSOLE_PASSWORD_HASH:?set it in .env, see README}
     depends_on:
@@ -52,3 +62,4 @@ services:
 
 volumes:
   gatus-data:
+  console-data:


### PR DESCRIPTION
Pairs with [Gryt-chat/console#3](https://github.com/Gryt-chat/console/pull/3), which gives the console a record of who has been getting the password wrong — failures per address, an escalating lockout, a ban list.

That record has to survive a restart or it is worth nothing: an in-memory lockout is defeated by whatever restarts the container, and a container that restarts on a crash is exactly what somebody guessing gets to provoke.

**Its own volume, not a corner of `./config`.** Gatus merges every `*.yaml` in that directory into its own configuration, so console state there is one filename away from the status page refusing to start — during the outage it was meant to report.

**Merge this first.** If the console lands first it runs one cycle without the volume: it keeps the ledger in memory and warns at boot rather than failing.

```
console-data:/data
```

`docker compose config` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)