### PR TITLE
Do not open a second winget PR while one is still open (GRYT-1084)

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -106,6 +106,24 @@ jobs:
             exit 0
           fi
 
+          # One at a time. A first submission is reviewed by a person, which took
+          # days here, and every release opening another buries that queue.
+          OPEN=$(GH_TOKEN="$WINGET_TOKEN" gh pr list \
+            --repo microsoft/winget-pkgs \
+            --author "@me" --state open \
+            --search "Gryt.GrytChat in:title" \
+            --json number,title \
+            --jq '.[] | "#\(.number) \(.title)"')
+
+          if [[ -n "$OPEN" ]]; then
+            echo "Already waiting on microsoft/winget-pkgs, so nothing was submitted:"
+            echo "$OPEN"
+            echo
+            echo "That one has to land or be closed first. Closing it here would"
+            echo "throw away a review that has already passed validation."
+            exit 0
+          fi
+
           winget install --id Microsoft.WingetCreate --exact --silent \
             --accept-source-agreements --accept-package-agreements
 


### PR DESCRIPTION
> "we are getting spammed by winget btw" / "We dont need two PRs open"

`publish-winget.yml` ran `wingetcreate submit` on every release and never looked for an existing pull request. Two were open on microsoft/winget-pkgs at once today — [#431457](https://github.com/microsoft/winget-pkgs/pull/431457) for 1.10.1 and [#431568](https://github.com/microsoft/winget-pkgs/pull/431568) for 1.10.3, opened two and a half hours apart. The winget PR template asks the submitter to confirm there are no others for the same manifest, so it's also a thing a reviewer can bounce.

It asks first now, and submits nothing if one of ours is already open.

## Skip, don't close

My first instinct was to close the superseded one automatically. That's wrong here.

#431457 has passed **all ten validation stages** plus `license/cla`, and is sitting on `Policy-Test-2.7` — *"needs to go through a manual review by a repository admin"*, which is standard for a **New-Package**. Closing that to open an unvalidated replacement would throw away days of queue position and start the clock again. Once it lands, the package exists and every later release is an ordinary version update that validates on its own.

So: if one of ours is open, log which and stop.

## Verified against the real repo

Not reasoned about — I ran the exact query:

```
$ gh pr list --repo microsoft/winget-pkgs --author "@me" --state open \
    --search "Gryt.GrytChat in:title" --json number,title
#431457 Gryt.GrytChat version 1.10.1
```

That's precisely what would have stopped today's second submission. I also checked it against a plain `--author` listing filtered locally, in case the search index lagged; same answer.

## What to look at

`--author "@me"` as well as the title filter, so it can only ever see pull requests this token opened. Nothing here touches anybody else's PR on somebody else's repository, and it never closes anything.

The failure mode this introduces: an abandoned PR of ours blocks submissions until a human closes it. That seemed better than a workflow closing things on Microsoft's repo unattended, but say the word and I'll add an age cutoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)