### PR TITLE
Check voice from the status page, not only the websites

### DIFF
--- a/ops/internal/status/README.md
+++ b/ops/internal/status/README.md
@@ -136,6 +136,35 @@ ssh vps 'cd /opt/gryt-status && docker compose pull console && docker compose up
 The password, the tunnel route and how the path prefix works are all documented
 in that repository's README.
 
+## Voice calls are checked from here too
+
+Voice media is UDP. It reaches the SFUs at home through WireGuard, so none of the HTTP
+checks above can see it. In September 2026 the dev box rebooted, `wg-quick@wg0` was
+disabled, and the tunnel stayed down for eight days while every check on this page read
+green. Chat worked, sign-in worked, and nobody off the LAN could hear anybody.
+
+`tunnel-check.sh` runs every minute and reports each Gryt tunnel's last WireGuard
+handshake to Gatus as an [external endpoint](https://github.com/TwiN/gatus#external-endpoints).
+Older than five minutes is down. They show under **Talking** as *Voice calls* (the dev
+box, prod and beta) and *Community voice calls*. The game server's tunnel is not ours to
+report, so it is left out.
+
+Each has a five-minute heartbeat. If the checker stops pushing, whether the timer died or
+the script broke, Gatus marks it down on its own. Silence cannot read as healthy.
+
+The push is authenticated with `VOICE_TUNNEL_TOKEN` from `.env`. It has to be secret,
+because `status.gryt.chat` routes the whole Gatus API to the internet, including the
+endpoint that accepts these results.
+
+Setting it up once, after the first deploy has synced `tunnel-check.sh`:
+
+```bash
+ssh vps 'echo "VOICE_TUNNEL_TOKEN=$(openssl rand -hex 32)" | sudo tee -a /opt/gryt-status/.env >/dev/null'
+ssh vps 'sudo cp /opt/gryt-src/ops/internal/status/gryt-tunnel-check.{service,timer} /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now gryt-tunnel-check.timer'
+```
+
+The units are not synced by `update.sh`, for the same daemon-reload reason as its own.
+
 ## Validate before you deploy
 
 A bad config stops the container, and the page goes down with it. Run the config

--- a/ops/internal/status/config/config.yaml
+++ b/ops/internal/status/config/config.yaml
@@ -128,3 +128,19 @@ endpoints:
     conditions:
       - "[STATUS] == 200"
       - "[BODY].ok == true"
+
+# Voice media is UDP through WireGuard, invisible to the HTTP checks above. It was down
+# eight days in September 2026 with this page green. tunnel-check.sh pushes these.
+external-endpoints:
+  # gryt.chat's own servers, prod and beta, on the dev box's tunnel.
+  - name: "Voice calls"
+    group: "Talking"
+    token: "${VOICE_TUNNEL_TOKEN}"
+    heartbeat:
+      interval: 5m
+
+  - name: "Community voice calls"
+    group: "Talking"
+    token: "${VOICE_TUNNEL_TOKEN}"
+    heartbeat:
+      interval: 5m

--- a/ops/internal/status/docker-compose.yml
+++ b/ops/internal/status/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - gatus-data:/data
     environment:
       GATUS_CONFIG_PATH: /config
+      # The push token for the voice-tunnel checks; unset fails loudly rather than open.
+      VOICE_TUNNEL_TOKEN: ${VOICE_TUNNEL_TOKEN:?set it in .env, see README}
     # No healthcheck, because this image cannot hold one: it carries `/gatus` and
     # nothing else, so every candidate fails on "executable file not found".
 

--- a/ops/internal/status/gryt-tunnel-check.service
+++ b/ops/internal/status/gryt-tunnel-check.service
@@ -1,0 +1,8 @@
+# Pushes the voice tunnels' health to Gatus. Root, because `wg show` needs it.
+[Unit]
+Description=Report Gryt voice tunnel health to the status page
+After=network-online.target wg-quick@wg0.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/gryt-status/tunnel-check.sh

--- a/ops/internal/status/gryt-tunnel-check.timer
+++ b/ops/internal/status/gryt-tunnel-check.timer
@@ -1,0 +1,11 @@
+# Every minute. Gatus alarms after five without a push, so a dead timer is visible.
+[Unit]
+Description=Report Gryt voice tunnel health every minute
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+AccuracySec=5s
+
+[Install]
+WantedBy=timers.target

--- a/ops/internal/status/tunnel-check.sh
+++ b/ops/internal/status/tunnel-check.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Voice media is UDP through WireGuard, which no HTTP check can see. This pushes
+# each Gryt tunnel's handshake health to Gatus; stop pushing and its heartbeat fails.
+
+set -u
+
+DEST="${CONSOLE_DEST:-/opt/gryt-status}"
+GATUS="http://127.0.0.1:3001"
+
+# A live peer rekeys every ~2 minutes under keepalive 25, so 5 minutes is dead.
+STALE=300
+
+# Peer address -> Gatus key. Only Gryt's own tunnels: the game server is not ours to report.
+declare -A TUNNELS=(
+    ["10.2.0.5/32"]="talking_voice-calls"
+    ["10.2.0.6/32"]="talking_community-voice-calls"
+)
+
+TOKEN="$(grep -E '^VOICE_TUNNEL_TOKEN=' "$DEST/.env" 2>/dev/null | cut -d= -f2-)"
+if [[ -z "$TOKEN" ]]; then
+    echo "[$(date -Is)] VOICE_TUNNEL_TOKEN missing from $DEST/.env; nothing pushed"
+    exit 1
+fi
+
+now=$(date +%s)
+declare -A seen=()
+
+# `wg show dump` is tab-separated; line one is the interface, the rest are peers.
+while IFS=$'\t' read -r _pub _psk _endpoint allowed handshake _rx _tx _ka; do
+    for ip in "${!TUNNELS[@]}"; do
+        [[ ",$allowed," == *",$ip,"* ]] || continue
+        seen[$ip]=1
+        age=$(( now - handshake ))
+
+        if (( handshake > 0 && age < STALE )); then
+            query="success=true"
+        else
+            query="success=false&error=no%20WireGuard%20handshake%20for%20${age}s"
+        fi
+
+        code=$(curl -s -o /dev/null -w '%{http_code}' -m 10 -X POST \
+            -H "Authorization: Bearer $TOKEN" "$GATUS/api/v1/endpoints/${TUNNELS[$ip]}/external?$query")
+        echo "[$(date -Is)] ${TUNNELS[$ip]} age=${age}s -> $query (gatus $code)"
+    done
+done < <(wg show wg0 dump 2>/dev/null | tail -n +2)
+
+# A peer missing from wg entirely is as dead as a stale one, and must say so.
+for ip in "${!TUNNELS[@]}"; do
+    [[ -n "${seen[$ip]:-}" ]] && continue
+    curl -s -o /dev/null -m 10 -X POST -H "Authorization: Bearer $TOKEN" \
+        "$GATUS/api/v1/endpoints/${TUNNELS[$ip]}/external?success=false&error=peer%20not%20configured%20on%20wg0"
+    echo "[$(date -Is)] ${TUNNELS[$ip]} -> not on wg0"
+done

--- a/ops/internal/status/update.sh
+++ b/ops/internal/status/update.sh
@@ -41,6 +41,7 @@ SYNCED=(
     "README.md:$DEST/README.md"
     "config/config.yaml:$DEST/config/config.yaml"
     "update.sh:$DEST/update.sh"
+    "tunnel-check.sh:$DEST/tunnel-check.sh"
 )
 
 files_match() {
@@ -106,6 +107,7 @@ update_config() {
         -v /tmp/gatus-validate-config:/config:ro \
         -v /tmp/gatus-validate-data:/data \
         -e GATUS_CONFIG_PATH=/config \
+        --env-file "$DEST/.env" \
         twinproduction/gatus:v5.36.0 >/dev/null 2>&1 || true
 
     local ok=1 i


### PR DESCRIPTION
Voice was down for **eight days** in September with status.gryt.chat green the whole time.

The dev box rebooted on 1 September, `wg-quick@wg0` was disabled, and the WireGuard tunnel carrying every Gryt voice call never came back. Chat worked, sign-in worked, the page was green — and nobody off the LAN could hear anybody. Gatus only checks HTTP, and voice media is UDP. The config even said so, on line 43: *"Its SFU is not checked."*

## What this adds

`tunnel-check.sh` runs every minute and reports each Gryt tunnel's last WireGuard handshake to Gatus as an **external endpoint**. Older than five minutes is down. Under **Talking**:

- **Voice calls** — the dev box's tunnel, which carries prod and beta
- **Community voice calls** — the community server's

The game server's tunnel isn't ours to report, so it's left out.

**Each has a five-minute heartbeat.** If the checker stops pushing — timer dead, script broken — Gatus marks it down on its own. Silence can't read as healthy, which is the exact property the last outage lacked.

The console picks these up with no change, because it reads the same `/api/v1/endpoints/statuses` list.

## What to look at

- **The token has to stay secret.** `status.gryt.chat` routes the *whole* Gatus API to the internet, including the endpoint that accepts results — so anyone with the token could push a fake green. It lives in `.env` on the VPS, was generated there with `openssl rand -hex 32`, and never went through me. The compose file uses `:?` so an unset token refuses to start rather than falling open.
- **`update.sh` now validates with `--env-file`.** Without it the throwaway Gatus that checks a new config sees an empty token, the config fails validation, and this would never deploy. Worth a look since it touches the one script that deploys everything here.
- **Five minutes is the threshold.** A live peer rekeys about every two minutes under keepalive 25; the real tunnels read 44–45s during testing. Tighter risks flapping.

## Verified — against `gatus:v5.36.0` before relying on any of it

| Claim | Result |
|---|---|
| Real config loads | `Validated 11 endpoints` / `Validated 2 external endpoints` |
| Right token / wrong token | 200 / `401 invalid token` |
| Failure reason is shown | `no WireGuard handshake for 700000s` |
| Appears where the console reads | listed in `/statuses` |
| **A silent checker alarms** | `heartbeat: no update received within 15s` |

Plus a dry run of the script against the VPS's real `wg0`: both Gryt peers found at ~45s, game server ignored. `check-comment-length` and `docker compose config` both pass.

## Already done on the VPS

`VOICE_TUNNEL_TOKEN` is in `/opt/gryt-status/.env`. It had to be there *before* merge, or the new compose file refuses to deploy.

## After merge

`update.sh` syncs the config, compose and script within five minutes. The systemd timer is a one-off (daemon-reload), and I'll install it — documented in the README either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)