### PR TITLE
Keep the winget manifests as an artifact (GRYT-1061)

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -93,6 +93,19 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      # Kept whether or not the submit below runs. Without a token the step
+      # skips, and the manifests it just built and validated would otherwise
+      # exist only in the log -- so submitting by hand meant rebuilding them by
+      # hand. Downloading three files and opening the pull request yourself is
+      # the whole alternative to giving CI a token that can write to every
+      # public repository you own.
+      - name: Keep the manifests
+        uses: actions/upload-artifact@v4
+        with:
+          name: winget-manifests-${{ steps.build.outputs.version }}
+          path: out/
+          if-no-files-found: error
+
       - name: Submit to microsoft/winget-pkgs
         shell: bash
         env:


### PR DESCRIPTION
**Optional now.** This was written as the alternative to giving CI a `public_repo` token — Sivert has since created the classic token, so the case it was arguing is gone.

What it still does: uploads the built manifests as `winget-manifests-<version>` whether or not the submit runs.

The remaining value is narrow. If `wingetcreate submit` fails *before* it opens a PR — bad token, network, a wingetcreate error — the manifests it just built and validated exist only in the run log. Once a PR is open you can read them there instead, so this only covers that window.

Against that: one step, three small YAML files.

**Keep it or close it, your call.** I'd keep it — it's cheap and the first submission of a new package is the most likely one to fail in exactly that way. But I'm not going to pretend it's load-bearing.

`if-no-files-found: error`, so an empty artifact fails loudly rather than being the silent nothing this was meant to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
