### PR TITLE
Check that every publisher is actually dispatched (GRYT-1060)

### DIFF
--- a/.github/scripts/check-publishers-dispatched.mjs
+++ b/.github/scripts/check-publishers-dispatched.mjs
@@ -1,0 +1,63 @@
+/* eslint-env node */
+
+/**
+ * Every publish-*.yml is dispatched by Release Client.
+ *
+ * They listen for `release: published`, which never fires for a release
+ * GITHUB_TOKEN published, so the release dispatches them by hand. A publisher
+ * that is not in that list simply never runs, and nothing goes red — v1.10.1
+ * shipped with the AUR, Homebrew and winget publishers untouched and two stores
+ * a release behind, because they were written after the dispatch step and
+ * nobody came back to it. GRYT-1058.
+ */
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const workflows = join(dirname(fileURLToPath(import.meta.url)), "..", "workflows");
+
+const publishers = readdirSync(workflows)
+  .filter((f) => f.startsWith("publish-") && f.endsWith(".yml"))
+  .sort();
+
+assert.ok(publishers.length > 0, "no publish-*.yml found, so this check is looking in the wrong place");
+
+const release = readFileSync(join(workflows, "release-client.yml"), "utf8");
+
+// The step's own list, not the whole file: a publisher named only in a comment
+// somewhere else must not count as dispatched.
+const step = release.match(/for WF in \\\n([\s\S]*?)\n\s*do\n/);
+
+assert.ok(
+  step,
+  "release-client.yml has no `for WF in ...` dispatch loop. If the fan-out moved, " +
+    "move this check with it rather than deleting it.",
+);
+
+const dispatched = new Set(
+  step[1]
+    .split("\n")
+    .map((line) => line.replace(/\\\s*$/, "").trim())
+    .filter(Boolean),
+);
+
+const missing = publishers.filter((p) => !dispatched.has(p));
+
+assert.deepEqual(
+  missing,
+  [],
+  `these publishers exist but Release Client never dispatches them, so they will ` +
+    `never run: ${missing.join(", ")}`,
+);
+
+const unknown = [...dispatched].filter((d) => !publishers.includes(d));
+
+assert.deepEqual(
+  unknown,
+  [],
+  `Release Client dispatches workflows that do not exist: ${unknown.join(", ")}`,
+);
+
+console.log(`publisher dispatch: ok, ${publishers.length} publishers, all dispatched`);

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -2,7 +2,8 @@ name: Repo checks
 
 # Small checks on things nothing else reads: the skills CLAUDE.md requires, the
 # winget manifests, which are otherwise only validated at submission, and the
-# Homebrew cask, whose arch stanza fails at the point somebody opens the app.
+# Homebrew cask, whose arch stanza fails at the point somebody opens the app, and
+# that every publisher is actually dispatched by a release.
 
 on:
   pull_request:
@@ -14,6 +15,9 @@ on:
       - .github/scripts/check-skills-shipped.mjs
       - .github/scripts/check-winget-manifests.mjs
       - .github/scripts/check-homebrew-casks.mjs
+      - .github/scripts/check-publishers-dispatched.mjs
+      - .github/workflows/publish-*.yml
+      - .github/workflows/release-client.yml
       - .github/workflows/repo-checks.yml
 
   push:
@@ -23,6 +27,8 @@ on:
       - .claude/skills/**
       - packaging/winget/**
       - packaging/homebrew/**
+      - .github/workflows/publish-*.yml
+      - .github/workflows/release-client.yml
 
   workflow_dispatch:
 
@@ -43,3 +49,4 @@ jobs:
       - run: node .github/scripts/check-skills-shipped.mjs
       - run: node .github/scripts/check-winget-manifests.mjs
       - run: node .github/scripts/check-homebrew-casks.mjs
+      - run: node .github/scripts/check-publishers-dispatched.mjs


### PR DESCRIPTION
You asked whether Release Client should publish to all the stores automatically. It does now, after #243 — this makes sure it stays true.

The publishers listen for `release: published`, which never fires for a release `GITHUB_TOKEN` published, so Release Client dispatches them by hand. **A publisher missing from that list never runs, and nothing goes red.**

That's exactly what happened: the dispatch step carried only the snap, the AUR/Homebrew/winget publishers were written afterwards, and nobody came back to it. v1.10.1 shipped with three of four never started, and the only symptom was two stores quietly serving an older version.

This compares `publish-*.yml` on disk against the names in the dispatch loop, **both ways**:

- a publisher nobody dispatches → fail
- a dispatch naming a workflow that doesn't exist → fail

## Mutation tested

```
caught:  a publisher dropped from the dispatch list
caught:  a new publisher added but not dispatched
caught:  dispatch names a workflow that does not exist
caught:  the whole loop removed
```

If the fan-out ever moves out of that `for WF in` loop the check fails loudly rather than silently passing — the error says to move the check with it, not delete it.

`repo-checks.yml` now also triggers on `publish-*.yml` and `release-client.yml`, which it didn't before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
