### PR TITLE
Stop the status page calling a rename an outage (GRYT-1047)

### DIFF
--- a/ops/internal/status/README.md
+++ b/ops/internal/status/README.md
@@ -26,15 +26,23 @@ and nothing else, so a page that wasn't the service passed.
 If you add an endpoint, give it a body condition. To check the condition does
 any work, break it on purpose and confirm the endpoint goes red.
 
+Pick a field that changes when the service breaks, not one that changes when
+somebody makes a decision. The community server check asserted on its `name`
+until GRYT-1047; the server was renamed and the check went red and stayed
+there while the service was fine. Names, descriptions and titles are editorial — the
+community server's name is seasonal on purpose. `has([BODY].field) == true` on
+something structural proves an error page isn't standing in for the service
+without pinning anything a human might reasonably edit.
+
 ## What it deliberately doesn't watch
 
 Only hosts under `gryt.chat`. Nothing personal, nothing on another domain.
 
 The demo server is for store review. This page is for people using Gryt.
 
-The community server belongs here once it has a DNS record. It's the default
-server in the client and it's named on the site, so it's the one server a user
-has a reason to see the state of. Tracked as GRYT-873.
+The community server is watched — it got its DNS record and went in under
+GRYT-873. It's the default server in the client and it's named on the site, so
+it's the one server a user has a reason to see the state of.
 
 ## Deploying
 

--- a/ops/internal/status/config/config.yaml
+++ b/ops/internal/status/config/config.yaml
@@ -52,16 +52,24 @@ endpoints:
   # Its SFU is not checked. Voice is not expected on this server, and a red
   # light for something nobody uses trains people to ignore the page.
   #
-  # No serverId assertion: /info reports it as null on this deployment, so the
-  # name is what distinguishes the real service from anything else answering
-  # on the hostname.
+  # No serverId assertion: /info reports it as null on this deployment. What
+  # distinguishes the real service is the shape of the answer — an edge error
+  # page returns HTML, and nothing else answering on this hostname returns an
+  # /info body with these fields in it.
+  #
+  # Deliberately not the name. It used to assert `name == Gryt Chat (OFFICIAL)`,
+  # the server was renamed to "Gryt Chat", and the check went red and stayed
+  # there — a rename is not an outage, and this page is the thing people look at
+  # to find out which it was. The name is also seasonal: a pumpkin in October is
+  # a change to the server's title, not to whether anybody can reach it.
   - name: "Community server"
     group: "Talking"
     url: "https://community.gryt.chat/info"
     interval: 60s
     conditions:
       - "[STATUS] == 200"
-      - "[BODY].name == Gryt Chat (OFFICIAL)"
+      - "has([BODY].joinPolicy) == true"
+      - "has([BODY].identityTiers) == true"
 
   # ── Apps ────────────────────────────────────────────────────────
   - name: "Web client"


### PR DESCRIPTION
The community server check asserted `[BODY].name == Gryt Chat (OFFICIAL)`. You renamed the server to "Gryt Chat", so that condition can never match — the endpoint has been red ever since, on the one page whose entire job is telling people whether something is genuinely down.

## What changed

```diff
-      - "[BODY].name == Gryt Chat (OFFICIAL)"
+      - "has([BODY].joinPolicy) == true"
+      - "has([BODY].identityTiers) == true"
```

The body-condition reasoning from 2026-09-03 is right and stays: a status code can't tell a working service from an error page standing in its place. The mistake was anchoring on the *name*, which is editorial rather than operational — and on this server deliberately seasonal. A pumpkin in October changes the title, not whether anybody can connect.

So it asserts the **shape** of the answer. Nothing else answering on that hostname returns an `/info` body with `joinPolicy` and `identityTiers` in it, and an edge error page returns HTML, so the check still does what a status code can't. It just has no opinion about what the server is called.

I deliberately didn't use `pat(*Gryt*)` as a looser name check — it would break the moment you wanted "🎃 Spooky Server 🎃", which is exactly the thing that caused this.

## Verified

Live body right now:

```json
{"serverId":null,"name":"Gryt Chat","description":"…","members":"9","lanOpen":false,"identityTiers":["account"],"joinPolicy":"open"}
```

Both conditions pass against it. YAML still parses to 11 endpoints. `has()` syntax checked against the gatus README for v5.36.0, which is the pinned image.

## README

It still said the community server "belongs here once it has a DNS record ... Tracked as GRYT-873" — untrue since that landed. Corrected, and the guidance for new endpoints now says to pick a field that changes when the service breaks, not one that changes when somebody makes a decision.

## Not in this PR

**status.gryt.chat is currently down** — HTTP 530, Cloudflare error 1016, origin unreachable, consistent across retries. Every other host is fine. That's the VPS or its tunnel, not this config, and I can't reach that box. Filed separately as GRYT-1048.

Which does mean this fix won't be visible until the page is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)