### PR TITLE
Drop the www route (GRYT-1110)

### DIFF
--- a/.github/scripts/check-offline-page.mjs
+++ b/.github/scripts/check-offline-page.mjs
@@ -77,7 +77,7 @@ assert.ok(
 // to say why it is absent, and a substring search reads that as a route.
 const routed = [...wrangler.matchAll(/pattern\s*=\s*"([^/"]+)/g)].map((m) => m[1]);
 
-for (const host of ["status.gryt.chat", "ws1.sivert.io", "sfu.sivert.io"]) {
+for (const host of ["status.gryt.chat", "www.gryt.chat", "ws1.sivert.io", "sfu.sivert.io"]) {
   assert.equal(routed.includes(host), false, `${host} is routed through the offline page`);
 }
 

--- a/ops/edge/README.md
+++ b/ops/edge/README.md
@@ -35,6 +35,11 @@ than the status page.
 
 ## What it isn't in front of
 
+`www.gryt.chat` is a redirect to the bare hostname. Redirect rules run before Workers,
+so a route there would never serve anything — whoever typed `www` lands on `gryt.chat`
+and gets the page from there if it's down.
+
+
 `ws1.sivert.io` and `sfu.sivert.io` are the API and the signalling socket. The
 client already handles a connection it can't make, and an HTML body there would
 only confuse it.

--- a/ops/edge/wrangler.toml
+++ b/ops/edge/wrangler.toml
@@ -9,11 +9,13 @@ workers_dev = false
 # Browser-facing hostnames only. ws1 and sfu are the API and the signalling
 # socket, where the client handles a failed connection and an HTML body would not.
 
+# www is absent too. It is a redirect rule to the bare hostname, and those run before
+# Workers, so a route here would never serve anything.
+
 # status.gryt.chat is deliberately absent: it is what this page links to, it runs
 # on the VPS on its own tunnel, and it has to stay up when these do not.
 routes = [
   { pattern = "gryt.chat/*", zone_name = "gryt.chat" },
-  { pattern = "www.gryt.chat/*", zone_name = "gryt.chat" },
   { pattern = "docs.gryt.chat/*", zone_name = "gryt.chat" },
   { pattern = "app.gryt.chat/*", zone_name = "gryt.chat" },
   { pattern = "beta.gryt.chat/*", zone_name = "gryt.chat" },


### PR DESCRIPTION
`www.gryt.chat` has no DNS record, so that route was attached to nothing.

It becomes a redirect to the bare hostname instead. Redirect rules run before Workers,
so a route there would never serve anything either way — whoever types `www` lands on
`gryt.chat` and gets the offline page from there when it's down.

The check now refuses `www` alongside `status`, `ws1` and `sfu`, and fails if it's
added back.

Five routes after this: `gryt.chat`, `docs`, `app`, `beta`, `ui`.

Needs a redeploy to take the route off the Worker:

```bash
cd ~ && rm -rf /tmp/gryt-edge && git clone --depth 1 https://github.com/Gryt-chat/gryt.git /tmp/gryt-edge && cd /tmp/gryt-edge/ops/edge && npx --yes wrangler@4 deploy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)