### PR TITLE
Write down that links in prose are underlined (GRYT-1093)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -293,6 +293,23 @@ docker compose -f docker-compose.keycloak.yml -p auth run --rm --no-deps \
 `--no-deps` matters: without it Compose starts what the service depends on, and that is how
 an import gets triggered by accident.
 
+## Interface rules
+
+Sivert's, given once in passing and easy to lose, so they live here rather than in a
+stylesheet nobody opens.
+
+**Every link in running text is underlined.** At rest, not on hover. A link that only
+underlines under the pointer reads as coloured text, and on a touch screen it never
+resolves at all. In the client that is `.gryt-link` in `packages/client/src/style.css`,
+and `yarn test:link-underline` fails on `hover:underline` with nothing behind it.
+
+This is about links in prose. A nav item, a card and a button that happen to be an `<a>`
+are read by their position and shape, and an underline makes those worse.
+
+The site does not follow it yet. `packages/site/src/index.css` sets
+`a { text-decoration: none }` in its base layer and four stylesheets add the underline
+back per page, so a new prose link there starts wrong. That is GRYT-1094.
+
 ## Style
 
 Match the surrounding code, with one exception: comment density. Most of what is in the


### PR DESCRIPTION
"Every link needs an underline. That's a ground rule for Gryt UI" — said once while reviewing the what's-new modal, and written down nowhere. Not in `packages/ui`, not in the site's `design.md`, not here.

Eight links in the client were breaking it, four of them also using `--gryt-accent` as text, which lands around 2.8:1 on the light theme's white.

A new **Interface rules** heading, above Style, for the rules that come up in review and have nowhere else to live. Seventeen lines, one rule in it so far.

The rule is about links in prose. A nav item, a card and a button that happen to be an `<a>` are read by their position and shape, and an underline makes those worse — the section says so, because the first thing an agent will do with a blunt rule is underline the navigation.

## The other halves

- **Client**: [Gryt-chat/client#514](https://github.com/Gryt-chat/client/pull/514) — the eight links, one `.gryt-link` class, and `yarn test:link-underline`.
- **Site**: not fixed. `packages/site/src/index.css` sets `a { text-decoration: none }` in its base layer and four stylesheets add the underline back per page, so a new prose link there starts wrong. That is a whole-site visual pass and its own task, [GRYT-1094](https://tasks.sivert.io/tasks/1151). The section says so rather than claiming the rule holds everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)