### PR TITLE
Default to the port both SFU builds answer (GRYT-1135)

### DIFF
--- a/ops/deploy/compose/.env.example
+++ b/ops/deploy/compose/.env.example
@@ -89,6 +89,10 @@ GRYT_SERVER_ENABLED=true
 SERVER_PORT=5000
 SFU_PORT=5005
 
+# Where the SFU takes server registration, published on loopback only. Change it if
+# something else on this host already holds 9092 — the server finds it on its own.
+SFU_CONTROL_PORT=9092
+
 # WebRTC media, UDP. Every participant's media shares this one port, and it is
 # the only port voice needs open. Publish it as UDP and forward it to this host.
 #

--- a/ops/deploy/compose/beta.local.yml
+++ b/ops/deploy/compose/beta.local.yml
@@ -71,7 +71,7 @@ services:
       SERVER_PASSWORD: ${NT_SERVER_PASSWORD:-}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3667,https://app.gryt.chat,https://beta.gryt.chat}
       JWT_SECRET: ${NT_JWT_SECRET:?Set NT_JWT_SECRET in .env.beta}
-      SFU_WS_HOST: ws://sfu:9092
+      SFU_WS_HOST: ws://sfu:5005
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5015}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-20}

--- a/ops/deploy/compose/beta.yml
+++ b/ops/deploy/compose/beta.yml
@@ -128,9 +128,12 @@ services:
       METRICS_PORT: ${METRICS_PORT:-9091}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3667,https://app.gryt.chat,https://beta.gryt.chat}
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env}
-      # 127.0.0.1, not sfu: this service has host networking, where the compose
-      # network does not resolve and only published ports can be reached.
-      SFU_WS_HOST: ws://127.0.0.1:${SFU_CONTROL_PORT:-9092}
+      # The websocket port, not the control port. An SFU that has moved registration
+      # refuses here and names the port to move to, and the server follows that.
+
+      # So this works against an SFU that serves registration here and one that does
+      # not, which is what keeps an upgrade from needing the two changed together.
+      SFU_WS_HOST: ws://127.0.0.1:${SFU_PORT:-5015}
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5015}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-20}

--- a/ops/deploy/compose/prod.local.yml
+++ b/ops/deploy/compose/prod.local.yml
@@ -66,7 +66,7 @@ services:
       SERVER_PASSWORD: ${NT_SERVER_PASSWORD:-}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,http://localhost:3666,https://app.gryt.chat,https://beta.gryt.chat}
       JWT_SECRET: ${NT_JWT_SECRET:?Set NT_JWT_SECRET in .env.prod}
-      SFU_WS_HOST: ws://sfu:9092
+      SFU_WS_HOST: ws://sfu:5005
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-}

--- a/ops/deploy/compose/prod.yml
+++ b/ops/deploy/compose/prod.yml
@@ -117,9 +117,12 @@ services:
       METRICS_PORT: ${METRICS_PORT:-9091}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://127.0.0.1:15738,https://app.gryt.chat}
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env}
-      # 127.0.0.1, not sfu: this service has host networking, where the compose
-      # network does not resolve and only published ports can be reached.
-      SFU_WS_HOST: ws://127.0.0.1:${SFU_CONTROL_PORT:-9092}
+      # The websocket port, not the control port. An SFU that has moved registration
+      # refuses here and names the port to move to, and the server follows that.
+
+      # So this works against an SFU that serves registration here and one that does
+      # not, which is what keeps an upgrade from needing the two changed together.
+      SFU_WS_HOST: ws://127.0.0.1:${SFU_PORT:-5005}
       SFU_PUBLIC_HOST: ${SFU_PUBLIC_HOST:-ws://localhost:5005}
       STUN_SERVERS: ${STUN_SERVERS:-stun:stun.cloudflare.com:3478,stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302}
       VOICE_MAX_USERS: ${VOICE_MAX_USERS:-}

--- a/ops/helm/gryt/templates/_helpers.tpl
+++ b/ops/helm/gryt/templates/_helpers.tpl
@@ -130,7 +130,9 @@ Get the image name with registry and tag
 Get the SFU WebSocket host
 */}}
 {{- define "gryt.sfu.wsHost" -}}
-{{- printf "ws://%s-sfu:%d" (include "gryt.fullname" .) (.Values.sfu.controlPort | default 9092 | int) -}}
+{{- /* The websocket port. An SFU that has moved registration refuses here and names
+the control port, and the server follows it — so this works against either build. */ -}}
+{{- printf "ws://%s-sfu:%d" (include "gryt.fullname" .) (.Values.sfu.service.port | int) -}}
 {{- end }}
 
 


### PR DESCRIPTION
Follow-up to #257, which merged before this part of it was pushed.

## The gap

#257 made the control port reachable — that was the real bug, and it is fixed. It also left the shipped default naming that port:

```yaml
SFU_WS_HOST: ws://127.0.0.1:${SFU_CONTROL_PORT:-9092}
```

Which needs an SFU build that serves a control port. #36 adds one but no release carries it yet, so `ghcr.io/gryt-chat/sfu:latest` still refuses nothing and listens on nothing there. Anyone following the quick start right now downloads this file from `main` and gets a server dialling a port with nothing behind it:

```
curl -Lo docker-compose.yml https://raw.githubusercontent.com/Gryt-chat/gryt/main/ops/deploy/compose/prod.yml
```

## The change

The default names the **websocket** port. Both builds answer there:

| | old SFU (`:latest` today) | new SFU (after the release) |
|---|---|---|
| **old compose** already downloaded | serves registration | 403 → server follows to the control port |
| **new compose** (this PR) | serves registration | 403 → server follows to the control port |

So the SFU release and the compose no longer have to move together, and nobody has to re-download anything to stay working. The control port stays published on loopback as the migration target, which is what #257 got right.

The bridge-networked `nt` servers go back to the SFU container's own websocket port for the same reason.

## A correction to #257

Its comment said a host-networked server "cannot resolve `sfu`". It can — `extra_hosts` maps `sfu` to `127.0.0.1` five lines above, which is also why the old value produced a 404 instead of a DNS failure. The reason it failed was only that the port was published nowhere. The comment is rewritten; `127.0.0.1` stays because it says plainly what `extra_hosts` already arranges.

## `SFU_CONTROL_PORT` in `.env.example`

Worth naming because the default collides on any host already using 9092. On our own box that is beta's metrics listener, which answered every registration attempt with a 404 — a refused connection would have been much easier to read.

## Verified

`docker compose config`, local overrides merged:

```
prod   server:    net=host   -> ws://127.0.0.1:5005
       server-nt: net=bridge -> ws://sfu:5005
       sfu ports: 5005 (all interfaces), 3478/udp, 127.0.0.1:9192 -> 9192
beta   server:    net=host   -> ws://127.0.0.1:5015
       server-nt: net=bridge -> ws://sfu:5005
       sfu ports: 5015 (all interfaces), 4443/udp, 127.0.0.1:9192 -> 9192
```

The follow itself was verified in #174 against an SFU built from #36: a server pointed at the websocket port migrates to the control port and registers a room with no configuration change.

## After this merges

Our own `.env.prod` and `.env.beta` still carry a hand-added `SFU_CONTROL_PORT=5005` from last night, which is what restored voice. Once this is on the box those lines come out, and the two servers work on the shipped defaults again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)