### PR TITLE
Point SFU_WS_HOST at the control port (GRYT-1129)

### DIFF
--- a/ops/.env.example
+++ b/ops/.env.example
@@ -22,7 +22,7 @@
 # KEYCLOAK_ADMIN_PASSWORD=admin
 
 # ── SFU ───────────────────────────────────────────────────────────────
-# SFU_WS_HOST=ws://127.0.0.1:5005
+# SFU_WS_HOST=ws://127.0.0.1:9092
 # SFU_PUBLIC_HOST=wss://sfu.example.com
 # Multiple SFU URLs (comma-separated) for LAN + public access:
 # SFU_PUBLIC_HOST=wss://sfu.example.com,ws://192.168.1.100:5005

--- a/ops/deploy/compose/beta.local.yml
+++ b/ops/deploy/compose/beta.local.yml
@@ -71,7 +71,7 @@ services:
       SERVER_PASSWORD: ${NT_SERVER_PASSWORD:-}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3667,https://app.gryt.chat,https://beta.gryt.chat}
       JWT_SECRET: ${NT_JWT_SECRET:?Set NT_JWT_SECRET in .env.beta}
-      SFU_WS_HOST: ws://sfu:5005
+      SFU_WS_HOST: ws://sfu:9092
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5015}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-20}

--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -69,6 +69,9 @@ services:
       - "${ICE_UDP_MUX_PORT:-4443}:${ICE_UDP_MUX_PORT:-4443}/udp"
     environment:
       PORT: "5005"
+      # Registration, deliberately unpublished: the port above is public so clients
+      # can reach it, and a published /server lets anyone use this SFU as their relay.
+      SFU_CONTROL_PORT: "${SFU_CONTROL_PORT:-9092}"
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       ICE_UDP_MUX_PORT: ${ICE_UDP_MUX_PORT:-4443}
       ICE_ADVERTISE_IP: ${ICE_ADVERTISE_IP:-}
@@ -122,7 +125,7 @@ services:
       METRICS_PORT: ${METRICS_PORT:-9091}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3667,https://app.gryt.chat,https://beta.gryt.chat}
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env}
-      SFU_WS_HOST: ws://sfu:${SFU_PORT:-5015}
+      SFU_WS_HOST: ws://sfu:${SFU_CONTROL_PORT:-9092}
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5015}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-20}

--- a/ops/deploy/compose/dev.yml
+++ b/ops/deploy/compose/dev.yml
@@ -11,6 +11,9 @@ services:
       - "${ICE_UDP_MUX_PORT:-3478}:${ICE_UDP_MUX_PORT:-3478}/udp"
     environment:
       - PORT=5005
+      # Registration, deliberately unpublished: the port above is public so clients
+      # can reach it, and a published /server lets anyone use this SFU as their relay.
+      - SFU_CONTROL_PORT=9092
       - STUN_SERVERS=stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
       # All media flows over this one UDP port. It has to be published above.
       - ICE_UDP_MUX_PORT=${ICE_UDP_MUX_PORT:-3478}
@@ -40,7 +43,7 @@ services:
     environment:
       - PORT=5000
       - SERVER_NAME=Gryta Krutt
-      - SFU_WS_HOST=ws://sfu:5005
+      - SFU_WS_HOST=ws://sfu:9092
       - STUN_SERVERS=stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3777,http://127.0.0.1:15738,https://app.gryt.chat}
       - SERVER_PASSWORD=changeme-1
@@ -85,7 +88,7 @@ services:
     environment:
       - PORT=5000
       - SERVER_NAME=Techial
-      - SFU_WS_HOST=ws://sfu:5005
+      - SFU_WS_HOST=ws://sfu:9092
       - STUN_SERVERS=stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3777,http://127.0.0.1:15738,https://app.gryt.chat}
       - SERVER_PASSWORD=changeme-2

--- a/ops/deploy/compose/prod.local.yml
+++ b/ops/deploy/compose/prod.local.yml
@@ -66,7 +66,7 @@ services:
       SERVER_PASSWORD: ${NT_SERVER_PASSWORD:-}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3666,https://app.gryt.chat,https://beta.gryt.chat}
       JWT_SECRET: ${NT_JWT_SECRET:?Set NT_JWT_SECRET in .env.prod}
-      SFU_WS_HOST: ws://sfu:5005
+      SFU_WS_HOST: ws://sfu:9092
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-}

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -64,6 +64,9 @@ services:
       - "${ICE_UDP_MUX_PORT:-3478}:${ICE_UDP_MUX_PORT:-3478}/udp"
     environment:
       PORT: "5005"
+      # Registration, deliberately unpublished: the port above is public so clients
+      # can reach it, and a published /server lets anyone use this SFU as their relay.
+      SFU_CONTROL_PORT: "${SFU_CONTROL_PORT:-9092}"
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       ICE_UDP_MUX_PORT: ${ICE_UDP_MUX_PORT:-3478}
       ICE_ADVERTISE_IP: ${ICE_ADVERTISE_IP:-}
@@ -111,7 +114,7 @@ services:
       METRICS_PORT: ${METRICS_PORT:-9091}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,https://app.gryt.chat}
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env}
-      SFU_WS_HOST: ws://sfu:${SFU_PORT:-5005}
+      SFU_WS_HOST: ws://sfu:${SFU_CONTROL_PORT:-9092}
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-}
@@ -239,7 +242,7 @@ services:
   #     # sharing one is not exploitable — but there is no reason to.
   #     JWT_SECRET: ${JWT_SECRET_2:?Set JWT_SECRET_2 in .env}
   #     # The same SFU as the first server, on purpose.
-  #     SFU_WS_HOST: ws://sfu:${SFU_PORT:-5005}
+  #     SFU_WS_HOST: ws://sfu:${SFU_CONTROL_PORT:-9092}
   #     SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
   #     STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
   #     GRYT_SERVER_ENABLED: ${GRYT_SERVER_ENABLED:-${GRYT_AUTH_MODE:-true}}

--- a/ops/deploy/host/compose.yml
+++ b/ops/deploy/host/compose.yml
@@ -49,7 +49,7 @@ services:
       NODE_ENV: production
       PORT: "5000"
       # Internal SFU websocket (server -> sfu container)
-      SFU_WS_HOST: "ws://sfu:5005"
+      SFU_WS_HOST: "ws://sfu:9092"
       DATA_DIR: /data
       S3_ENDPOINT: "http://minio:9000"
       S3_REGION: "${S3_REGION:-us-east-1}"
@@ -89,6 +89,9 @@ services:
       - ./.env
     environment:
       PORT: "5005"
+      # Registration, deliberately unpublished: the port above is public so clients
+      # can reach it, and a published /server lets anyone use this SFU as their relay.
+      SFU_CONTROL_PORT: "9092"
       STUN_SERVERS: "${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
       ICE_UDP_MUX_PORT: "${ICE_UDP_MUX_PORT:-3478}"
       ICE_ADVERTISE_IP: "${ICE_ADVERTISE_IP:-}"

--- a/ops/dev/common.env.sh
+++ b/ops/dev/common.env.sh
@@ -19,7 +19,7 @@ export S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY:-$MINIO_ROOT_PASSWORD}"
 export S3_FORCE_PATH_STYLE="${S3_FORCE_PATH_STYLE:-true}"
 
 # Local defaults for SFU + STUN in dev
-export SFU_WS_HOST="${SFU_WS_HOST:-ws://127.0.0.1:5005}"
+export SFU_WS_HOST="${SFU_WS_HOST:-ws://127.0.0.1:9092}"
 export SFU_PUBLIC_HOST="${SFU_PUBLIC_HOST:-wss://sfu.example.com}"
 export STUN_SERVERS="${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
 

--- a/ops/helm/gryt/templates/_helpers.tpl
+++ b/ops/helm/gryt/templates/_helpers.tpl
@@ -130,7 +130,7 @@ Get the image name with registry and tag
 Get the SFU WebSocket host
 */}}
 {{- define "gryt.sfu.wsHost" -}}
-{{- printf "ws://%s-sfu:%d" (include "gryt.fullname" .) (.Values.sfu.service.port | int) -}}
+{{- printf "ws://%s-sfu:%d" (include "gryt.fullname" .) (.Values.sfu.controlPort | default 9092 | int) -}}
 {{- end }}
 
 

--- a/ops/helm/gryt/templates/deployments/sfu-deployment.yaml
+++ b/ops/helm/gryt/templates/deployments/sfu-deployment.yaml
@@ -44,6 +44,10 @@ spec:
             configMapKeyRef:
               name: {{ include "gryt.fullname" . }}-config
               key: SFU_PORT
+        # Not in the Service, on purpose. The Service port is reachable by clients,
+        # and a reachable /server lets anyone register on this SFU as their own.
+        - name: SFU_CONTROL_PORT
+          value: {{ .Values.sfu.controlPort | default 9092 | quote }}
         - name: STUN_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/ops/helm/gryt/values.yaml
+++ b/ops/helm/gryt/values.yaml
@@ -41,6 +41,10 @@ gryt:
 # SFU (Selective Forwarding Unit) configuration
 sfu:
   enabled: true
+
+  # Where servers register. Never exposed by the Service: the Service port is
+  # reachable by clients, and a reachable /server lets anyone register on this SFU.
+  controlPort: 9092
   image:
     repository: ghcr.io/gryt-chat/sfu
     tag: "latest"

--- a/ops/internal/community/compose.yml
+++ b/ops/internal/community/compose.yml
@@ -95,6 +95,9 @@ services:
       - "${ICE_UDP_MUX_PORT:-10000}:${ICE_UDP_MUX_PORT:-10000}/udp"
     environment:
       PORT: "5005"
+      # Registration, deliberately unpublished: the port above is public so clients
+      # can reach it, and a published /server lets anyone use this SFU as their relay.
+      SFU_CONTROL_PORT: "9092"
       ICE_UDP_MUX_PORT: ${ICE_UDP_MUX_PORT:-10000}
       # The VPS's address, not this machine's: media arrives DNATd from there and
       # leaves the same way, so it is the only address a client can reach it on.
@@ -144,7 +147,7 @@ services:
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env}
       IMAGE_WORKER_URL: http://image-worker:8080
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,https://app.gryt.chat,https://beta.gryt.chat}
-      SFU_WS_HOST: ws://sfu:5005
+      SFU_WS_HOST: ws://sfu:9092
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:?Set SFU_PUBLIC_HOST to the public wss:// address of the SFU}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-}

--- a/ops/start_dev.sh
+++ b/ops/start_dev.sh
@@ -40,7 +40,7 @@ detect_lan_ip() {
 }
 LAN_IP="${LAN_IP:-$(detect_lan_ip || true)}"
 
-SFU_WS_HOST="${SFU_WS_HOST:-ws://127.0.0.1:5005}"
+SFU_WS_HOST="${SFU_WS_HOST:-ws://127.0.0.1:9092}"
 SFU_PUBLIC_HOST="${SFU_PUBLIC_HOST:-ws://${LAN_IP:-127.0.0.1}:5005}"
 STUN_SERVERS="${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}"
 # 3666 is the Vite dev server port (packages/client/vite.config.ts); the server


### PR DESCRIPTION
The deployment half of **[Gryt-chat/sfu#35](https://github.com/Gryt-chat/sfu/pull/35)**. That PR moves server registration onto its own port and answers `/server` with `403` on the published one. **These must land together** — the SFU change alone stops servers registering.

## The bug, in one line

```yaml
SFU_WS_HOST: ws://sfu:${SFU_PORT:-5005}
```

The same value described *where the world connects* and *where servers register*. Publishing the first published the second, and anyone who could reach the SFU could claim an unused server id and use it as their own media relay.

Now `ws://sfu:9092`, with the SFU services declaring `SFU_CONTROL_PORT` so the port is stated rather than inherited from a default.

**9092 sits beside metrics on 9091 because both are container-only.** Neither appears in a `ports:` block anywhere in this repo, and that is the entire security property — not a setting somebody has to know to apply.

## Files

Ten carried the old value: `prod`, `beta`, `dev`, both `.local` overlays, the host and community composes, `.env.example`, `start_dev.sh`, `dev/common.env.sh`.

**Helm needed two of its own, and this is the part worth a look.** `gryt.sfu.wsHost` was built from `.Values.sfu.service.port` — so it pointed at the *Service*, which is precisely the reachable-from-outside port. It reads `sfu.controlPort` now, `values.yaml` gains the key, and the SFU deployment sets the env var. A Kubernetes install had the same hole as the compose one and by the same route.

## Verification

`docker compose config` on prod, beta, dev, and both overlay pairs used as intended (`-f prod.yml -f prod.local.yml`):

```
SFU_WS_HOST: ws://sfu:9092
SFU_CONTROL_PORT: "9092"
```

in every one. `internal/community/compose.yml` fails `config` on a missing `GRYT_ADMIN_TOKEN` — checked, it does that on `main` too, so it is not from this change.

Helm was not rendered: `helm` is not installed on this machine. The template edit is two lines and wants an eye on it for that reason.

## Deploying

Both PRs, then `up -d --no-deps sfu server` — the SFU picks up the new listener and the server dials it. Doing the compose side alone means the server points at a port nothing serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)