### PR TITLE
Refuse a release nobody wrote a changelog line for (GRYT-1107)

### DIFF
--- a/.github/scripts/check-release-line.mjs
+++ b/.github/scripts/check-release-line.mjs
@@ -1,0 +1,139 @@
+/**
+ * Refuses a release nobody has written a changelog line for. Run by
+ * release-client.yml and release-server.yml once the version is known and
+ * before the first commit is made. GRYT-1107.
+ *
+ * Two ways to ship a release the site cannot build: no line at all, and a line
+ * whose date is not the day the release happened. check-changelog-lines.mjs in
+ * the site repository asserts both, inside the Docker build, so either one
+ * stops gryt.chat and docs.gryt.chat deploying until somebody fixes it — and
+ * the app's changelog.json is emitted by that same build, so the notice about
+ * what changed never reaches anybody either.
+ */
+
+const SOURCE =
+  process.env.GRYT_RELEASES_URL ??
+  "https://raw.githubusercontent.com/Gryt-chat/site/main/content/changelog/releases.ts";
+
+/* The surfaces released from this repository. voice and images have their own,
+   and a 1.11.3 in one of those is a different release from the app's. */
+const SURFACES = ["app", "server"];
+
+const [surface, version] = process.argv.slice(2);
+
+if (!surface || !version) {
+  console.error("usage: check-release-line.mjs <surface> <version>");
+  process.exit(2);
+}
+
+if (!SURFACES.includes(surface)) {
+  console.error(`Unknown surface ${surface}. Expected one of: ${SURFACES.join(", ")}`);
+  process.exit(2);
+}
+
+/* A -beta.N is a build of a version rather than a version — 1.4.0 had twenty —
+   and the site's own check skips prereleases for that reason. */
+if (version.includes("-")) {
+  console.log(`changelog line: ${surface} ${version} is a prerelease, no line required`);
+  process.exit(0);
+}
+
+/** The releases source, read over the network or, for the tests, off disk. */
+async function read() {
+  if (!SOURCE.startsWith("http")) {
+    const { readFile } = await import("node:fs/promises");
+    return readFile(SOURCE, "utf8");
+  }
+
+  /* Three tries. A release that fails because raw.githubusercontent.com
+     blinked burns a version number, and the retry costs a second. */
+  let last;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const res = await fetch(SOURCE);
+      if (!res.ok) throw new Error(`answered ${res.status}`);
+      return await res.text();
+    } catch (e) {
+      last = e;
+      if (attempt < 3) await new Promise((r) => setTimeout(r, attempt * 1000));
+    }
+  }
+  throw last;
+}
+
+let source;
+try {
+  source = await read();
+} catch (e) {
+  console.error(`Could not read the changelog source, so the line could not be checked.`);
+  console.error(`  ${SOURCE}`);
+  console.error(`  ${e.message}`);
+  console.error("");
+  console.error("This is not a missing line — the check itself did not run. Try again.");
+  process.exit(1);
+}
+
+/* The same shape the site's check-changelog-lines.mjs parses. If the file stops
+   matching this, both break together rather than this one passing quietly. */
+const array = source.match(
+  new RegExp(`export const ${surface}: ReleaseLine\\[\\] = \\[([\\s\\S]*?)\\n\\];`),
+);
+
+if (!array) {
+  console.error(`Could not find the ${surface} releases in the site's changelog source.`);
+  console.error(`Looked in ${SOURCE}`);
+  process.exit(1);
+}
+
+const quoted = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const entry = array[1].match(new RegExp(`version: "${quoted}",\\s*\\n\\s*date: "([^"]+)"`));
+
+/* Today where GitHub reads it. The site compares each line's date against the
+   release's published date, which is UTC. */
+const today = new Date().toISOString().slice(0, 10);
+
+if (!entry) {
+  if (new RegExp(`version: "${quoted}"`).test(array[1])) {
+    console.error(`The ${surface} ${version} entry has no date directly after its version.`);
+    console.error("The site reads the two together, so an entry shaped any other way is");
+    console.error("invisible to it and the release counts as unwritten. Put them back in");
+    console.error(`order, with date: "${today}".`);
+    process.exit(1);
+  }
+
+  console.error(`No changelog line for ${surface} ${version}.`);
+  console.error("");
+  console.error("The desktop app reads the line to say what changed after it updates, and the");
+  console.error("site's build refuses to pass while a release has no line — so releasing this");
+  console.error("now stops gryt.chat deploying until somebody writes it.");
+  console.error("");
+  console.error(`Add an entry to the top of the \`${surface}\` array in the site repository:`);
+  console.error("");
+  console.error("  content/changelog/releases.ts");
+  console.error("");
+  console.error(`  {`);
+  console.error(`    version: "${version}",`);
+  console.error(`    date: "${today}",`);
+  console.error(`    line: "One sentence, present tense, from the reader's side.",`);
+  if (surface === "app") {
+    console.error(`    changes: [{ kind: "fixed", text: "..." }],`);
+  }
+  console.error(`  },`);
+  console.error("");
+  console.error("Merge that, then run this release again.");
+  process.exit(1);
+}
+
+if (entry[1] !== today) {
+  console.error(`The ${surface} ${version} line is dated ${entry[1]}, and today is ${today}.`);
+  console.error("");
+  console.error("The site checks every line's date against the day the release was published,");
+  console.error("in UTC, and fails its build when they disagree. Shipping now would break");
+  console.error("gryt.chat the same way a missing line does.");
+  console.error("");
+  console.error(`Change that entry's date to "${today}" in the site repository, or wait and`);
+  console.error("release on the day the line already names.");
+  process.exit(1);
+}
+
+console.log(`changelog line: ${surface} ${version} has one, dated ${entry[1]}`);

--- a/.github/scripts/check-release-line.mjs
+++ b/.github/scripts/check-release-line.mjs
@@ -1,22 +1,12 @@
-/**
- * Refuses a release nobody has written a changelog line for. Run by
- * release-client.yml and release-server.yml once the version is known and
- * before the first commit is made. GRYT-1107.
- *
- * Two ways to ship a release the site cannot build: no line at all, and a line
- * whose date is not the day the release happened. check-changelog-lines.mjs in
- * the site repository asserts both, inside the Docker build, so either one
- * stops gryt.chat and docs.gryt.chat deploying until somebody fixes it — and
- * the app's changelog.json is emitted by that same build, so the notice about
- * what changed never reaches anybody either.
- */
+// Refuses a release with no changelog line, or one dated another day. The
+// site's build asserts both, and emits the app's changelog.json. GRYT-1107.
 
 const SOURCE =
   process.env.GRYT_RELEASES_URL ??
   "https://raw.githubusercontent.com/Gryt-chat/site/main/content/changelog/releases.ts";
 
-/* The surfaces released from this repository. voice and images have their own,
-   and a 1.11.3 in one of those is a different release from the app's. */
+/* Released from this repository. A 1.11.3 under voice or images is another
+   release entirely. */
 const SURFACES = ["app", "server"];
 
 const [surface, version] = process.argv.slice(2);
@@ -31,8 +21,8 @@ if (!SURFACES.includes(surface)) {
   process.exit(2);
 }
 
-/* A -beta.N is a build of a version rather than a version — 1.4.0 had twenty —
-   and the site's own check skips prereleases for that reason. */
+/* A -beta.N is a build of a version rather than a version. The site's own
+   check skips them for the same reason. */
 if (version.includes("-")) {
   console.log(`changelog line: ${surface} ${version} is a prerelease, no line required`);
   process.exit(0);
@@ -45,8 +35,8 @@ async function read() {
     return readFile(SOURCE, "utf8");
   }
 
-  /* Three tries. A release that fails because raw.githubusercontent.com
-     blinked burns a version number, and the retry costs a second. */
+  /* A release that fails because raw.githubusercontent.com blinked burns a
+     version number, and the retry costs a second. */
   let last;
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
@@ -73,8 +63,8 @@ try {
   process.exit(1);
 }
 
-/* The same shape the site's check-changelog-lines.mjs parses. If the file stops
-   matching this, both break together rather than this one passing quietly. */
+/* The shape check-changelog-lines.mjs parses, so the two break together
+   rather than this one passing quietly. */
 const array = source.match(
   new RegExp(`export const ${surface}: ReleaseLine\\[\\] = \\[([\\s\\S]*?)\\n\\];`),
 );
@@ -88,8 +78,8 @@ if (!array) {
 const quoted = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const entry = array[1].match(new RegExp(`version: "${quoted}",\\s*\\n\\s*date: "([^"]+)"`));
 
-/* Today where GitHub reads it. The site compares each line's date against the
-   release's published date, which is UTC. */
+/* The site compares each line's date against the release's published date,
+   which is UTC. */
 const today = new Date().toISOString().slice(0, 10);
 
 if (!entry) {

--- a/.github/scripts/check-release-line.test.mjs
+++ b/.github/scripts/check-release-line.test.mjs
@@ -1,11 +1,5 @@
-/**
- * The release gate, against fixtures rather than the live site. It never
- * reaches the network: GRYT_RELEASES_URL takes a path as readily as a URL.
- *
- * The gate is the only thing standing between a dispatched release and a
- * gryt.chat deploy that stops until somebody writes a line, and nothing else
- * exercises it — a release either passes it or is the test.
- */
+// The release gate against fixtures, never the network: GRYT_RELEASES_URL
+// takes a path as readily as a URL. Nothing else exercises it.
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
@@ -68,7 +62,7 @@ test("each surface reads its own array", () => {
   assert.equal(run(written, "server", "1.7.0").code, 0);
 
   /* 1.11.3 is the app's. Finding it under server would let a server release
-     ride on a line written for the client. */
+     ride on the client's line. */
   const { code, out } = run(written, "server", "1.11.3");
   assert.equal(code, 1);
   assert.match(out, /No changelog line for server 1\.11\.3/);
@@ -111,8 +105,7 @@ test("a version is matched whole, not as a prefix", () => {
 });
 
 test("the dots in a version are not wildcards", () => {
-  /* Unescaped, 1.11.3 as a pattern matches 1211x3, and a release rides on a
-     line written for something else. */
+  /* Unescaped, 1.11.3 as a pattern also matches 1211x3. */
   const lookalike = fixture("lookalike", { app: [{ version: "1211x3", date: today }] });
   assert.equal(run(lookalike, "app", "1.11.3").code, 1);
 });

--- a/.github/scripts/check-release-line.test.mjs
+++ b/.github/scripts/check-release-line.test.mjs
@@ -107,9 +107,14 @@ test("a prerelease needs no line", () => {
 });
 
 test("a version is matched whole, not as a prefix", () => {
-  /* 1.11.3 must not satisfy 1.11.30, and the dots are not wildcards. */
   assert.equal(run(written, "app", "1.11.30").code, 1);
-  assert.equal(run(written, "app", "1211x3").code, 1);
+});
+
+test("the dots in a version are not wildcards", () => {
+  /* Unescaped, 1.11.3 as a pattern matches 1211x3, and a release rides on a
+     line written for something else. */
+  const lookalike = fixture("lookalike", { app: [{ version: "1211x3", date: today }] });
+  assert.equal(run(lookalike, "app", "1.11.3").code, 1);
 });
 
 test("a source it cannot read fails, and says the check did not run", () => {

--- a/.github/scripts/check-release-line.test.mjs
+++ b/.github/scripts/check-release-line.test.mjs
@@ -1,0 +1,133 @@
+/**
+ * The release gate, against fixtures rather than the live site. It never
+ * reaches the network: GRYT_RELEASES_URL takes a path as readily as a URL.
+ *
+ * The gate is the only thing standing between a dispatched release and a
+ * gryt.chat deploy that stops until somebody writes a line, and nothing else
+ * exercises it — a release either passes it or is the test.
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const SCRIPT = new URL("check-release-line.mjs", import.meta.url).pathname;
+const dir = mkdtempSync(join(tmpdir(), "release-line-"));
+const today = new Date().toISOString().slice(0, 10);
+
+/** A releases.ts holding exactly the entries given, in the site's shape. */
+function fixture(name, { app = [], server = [] }) {
+  const entries = (list) =>
+    list
+      .map(
+        ({ version, date, line = "Something changed." }) =>
+          `  {\n    version: "${version}",\n` +
+          (date === null ? "" : `    date: "${date}",\n`) +
+          `    line: "${line}",\n  },`,
+      )
+      .join("\n");
+
+  const path = join(dir, `${name}.ts`);
+  writeFileSync(
+    path,
+    `export const app: ReleaseLine[] = [\n${entries(app)}\n];\n\n` +
+      `export const server: ReleaseLine[] = [\n${entries(server)}\n];\n`,
+  );
+  return path;
+}
+
+/** Runs the gate and hands back its exit code and combined output. */
+function run(source, ...args) {
+  try {
+    const stdout = execFileSync("node", [SCRIPT, ...args], {
+      env: { ...process.env, GRYT_RELEASES_URL: source },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, out: stdout };
+  } catch (e) {
+    return { code: e.status, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
+
+const written = fixture("written", {
+  app: [{ version: "1.11.3", date: today }],
+  server: [{ version: "1.7.0", date: today }],
+});
+
+test("a line dated today passes", () => {
+  const { code, out } = run(written, "app", "1.11.3");
+  assert.equal(code, 0);
+  assert.match(out, /app 1\.11\.3 has one/);
+});
+
+test("each surface reads its own array", () => {
+  assert.equal(run(written, "server", "1.7.0").code, 0);
+
+  /* 1.11.3 is the app's. Finding it under server would let a server release
+     ride on a line written for the client. */
+  const { code, out } = run(written, "server", "1.11.3");
+  assert.equal(code, 1);
+  assert.match(out, /No changelog line for server 1\.11\.3/);
+});
+
+test("a missing line fails, and says what to write", () => {
+  const { code, out } = run(written, "app", "9.9.9");
+  assert.equal(code, 1);
+  assert.match(out, /No changelog line for app 9\.9\.9/);
+  assert.match(out, /content\/changelog\/releases\.ts/);
+  assert.match(out, new RegExp(`version: "9\\.9\\.9"`));
+  assert.match(out, new RegExp(`date: "${today}"`));
+  /* The app has the dialog that reads them; the server has no changes array. */
+  assert.match(out, /kind: "fixed"/);
+  assert.doesNotMatch(run(written, "server", "9.9.9").out, /kind: "fixed"/);
+});
+
+test("a line dated some other day fails", () => {
+  const stale = fixture("stale", { app: [{ version: "1.11.4", date: "2026-01-02" }] });
+  const { code, out } = run(stale, "app", "1.11.4");
+  assert.equal(code, 1);
+  assert.match(out, /dated 2026-01-02, and today is/);
+});
+
+test("a version with no date after it fails as malformed", () => {
+  const shapeless = fixture("shapeless", { app: [{ version: "1.11.5", date: null }] });
+  const { code, out } = run(shapeless, "app", "1.11.5");
+  assert.equal(code, 1);
+  assert.match(out, /no date directly after its version/);
+});
+
+test("a prerelease needs no line", () => {
+  const { code, out } = run(written, "app", "1.12.0-beta.1");
+  assert.equal(code, 0);
+  assert.match(out, /prerelease, no line required/);
+});
+
+test("a version is matched whole, not as a prefix", () => {
+  /* 1.11.3 must not satisfy 1.11.30, and the dots are not wildcards. */
+  assert.equal(run(written, "app", "1.11.30").code, 1);
+  assert.equal(run(written, "app", "1211x3").code, 1);
+});
+
+test("a source it cannot read fails, and says the check did not run", () => {
+  const { code, out } = run(join(dir, "not-here.ts"), "app", "1.11.3");
+  assert.equal(code, 1);
+  assert.match(out, /the check itself did not run/);
+});
+
+test("a source with no such array fails rather than passing", () => {
+  const empty = join(dir, "empty.ts");
+  writeFileSync(empty, "export const voice: ReleaseLine[] = [\n];\n");
+  const { code, out } = run(empty, "app", "1.11.3");
+  assert.equal(code, 1);
+  assert.match(out, /Could not find the app releases/);
+});
+
+test("bad arguments exit 2, so a mistake is not read as a missing line", () => {
+  assert.equal(run(written, "app").code, 2);
+  assert.equal(run(written).code, 2);
+  assert.equal(run(written, "voice", "1.0.0").code, 2);
+});

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -361,6 +361,17 @@ jobs:
           echo "New base version: $BASE_VERSION"
           echo "Release version: $RELEASE_VERSION"
 
+      # Runs the moment the version is known and before the first commit is
+      # made. The app reads this line to tell the user what changed after it
+      # updates, and the site's build refuses to pass while a shipped release
+      # has no line, so releasing without one also stops gryt.chat deploying
+      # until the line lands (GRYT-1107).
+      - name: Require a changelog line
+        shell: bash
+        run: |
+          set -euo pipefail
+          node .github/scripts/check-release-line.mjs app "${{ steps.version.outputs.version }}"
+
       - name: Update monorepo release.json
         shell: bash
         run: |

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -361,11 +361,8 @@ jobs:
           echo "New base version: $BASE_VERSION"
           echo "Release version: $RELEASE_VERSION"
 
-      # Runs the moment the version is known and before the first commit is
-      # made. The app reads this line to tell the user what changed after it
-      # updates, and the site's build refuses to pass while a shipped release
-      # has no line, so releasing without one also stops gryt.chat deploying
-      # until the line lands (GRYT-1107).
+      # The version is known and nothing is committed yet. Without a line the
+      # app says nothing changed and gryt.chat stops deploying (GRYT-1107).
       - name: Require a changelog line
         shell: bash
         run: |

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -346,10 +346,8 @@ jobs:
           echo "Release server version: $RELEASE_VERSION"
           echo "Tag: $TAG"
 
-      # Runs the moment the version is known and before the first commit is
-      # made. The site's build refuses to pass while a shipped release has no
-      # changelog line, so releasing without one stops gryt.chat deploying
-      # until the line lands (GRYT-1107).
+      # The version is known and nothing is committed yet. Without a line the
+      # site's build fails and gryt.chat stops deploying (GRYT-1107).
       - name: Require a changelog line
         shell: bash
         run: |

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -346,6 +346,16 @@ jobs:
           echo "Release server version: $RELEASE_VERSION"
           echo "Tag: $TAG"
 
+      # Runs the moment the version is known and before the first commit is
+      # made. The site's build refuses to pass while a shipped release has no
+      # changelog line, so releasing without one stops gryt.chat deploying
+      # until the line lands (GRYT-1107).
+      - name: Require a changelog line
+        shell: bash
+        run: |
+          set -euo pipefail
+          node .github/scripts/check-release-line.mjs server "${{ steps.version.outputs.version }}"
+
       - name: Update monorepo release.json
         shell: bash
         run: |

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -61,3 +61,4 @@ jobs:
       - run: node .github/scripts/check-publishers-dispatched.mjs
       - run: node .github/scripts/check-offline-page.mjs
       - run: node .github/scripts/check-comment-length.mjs
+      - run: node --test .github/scripts/check-release-line.test.mjs


### PR DESCRIPTION
1.11.3 went out before its changelog line was merged. The site's build asserts
that every published release has one, so gryt.chat and docs.gryt.chat stopped
deploying and sat three commits back until somebody noticed. The app's
`changelog.json` comes out of that same build, so the notice about what changed
never reached anybody either — which is how this got found.

`.github/scripts/check-release-line.mjs` reads the site's `releases.ts` off main
and fails the release when the version has no entry there.

It also fails when the entry is dated some other day. The site compares each
line's date against the day the release was published, in UTC, and breaks the
same way when the two disagree. Writing the line ahead of the release means
guessing that date, which is a trap this change would otherwise have created.

## Where it runs

Both release workflows, once the version is known and before the first commit is
made, so there's nothing to undo when it refuses. In `release-client.yml` it
checks the `app` array, in `release-server.yml` the `server` array — a 1.11.3
under one is not the same release as a 1.11.3 under the other.

Prereleases are skipped, the way the site's own `check-changelog-lines.mjs`
skips them. The fetch gets three tries, and a network failure says the check
didn't run rather than claiming the line is missing.

## Tests

`repo-checks` runs `check-release-line.test.mjs`, which puts fixtures through the
real script rather than asserting on its source. Eleven cases: the line present,
missing, dated wrong, shaped wrong, matched per surface, matched whole rather
than as a prefix, dots escaped, prerelease skipped, source unreadable, array
absent, arguments bad.

Mutation-tested at 13 mutations, all caught: the date check disabled, the
prerelease skip forced both ways, the surface hardcoded, the version left
unescaped, the version/date pairing dropped, the argument checks removed, and
each of the five failing exits turned into a pass.

## What this does not cover

`voice` and `images` release from their own repositories and have their own
lines on the same page. They can still break the site's build the same way.
GRYT-1108 covers extending the gate to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)