### PR TITLE
Put the Worker routes where wrangler reads them (GRYT-1109)

### DIFF
--- a/.github/scripts/check-offline-page.mjs
+++ b/.github/scripts/check-offline-page.mjs
@@ -58,7 +58,20 @@ assert.equal(response.status, 503, "the page answers with a success-shaped code"
 assert.equal(response.headers.get("cache-control"), "no-store", "the outage gets cached");
 assert.ok(response.headers.get("retry-after"), "nothing tells a client when to come back");
 
-/* ── the routes leave out what must not be behind it ──────────────────────── */
+/* ── the routes are somewhere wrangler will read them ─────────────────────── */
+
+// In TOML every key after a table header belongs to that table. Below [[rules]]
+// this parsed as rules[0].routes, and the Worker deployed to nothing.
+const firstTable = wrangler.search(/^\[/m);
+const routesAt = wrangler.search(/^routes\s*=/m);
+
+assert.notEqual(routesAt, -1, "wrangler.toml declares no routes");
+assert.ok(
+  firstTable === -1 || routesAt < firstTable,
+  "routes sits under a [table] header, so wrangler reads it as that table's key",
+);
+
+/* ── and they leave out what must not be behind it ────────────────────────── */
 
 // The patterns, not the whole file: the comment above them names status.gryt.chat
 // to say why it is absent, and a substring search reads that as a route.
@@ -70,4 +83,4 @@ for (const host of ["status.gryt.chat", "ws1.sivert.io", "sfu.sivert.io"]) {
 
 assert.ok(routed.length >= 5, `only ${routed.length} hostnames are routed`);
 
-console.log(`offline page: self-contained, answers 503, ${routed.length} hostnames routed`);
+console.log(`offline page: self-contained, answers 503, ${routed.length} hostnames wrangler will route`);

--- a/ops/edge/wrangler.toml
+++ b/ops/edge/wrangler.toml
@@ -3,12 +3,8 @@ main = "src/index.js"
 compatibility_date = "2026-09-09"
 workers_dev = false
 
-# The page is a file rather than a template literal, so it can be opened in a
-# browser and edited like a page.
-[[rules]]
-type = "Text"
-globs = ["**/*.html"]
-fallthrough = true
+# Above [[rules]] on purpose. Every key after a table header belongs to that
+# table, so down there this parsed as rules[0].routes and deployed to nothing.
 
 # Browser-facing hostnames only. ws1 and sfu are the API and the signalling
 # socket, where the client handles a failed connection and an HTML body would not.
@@ -23,6 +19,13 @@ routes = [
   { pattern = "beta.gryt.chat/*", zone_name = "gryt.chat" },
   { pattern = "ui.gryt.chat/*", zone_name = "gryt.chat" },
 ]
+
+# The page is a file rather than a template literal, so it can be opened in a
+# browser and edited like a page.
+[[rules]]
+type = "Text"
+globs = ["**/*.html"]
+fallthrough = true
 
 [observability]
 enabled = true


### PR DESCRIPTION
`wrangler deploy` uploaded `gryt-offline` and then said **"No targets deployed"**.
The Worker was there and nothing reached it.

`routes` sat below `[[rules]]`. In TOML every key after a table header belongs to
that table, so it parsed as `rules[0].routes` — and Wrangler saw a Worker with
`workers_dev = false` and no routes at all. Moved above the table.

## The check passed the whole time

`check-offline-page.mjs` reads the route patterns with a regex over the file text,
which finds them wherever they sit. It confirmed the routes were *written down*, not
that Wrangler would ever read them — so it gave cover to exactly the mistake it
existed to catch.

It now asserts `routes` appears before the first `[table]` header. Both mutations
fail it: `routes` moved back under `[[rules]]`, and `routes` deleted.

## After this merges

```bash
rm -rf /tmp/gryt-edge && git clone --depth 1 https://github.com/Gryt-chat/gryt.git /tmp/gryt-edge
```

```bash
cd /tmp/gryt-edge/ops/edge && npx --yes wrangler@4 deploy
```

The output should name the six routes instead of "No targets deployed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)