### PR TITLE
Release Server and Release Client pick the same SFU and image worker (GRYT-1147)

### DIFF
--- a/.github/scripts/checkout-release-tag.sh
+++ b/.github/scripts/checkout-release-tag.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Puts a submodule on its newest release tag for a channel. Release Client and Release
+# Server both call this, so they can't ship different SFU or image worker commits.
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: checkout-release-tag.sh <submodule path> <beta|latest>" >&2
+  exit 2
+fi
+
+path="$1"
+channel="$2"
+
+# Beta takes plain releases too, so a stable newer than the last beta wins.
+case "$channel" in
+  beta) pattern='v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?' ;;
+  latest) pattern='v[0-9]+\.[0-9]+\.[0-9]+' ;;
+  *)
+    echo "::error::Unknown channel '$channel'. Expected beta or latest."
+    exit 2
+    ;;
+esac
+
+git -C "$path" fetch --quiet origin main --tags --force
+
+# versionsort.suffix makes -v:refname semver precedence rather than string order, or
+# v1.6.15-beta.1 sorts above v1.6.15. `|| true` because grep exits 1 on no match.
+tag=$(git -C "$path" \
+    -c versionsort.suffix=-alpha \
+    -c versionsort.suffix=-beta \
+    -c versionsort.suffix=-rc \
+    tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+  | grep -Ex "$pattern" \
+  | head -1 || true)
+
+if [[ -z "$tag" ]]; then
+  echo "::error::No release tag in $path for the $channel channel. Release it first."
+  exit 1
+fi
+
+# Detached on purpose: this is a point in history, not a branch to carry on from.
+git -C "$path" checkout --detach --quiet "$tag"
+echo "$path -> $(git -C "$path" rev-parse --short HEAD) ($tag)"

--- a/.github/scripts/checkout-release-tag.test.mjs
+++ b/.github/scripts/checkout-release-tag.test.mjs
@@ -1,0 +1,120 @@
+// checkout-release-tag.sh against a scratch repository: an "origin" with main and tags,
+// and a clone of it standing in for the submodule, the shape both release workflows have.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const SCRIPT = new URL("checkout-release-tag.sh", import.meta.url).pathname;
+const dir = mkdtempSync(join(tmpdir(), "release-tag-"));
+
+const ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "test@example.invalid",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "test@example.invalid",
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_CONFIG_GLOBAL: "/dev/null",
+};
+
+const git = (cwd, ...args) => execFileSync("git", args, { cwd, env: ENV, encoding: "utf8" }).trim();
+
+let n = 0;
+function commit(repo) {
+  writeFileSync(join(repo, "file"), String(++n));
+  git(repo, "add", "file");
+  git(repo, "commit", "--quiet", "-m", `commit ${n}`);
+  return git(repo, "rev-parse", "HEAD");
+}
+
+/** An origin whose main carries each tag given, in order, plus one untagged commit on top. */
+function origin(name, tags) {
+  const repo = join(dir, name);
+  git(dir, "init", "--quiet", "--initial-branch=main", repo);
+  const at = {};
+  for (const tag of tags) {
+    at[tag] = commit(repo);
+    git(repo, "tag", tag);
+  }
+  at.untagged = commit(repo);
+  return { repo, at };
+}
+
+function clone(from, name) {
+  const path = join(dir, name);
+  git(dir, "clone", "--quiet", from.repo, path);
+  return path;
+}
+
+/** Runs the script and hands back its exit code, its output, and where the clone ended up. */
+function run(path, channel) {
+  let code = 0;
+  let out;
+  try {
+    out = execFileSync("bash", [SCRIPT, path, channel], { env: ENV, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (e) {
+    code = e.status;
+    out = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+  }
+  return { code, out, head: git(path, "rev-parse", "HEAD") };
+}
+
+test("latest takes the newest plain release, not a newer beta or main's untagged head", () => {
+  const o = origin("latest", ["v1.0.0", "v1.0.1", "v1.1.0-beta.1"]);
+  const r = run(clone(o, "latest-work"), "latest");
+  assert.equal(r.code, 0, r.out);
+  assert.equal(r.head, o.at["v1.0.1"]);
+  assert.match(r.out, /\(v1\.0\.1\)/);
+});
+
+test("beta takes the newest beta when it is ahead of the last stable", () => {
+  const o = origin("beta", ["v1.0.0", "v1.0.1", "v1.1.0-beta.1"]);
+  const r = run(clone(o, "beta-work"), "beta");
+  assert.equal(r.code, 0, r.out);
+  assert.equal(r.head, o.at["v1.1.0-beta.1"]);
+});
+
+test("beta takes a stable that is newer than its own betas", () => {
+  const o = origin("beta-stable", ["v1.1.0-beta.1", "v1.1.0-beta.2", "v1.1.0"]);
+  const r = run(clone(o, "beta-stable-work"), "beta");
+  assert.equal(r.head, o.at["v1.1.0"], "v1.1.0-beta.2 sorted above v1.1.0");
+});
+
+test("versions sort as numbers, so 1.0.10 is newer than 1.0.9", () => {
+  const o = origin("numeric", ["v1.0.9", "v1.0.10"]);
+  const r = run(clone(o, "numeric-work"), "latest");
+  assert.equal(r.head, o.at["v1.0.10"]);
+});
+
+test("a tag made after the clone is fetched, which is how a fresh release reaches the next one", () => {
+  const o = origin("fresh", ["v1.2.5"]);
+  const path = clone(o, "fresh-work");
+  git(o.repo, "tag", "v1.2.6", o.at.untagged);
+  const r = run(path, "latest");
+  assert.equal(r.head, o.at.untagged, "the tag pushed after cloning was not seen");
+});
+
+test("no release for the channel stops the run and says to release it first", () => {
+  const o = origin("only-betas", ["v2.0.0-beta.1"]);
+  const r = run(clone(o, "only-betas-work"), "latest");
+  assert.equal(r.code, 1);
+  assert.match(r.out, /::error::No release tag in .* for the latest channel\. Release it first\./);
+});
+
+test("an unknown channel stops the run rather than picking something", () => {
+  const o = origin("channel", ["v1.0.0"]);
+  const r = run(clone(o, "channel-work"), "stable");
+  assert.equal(r.code, 2);
+  assert.match(r.out, /Unknown channel 'stable'/);
+});
+
+test("the clone is left detached at the tag, not on a branch that could be pushed", () => {
+  const o = origin("detached", ["v1.0.0"]);
+  const path = clone(o, "detached-work");
+  run(path, "latest");
+  assert.equal(git(path, "rev-parse", "--abbrev-ref", "HEAD"), "HEAD");
+});

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -132,40 +132,8 @@ jobs:
 
           # The three embedded services come from their newest release tag, not main: an
           # untagged build reports `git describe` and versionCheck compared it as 1.0.0.
-
-          # Which tag depends on the channel (GRYT-724): stable-only shipped a beta client
-          # with a server that did not publish the permission it asks about.
-          if [[ "${{ github.event.inputs.channel }}" == "beta" ]]; then
-            # Plain releases too, so a stable newer than the last beta wins.
-            tag_pattern='v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?'
-          else
-            tag_pattern='v[0-9]+\.[0-9]+\.[0-9]+'
-          fi
-
           for path in packages/server packages/sfu packages/image-worker; do
-            git -C "$path" fetch origin main --tags --force
-
-            # versionsort.suffix is what makes -v:refname semver precedence rather than
-            # string order: without it v1.6.15-beta.1 sorts above v1.6.15.
-            tag=$(git -C "$path" \
-                -c versionsort.suffix=-alpha \
-                -c versionsort.suffix=-beta \
-                -c versionsort.suffix=-rc \
-                tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
-              | grep -Ex "$tag_pattern" \
-              | head -1 || true)
-
-            # `|| true` above because grep exits 1 on no match and pipefail is
-            # on, which killed the step before this guard could say why.
-            if [[ -z "$tag" ]]; then
-              echo "::error::No release tag in $path for the ${{ github.event.inputs.channel }} channel. Release it before releasing the client."
-              exit 1
-            fi
-
-            # Detached on purpose: this is a point in history, not a branch to
-            # carry on from.
-            git -C "$path" checkout --detach --quiet "$tag"
-            echo "$path -> $(git -C "$path" rev-parse --short HEAD) ($tag)"
+            bash .github/scripts/checkout-release-tag.sh "$path" "${{ github.event.inputs.channel }}"
           done
 
       - name: Set up Node.js

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -127,17 +127,21 @@ jobs:
           monorepo: ${{ github.repository }}
           monorepo-token: ${{ github.token }}
 
-      - name: Move release submodules to their main
+      - name: Move release submodules into place
         shell: bash
         run: |
           set -euo pipefail
 
-          # Release from what is on each submodule's main, not the superproject's
-          # gitlink: a stale pointer ships a server the client disagrees with.
-          for path in packages/server packages/sfu packages/image-worker; do
-            git -C "$path" fetch origin main
-            git -C "$path" checkout -B main origin/main
-            echo "$path -> $(git -C "$path" rev-parse --short HEAD)"
+          # The server is released from its main, not the superproject's gitlink: a stale
+          # pointer ships a server the client disagrees with.
+          git -C packages/server fetch origin main
+          git -C packages/server checkout -B main origin/main
+          echo "packages/server -> $(git -C packages/server rev-parse --short HEAD) (main)"
+
+          # The SFU and image worker come from their newest release tag, the one Release
+          # Client embeds. Unreleased work on their main waits for their own release.
+          for path in packages/sfu packages/image-worker; do
+            bash .github/scripts/checkout-release-tag.sh "$path" "${{ github.event.inputs.channel }}"
           done
 
       - name: Set up Git user

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -62,3 +62,4 @@ jobs:
       - run: node .github/scripts/check-offline-page.mjs
       - run: node .github/scripts/check-comment-length.mjs
       - run: node --test .github/scripts/check-release-line.test.mjs
+      - run: node --test .github/scripts/checkout-release-tag.test.mjs


### PR DESCRIPTION
Release Server and Release Client picked the SFU and image worker differently. The server built them from their main, and the client used their newest release tag. So when image worker b463e09 sat on main without a tag, server 1.10.2 shipped it, and the desktop apps from 1.11.5 to 1.11.8 shipped ff725df.

Both workflows now call `.github/scripts/checkout-release-tag.sh`. It's the rule Release Client already had, moved into one file: the newest release tag for the channel, with beta taking a stable that's newer than its betas. The server itself still releases from its own main.

**What changes when you release.** SFU or image worker work sitting on main without a release no longer goes out in the server's zips. Release the SFU or image worker first, then the server. Docker and the desktop app already worked this way, so the zips now match them.

**The task suggested pinning the client to the server's manifest instead.** In 20 of the last 40 server releases, the manifest named an SFU or image worker commit that had no tag yet. The app would have embedded those, and an untagged build reports a `git describe` string as its version. That's GRYT-306, the bug that made the client pin tags in the first place.

**To look at:** `release-server.yml` is CRLF, and the edit keeps it that way. The server's step is renamed to match the client's, "Move release submodules into place".

**Tested:**
- `checkout-release-tag.test.mjs` runs the script against a scratch repo with an origin: latest skips a newer beta and main's untagged head, beta takes a stable over its own betas, 1.0.10 sorts above 1.0.9, a tag made after the clone is fetched, and a missing tag or an unknown channel stops the run. It's added to Repo checks.
- actionlint reports the same 12 findings on both workflows as on main, all in steps this doesn't touch. shellcheck is clean on the script.
- Every Repo checks step passes locally.

The next server release ships the same SFU and image worker it would have before, because their newest tags (the image worker's is v1.2.6) are the commits on their main.

Two things found on the way, both filed:
- GRYT-1149: a beta-channel SFU or image worker release still gets a plain tag, so stable releases pick it up.
- GRYT-1150: the self-hosted zips stamp the image worker with the server's version, and build the SFU with no version at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
