### PR TITLE
Say that the four sides check this themselves now (GRYT-1100)

### DIFF
--- a/.github/workflows/api-reference.yml
+++ b/.github/workflows/api-reference.yml
@@ -9,6 +9,12 @@ name: API reference
 # In the superproject because it is the only place that can see all four. /developers
 # printed `window.gryt` for weeks after GRYT-930 deleted the file it came from.
 
+# A backstop now rather than the first line of defence. server, client, bot and docs
+# each run the same check on their own pull requests, through Gryt-chat/.github.
+
+# This still catches what those cannot: a pair merged out of order, or a side whose
+# main moved without a pull request. GRYT-1100.
+
 on:
   # Time-based, like Permission labels and Avatar parity. The commit that changes
   # which versions ship together is a gitlink bump carrying [skip ci].


### PR DESCRIPTION
Comment only. `api-reference.yml` says it lives here because this is the only place
that can see server, client, bot and docs at once. That's still true, but it's no
longer the whole story: the four sides now run the same check on their own pull
requests through Gryt-chat/.github#20.

The schedule stays, as the backstop for a pair merged out of order or a side whose
main moved without a pull request. Both of the failures that led to this
(GRYT-1096, GRYT-1099) were the first kind.

Nothing runs differently. `check-comment-length` passes and the file still parses to
the same six steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)