### PR TITLE
Dispatch every publisher, fix the snap fallback, ship the rpm (GRYT-1058)

### DIFF
--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -240,7 +240,7 @@ jobs:
 
           VERSION="${TAG#v}"
 
-          snapcraft list-revisions "$SNAP_NAME" --arch amd64 > revisions.txt
+          snapcraft revisions "$SNAP_NAME" --arch amd64 > revisions.txt
           echo "Newest revisions on the Store:"
           head -6 revisions.txt
 

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1201,7 +1201,7 @@ jobs:
           # everyone who downloads it. See packages/client/scripts/sign-windows.cjs
           # for the HRESULTs and GRYT-848 for the certificate.
           if [[ "$RUNNER_OS" == "Linux" ]]; then
-            TARGETS="--linux AppImage deb snap"
+            TARGETS="--linux AppImage deb rpm snap"
           elif [[ "$RUNNER_OS" == "Windows" ]]; then
             TARGETS="--win nsis portable"
           else
@@ -1709,6 +1709,7 @@ jobs:
             dist/*.exe
             dist/*.AppImage
             dist/*.deb
+            dist/*.rpm
             dist/*.snap
             dist/*.dmg
             dist/*.zip
@@ -1789,14 +1790,17 @@ jobs:
           gh release edit "v$VERSION" --repo "$OWNER/$REPO" --draft=false
           echo "v$VERSION is published."
 
-      # publish-snap.yml listens for `release: published`, and that event does
+      # Every publisher listens for `release: published`, and that event does
       # not fire when the release was created with GITHUB_TOKEN — which is what
-      # the step above uses. So it never started on its own, and every stable
-      # release since it was split out has needed somebody to dispatch it by
-      # hand afterwards. It had two runs in total by v1.9.19, both manual.
+      # the step above uses. So none of them starts on its own.
       #
       # `workflow_dispatch` is one of the two events GitHub exempts from that
-      # rule, so dispatching it here does start a run.
+      # rule, so dispatching them here does start a run.
+      #
+      # All four, because this step carried only the snap: the AUR, Homebrew and
+      # winget publishers were written later and nobody came back here. v1.10.1
+      # went out with the snap dispatched and the other three never run, leaving
+      # the AUR and the tap a release behind with nothing red to show for it.
       #
       # Dispatched rather than made a job of this workflow. Release Client
       # shares its concurrency group with Release Server, a job holds that group
@@ -1811,7 +1815,7 @@ jobs:
       # availability contract. Everything a person can install has already
       # shipped by this point, so a failure to even start the upload must not
       # turn a finished release red.
-      - name: Start the Snap Store publish
+      - name: Start the store publishers
         if: needs.prepare-release.outputs.channel == 'latest'
         continue-on-error: true
         shell: bash
@@ -1820,12 +1824,23 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh workflow run publish-snap.yml \
-            --repo "$OWNER/$REPO" \
-            --ref main \
-            -f tag="v$VERSION"
-
-          echo "Dispatched publish-snap.yml for v$VERSION."
+          # One at a time, and a failure to dispatch one must not stop the rest.
+          for WF in \
+            publish-snap.yml \
+            publish-aur.yml \
+            publish-homebrew.yml \
+            publish-winget.yml
+          do
+            if gh workflow run "$WF" \
+              --repo "$OWNER/$REPO" \
+              --ref main \
+              -f tag="v$VERSION"
+            then
+              echo "Dispatched $WF for v$VERSION."
+            else
+              echo "::warning::Could not dispatch $WF for v$VERSION."
+            fi
+          done
 
       # Moved here from the Linux build leg. Announcing from there fired while
       # macOS was still signing, so #releases advertised a build that Mac users


### PR DESCRIPTION
v1.10.1 went out at 13:51 and reached **none** of the Linux stores. Three separate causes, all fixed here.

| | was serving | release |
|---|---|---|
| Snap Store | 1.5.10 (13 Aug) | 1.10.1 |
| AUR | 1.9.24-1 | 1.10.1 |
| Homebrew tap | 1.9.24 | 1.10.1 |
| RPM | not on the release at all | — |

## 1. Only the snap was ever dispatched

`release: published` doesn't fire for a release `GITHUB_TOKEN` published — this workflow already knew that and dispatches its publishers by hand, with a good comment explaining why it dispatches rather than making them jobs (the shared concurrency group).

**It just only ever carried the snap.** The AUR, Homebrew and winget publishers were written afterwards and nobody came back to this step. So the snap started on its own and the other three never ran, leaving two stores a release behind with nothing red to show for it.

All four now, each dispatched separately so one failing to start doesn't stop the rest.

## 2. The snap's safety net died on a renamed command

The snap did start. It uploaded for 100 minutes and hit the step timeout with the Store still reporting `Status: processing` — a slow review, which is exactly what the fallback step exists for. The fallback then failed:

```
The 'list-revisions' command was renamed to 'revisions'.   exit 64
```

So the revision reached the Store and never reached a channel — the precise failure GRYT-971 added that step to prevent. Now `snapcraft revisions`.

## 3. The RPM has never been built

GRYT-1031 added `rpm` to `linux.target` in the client's `electron-builder.yml`, and it *is* in the released commit. It did nothing, because the release overrides targets on the command line:

```
TARGETS="--linux AppImage deb snap"     →  now  ... deb rpm snap
dist/*.AppImage  dist/*.deb  dist/*.snap →  now  ... dist/*.rpm ...
```

Both lines needed it. My miss in GRYT-1031 — the target looked right in the config and was dead on arrival. Nothing caught it because no check asserts a release produces the artifacts the packaging claims.

## What to look at

The dispatch loop is the part I'd read twice: it runs under `set -euo pipefail`, so the `gh workflow run` sits inside an `if` to keep a failure from killing the loop, and the step keeps its `continue-on-error` and its stable-only guard.

## Checked

Both workflows parse, and every `run:` body passes `bash -n` — except *Submit the MSIX to the Microsoft Store*, which is `shell: pwsh` and was never bash. Confirmed rather than assumed.

Not fixed here because it isn't this workflow's to fix: winget still needs `WINGET_PKGS_TOKEN` before a dispatch does anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
