### PR TITLE
Hand the Store CLI a project, not a package (GRYT-1075)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1392,7 +1392,9 @@ jobs:
             --sellerId 0 `
             --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
             --clientSecret $env:AZURE_AD_APPLICATION_SECRET
-          msstore publish $appx.FullName -id $productId
+          # The argument is the project root, not the package: pointing it at
+          # the .appx makes it look there for a project and find no publisher.
+          msstore publish . --inputFile $appx.FullName -id $productId
 
       - name: Package macOS app
         if: runner.os == 'macOS'


### PR DESCRIPTION
v1.10.2 was the first release where the Microsoft Store submission actually ran — the `AZURE_AD_*` secrets exist now, so `HAS_STORE_CREDS` was true for the first time. It failed:

```
Submitting Gryt-Chat-1.10.2-win-x64.appx to the Microsoft Store (9PKPT1C2M95Q)
Testing configuration...
Configuration saved!
Awesome! It seems to be working!
We could not find a project publisher for the project at
'D:\a\gryt\gryt\packages\client\release\Gryt-Chat-1.10.2-win-x64.appx'.
Error: Process completed with exit code 1.
```

(The ASCII art above that in the log is the `microsoft/microsoft-store-apppublisher` action's own banner. It prints on every run and means nothing — worth saying because it looks like something went wrong before the error did.)

## Why

From the CLI's documented usage:

```
msstore publish <pathOrUrl>
  -i, --inputFile   The path to the '.msix' or '.msixupload' file to be used for
                    the publishing command.
  -id, --appId      Specifies the Application Id. Only needed if the project has
                    not been initialized before with the 'init' command.
```

`pathOrUrl` is *"the root directory path where the project file is"*. We were passing the `.appx` there, so the CLI went looking inside a package for a project, found none, and couldn't work out a publisher. The package belongs in `--inputFile`.

The step already runs with `working-directory: packages/client`, which is an Electron project the CLI recognises, so the argument is `.`.

## What this doesn't fix

Nothing was blocking the release — the step is `continue-on-error` and doesn't gate `publish-release`. What it means is that a Store install sits on whatever was last submitted by hand, which is what GRYT-954 is waiting on before the Store can be the default Windows download.

## What to look at

I can't verify this without running a release. Two things I'm not sure of, both recorded on GRYT-1075:

- `--inputFile` is documented as taking `.msix` or `.msixupload`, and electron-builder produces `.appx` here. If the CLI refuses the extension the fallback is emitting `.msix`, or the `submission get` / `update` / `publish` route Microsoft's own Actions guide uses.
- Whether an Electron project the CLI has never `init`ed is happy with `-id` alone. The docs say `-id` is exactly for that case, but "documented" and "true" have parted company in this CLI once already today.

Worst case is one more line in a log, which is why this is worth trying on the next release rather than staging elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)